### PR TITLE
Update utilities path and config

### DIFF
--- a/modules/OsmTs.py
+++ b/modules/OsmTs.py
@@ -29,7 +29,7 @@ import OsmoseLog
 import re
 
 def run(file_src, localstate, selectedstream, logger = OsmoseLog.logger()):
-    res = commands.getstatusoutput("%s/osmconvert/osmconvert %s --out-statistics" % (config.dir_osmose,file_src))
+    res = commands.getstatusoutput("%s %s --out-statistics" % (config.bin_osmconvert, file_src))
     if res[0]:
         logger.log("except osmconvert statistics")
         return False

--- a/modules/config.py
+++ b/modules/config.py
@@ -35,7 +35,13 @@ dir_work = "/data/work/%s" % (username)
 url_frontend_update = "http://osmose.openstreetmap.fr/cgi-bin/update.py"
 
 # binary used by osm2pgsql analyses
-bin_osm2pgsql = dir_osmose + "/osm2pgsql/osm2pgsql-squeeze"
+bin_osm2pgsql = "/usr/bin/osm2pgsql"
+
+# where osmosis is located
+bin_osmosis = "/usr/bin/osmosis"
+
+# where osmconvert is located
+bin_osmconvert = "/usr/bin/osmconvert"
 
 
 ### no need to modify following variables ###

--- a/modules/config.py
+++ b/modules/config.py
@@ -34,14 +34,20 @@ dir_work = "/data/work/%s" % (username)
 # frontend which will get results
 url_frontend_update = "http://osmose.openstreetmap.fr/cgi-bin/update.py"
 
-# binary used by osm2pgsql analyses
+# where osm2pgsql is located
 bin_osm2pgsql = "/usr/bin/osm2pgsql"
+# if you don't have the "osm2pgsql" package installed:
+#bin_osm2pgsql = dir_osmose + "/osm2pgsql/osm2pgsql-squeeze"
 
 # where osmosis is located
 bin_osmosis = "/usr/bin/osmosis"
+# if you don't have the "osmosis" package installed:
+#bin_osmosis = dir_osmose + "/osmosis/osmosis-0.41/bin/osmosis"
 
 # where osmconvert is located
 bin_osmconvert = "/usr/bin/osmconvert"
+# if you don't have the "osmctools" package installed:
+#bin_osmconvert = dir_osmose + "/osmconvert/osmconvert"
 
 
 ### no need to modify following variables ###

--- a/modules/download.py
+++ b/modules/download.py
@@ -91,7 +91,7 @@ def dl(url, local, logger=OsmoseLog.logger(), min_file_size=10*1024):
     # convert pbf to osm
     if convert_pbf:
         logger.log(u"osmconvert")
-        res = commands.getstatusoutput("./osmconvert/osmconvert %s > %s" % (file_dl, local))
+        res = commands.getstatusoutput("%s %s > %s" % (config.bin_osmconvert, file_dl, local))
         if res[0]:
             raise SystemError(res[1])
         os.remove(file_dl)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -63,9 +63,8 @@ class template_config:
     dir_work       = config.dir_work
     dir_tmp        = config.dir_tmp
     dir_scripts    = config.dir_osmose
-    dir_osm2pgsql  = dir_scripts + "/osm2pgsql"
     bin_osm2pgsql  = config.bin_osm2pgsql
-    osmosis_bin    = dir_scripts + "/osmosis/osmosis-0.41/bin/osmosis"
+    bin_osmosis    = config.bin_osmosis
     osmosis_pre_scripts = [
         dir_scripts + "/osmosis/osmosis-0.41/script/pgsnapshot_schema_0.6.sql",
 #       dir_scripts + "/osmosis/osmosis-0.41/script/pgsnapshot_schema_0.6_bbox.sql",

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -183,7 +183,7 @@ def init_database(conf, logger):
 
         # data
         logger.log(logger.log_av_r+"import osmosis data"+logger.log_ap)
-        cmd  = [conf.osmosis_bin]
+        cmd  = [conf.bin_osmosis]
         dst_ext = os.path.splitext(conf.download["dst"])[1]
         if dst_ext == ".pbf":
             cmd += ["--read-pbf", "file=%s" % conf.download["dst"]]
@@ -287,7 +287,7 @@ def init_osmosis_diff(conf, logger):
                 os.remove(f)
     else:
         os.makedirs(diff_path)
-    cmd  = [conf.osmosis_bin]
+    cmd  = [conf.bin_osmosis]
     cmd += ["--read-replication-interval-init", "workingDirectory=%s" % diff_path]
     cmd += ["-quiet"]
     logger.execute_err(cmd)
@@ -351,7 +351,7 @@ def run_osmosis_diff(conf, logger):
             logger.log("iteration=%d" % nb_iter)
 
             try:
-                cmd  = [conf.osmosis_bin]
+                cmd  = [conf.bin_osmosis]
                 cmd += ["--read-replication-interval", "workingDirectory=%s" % diff_path]
                 cmd += ["--simplify-change", "--write-xml-change", "file=%s" % xml_change]
                 cmd += ["-quiet"]
@@ -361,7 +361,7 @@ def run_osmosis_diff(conf, logger):
                 time.sleep(2*60)
                 continue
 
-            cmd  = [conf.osmosis_bin]
+            cmd  = [conf.bin_osmosis]
             cmd += ["--read-xml-change", "file=%s" % xml_change]
             cmd += ["--read-pbf", "file=%s" % conf.download["dst"] ]
             cmd += ["--apply-change", "--buffer"]
@@ -451,7 +451,7 @@ def run_osmosis_change(conf, logger):
                     os.path.join(diff_path, "state.txt.old"))
 
     try:
-        cmd  = [conf.osmosis_bin]
+        cmd  = [conf.bin_osmosis]
         cmd += ["--read-replication-interval", "workingDirectory=%s" % diff_path]
         cmd += ["--simplify-change", "--write-xml-change", "file=%s" % xml_change]
         cmd += ["-quiet"]
@@ -463,7 +463,7 @@ def run_osmosis_change(conf, logger):
         cmd += ["-c", "TRUNCATE TABLE actions"]
         logger.execute_out(cmd)
 
-        cmd  = [conf.osmosis_bin]
+        cmd  = [conf.bin_osmosis]
         cmd += ["--read-xml-change", xml_change]
         cmd += ["--write-pgsql-change", "database=%s"%conf.db_base, "user=%s"%conf.db_user, "password=%s"%conf.db_password]
         cmd += ["-quiet"]


### PR DESCRIPTION
Make it possible to configure all utilities inside modules/config.py only.
Use system apps by default (with alternative examples when the user don't have the packages installed)
