### PR TITLE
User-friendlier mkdir error messages

### DIFF
--- a/modules/downloader.py
+++ b/modules/downloader.py
@@ -30,9 +30,6 @@ import config
 HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
 def update_cache(url, delay, bz2_decompress=False):
-    if not os.path.exists(config.dir_cache):
-        os.makedirs(config.dir_cache)
-
     file_name = hashlib.sha1(url.encode('utf-8')).hexdigest()
     cache = os.path.join(config.dir_cache, file_name)
     tmp_file = cache + ".tmp"

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -62,6 +62,7 @@ class template_config:
     results_url    = results_url
     dir_work       = config.dir_work
     dir_tmp        = config.dir_tmp
+    dir_cache      = config.dir_cache
     dir_scripts    = config.dir_osmose
     osmosis_bin    = dir_scripts + "/osmosis/osmosis-0.41/bin/osmosis"
     osmosis_pre_scripts = [
@@ -123,19 +124,16 @@ class template_config:
                 self.db_schema = "%s,\"$user\"" % self.country
         else:
             self.db_string = None
+
         if "diff" in self.download:
-            if not os.path.exists(self.dir_diffs):
-                os.makedirs(self.dir_diffs)
             self.download["diff_path"] = os.path.join(self.dir_diffs, self.country)
+
         if "url" in self.download and not "dst" in self.download:
             ext = os.path.splitext(self.download["url"])[1]
             for e in [".osm.pbf", ".osm.bz2", ".osm.gz"]:
                 if self.download["url"].endswith(e):
                     ext = e
                     break
-
-            if not os.path.exists(self.dir_extracts):
-                os.makedirs(self.dir_extracts)
 
             self.download["dst"] = self.dir_extracts + "/" + self.country + ext
 


### PR DESCRIPTION
Instead having this:

```
Traceback (most recent call last):
  File "./osmose_run.py", line 767, in <module>
    err_code |= run(country_conf, logger, options)
  File "./osmose_run.py", line 474, in run
    os.makedirs(conf.dir_tmp)
  File "/usr/lib/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/data'
```

We now have this:

```
[Errno 13] Permission denied: '/data'
Check 'dir_work' in modules/config.py and its permissions
```
