### PR TITLE
Support specifying the database host

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,12 @@ The local postgresql database should be configured in osmose_config.py:
   - db_base = database name
   - db_user = database user
   - db_password = database password
+  - db_host = database hostname
+
+You may want to include this info in ~/.pgpass to avoid entering the database
+password while processing the files.
+
+See https://wiki.postgresql.org/wiki/Pgpass for more info.
 
 The following postgresql extensions should be enabled:
   hstore

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -89,6 +89,7 @@ class template_config:
     db_base     = "osmose"
     db_user     = "osmose"
     db_password = "-osmose-"
+    db_host     = "localhost"
     db_schema   = None
 
     def __init__(self, country, polygon_id=None, analyser_options=None, download_repo=GEOFABRIK):

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -178,6 +178,7 @@ def init_database(conf, logger):
             cmd  = ["psql"]
             cmd += ["-d", conf.db_base]
             cmd += ["-U", conf.db_user]
+            cmd += ["-h", conf.db_host]
             cmd += ["-f", script]
             logger.execute_out(cmd)
 
@@ -199,6 +200,7 @@ def init_database(conf, logger):
             cmd  = ["psql"]
             cmd += ["-d", conf.db_base]
             cmd += ["-U", conf.db_user]
+            cmd += ["-h", conf.db_host]
             cmd += ["-f", script]
             logger.execute_out(cmd)
 
@@ -430,6 +432,7 @@ def init_osmosis_change(conf, logger):
     cmd  = ["psql"]
     cmd += ["-d", conf.db_base]
     cmd += ["-U", conf.db_user]
+    cmd += ["-h", conf.db_host]
     cmd += ["-c", "ALTER ROLE %s IN DATABASE %s SET search_path = %s,public;" % (conf.db_user, conf.db_base, db_schema)]
     logger.execute_out(cmd)
 
@@ -438,6 +441,7 @@ def init_osmosis_change(conf, logger):
         cmd  = ["psql"]
         cmd += ["-d", conf.db_base]
         cmd += ["-U", conf.db_user]
+        cmd += ["-h", conf.db_host]
         cmd += ["-f", script]
         logger.execute_out(cmd)
 
@@ -460,6 +464,7 @@ def run_osmosis_change(conf, logger):
         cmd  = ["psql"]
         cmd += ["-d", conf.db_base]
         cmd += ["-U", conf.db_user]
+        cmd += ["-h", conf.db_host]
         cmd += ["-c", "TRUNCATE TABLE actions"]
         logger.execute_out(cmd)
 
@@ -475,6 +480,7 @@ def run_osmosis_change(conf, logger):
             cmd  = ["psql"]
             cmd += ["-d", conf.db_base]
             cmd += ["-U", conf.db_user]
+            cmd += ["-h", conf.db_host]
             cmd += ["-f", script]
             logger.execute_out(cmd)
 
@@ -548,6 +554,7 @@ def run(conf, logger, options):
             cmd  = ["psql"]
             cmd += ["-d", conf.db_base]
             cmd += ["-U", conf.db_user]
+            cmd += ["-h", conf.db_host]
             cmd += ["-f", script]
             logger.execute_out(cmd)
 


### PR DESCRIPTION
This allows using a different host for the database server.
Also cite the usage of .pgpass
