### PR TITLE
wait much longer for osmosis import lock

### DIFF
--- a/osmose_run.py
+++ b/osmose_run.py
@@ -143,7 +143,7 @@ def init_database(conf, logger):
     # import osmosis
     if "osmosis" in conf.download:
         osmosis_lock = False
-        for trial in xrange(60):
+        for trial in xrange(180):
             # acquire lock
             try:
                 lfil = "/tmp/osmose-osmosis_import"


### PR DESCRIPTION
For paralell import, it is OK to wait quiet long for import lock.