### PR TITLE
Fix unicode exception

### DIFF
--- a/plugins/TagFix_Wikipedia.py
+++ b/plugins/TagFix_Wikipedia.py
@@ -81,7 +81,7 @@ class TagFix_Wikipedia(Plugin):
                 if interwiki == False:
                     try:
                         lang, title = tags[wikipediaTag].split(':')
-                        json_str = urlread("http://"+lang+".wikipedia.org/w/api.php?action=query&prop=langlinks&titles="+urllib.quote(title)+"&redirects=&lllimit=500&format=json" , 30)
+                        json_str = urlread("http://"+lang+".wikipedia.org/w/api.php?action=query&prop=langlinks&titles="+urllib.quote(title.encode('utf-8'))+"&redirects=&lllimit=500&format=json" , 30)
                         interwiki = json.loads(json_str)
                         interwiki = dict(map(lambda x: [x["lang"], x["*"]], interwiki["query"]["pages"].values()[0]["langlinks"]))
                     except:


### PR DESCRIPTION
urllib.quote needs to have "title" encoded as utf-8 to properly deal with URLs having non-ascii chars.

Example:

```
>>> urllib.quote(u'á')
/usr/lib/python2.7/urllib.py:1288: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  return ''.join(map(quoter, s))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/urllib.py", line 1288, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xe1'
```

With encode:

```
>>> urllib.quote(u'á'.encode('utf-8'))
'%C3%A1'
```
