### PR TITLE
Allow maxspeed=implicit if traffic_sign=maxspeed

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -36,7 +36,12 @@ class Number(Plugin):
         for i in self.tag_number:
             if i in tags:
                 m = self.Number.match(tags[i])
-                if not m and not (i=="width" and tags[i]=="narrow") and not (i=="maxspeed" and (tags[i] in self.MaxspeedExtraValue or self.MaxspeedClassValue.match(tags[i]))):
+                if not m and not (i=="width" and tags[i]=="narrow") \
+                         and not (i=="maxspeed" and ( \
+                            tags[i] in self.MaxspeedExtraValue or \
+                            self.MaxspeedClassValue.match(tags[i]) or \
+                            (tags[i] == "implicit" and ("traffic_sign" in tags) and \
+                                "maxspeed" in tags["traffic_sign"].split(";")))):
                     return [(3091, 1, T_(u"Incorrect number \"%s\"", tags[i]))]
                 elif m and i=="height" and float(m.group(1)) > 500:
                     return [{"class": 3091, "subclass": 2,

--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -36,12 +36,12 @@ class Number(Plugin):
         for i in self.tag_number:
             if i in tags:
                 m = self.Number.match(tags[i])
-                if not m and not (i=="width" and tags[i]=="narrow") \
-                         and not (i=="maxspeed" and ( \
-                            tags[i] in self.MaxspeedExtraValue or \
-                            self.MaxspeedClassValue.match(tags[i]) or \
-                            (tags[i] == "implicit" and ("traffic_sign" in tags) and \
-                                "maxspeed" in tags["traffic_sign"].split(";")))):
+                if (not m and not (i=="width" and tags[i]=="narrow")
+                          and not (i=="maxspeed" and (
+                            tags[i] in self.MaxspeedExtraValue or
+                            self.MaxspeedClassValue.match(tags[i]) or
+                            (tags[i] == "implicit" and ("traffic_sign" in tags) and
+                                "maxspeed" in tags["traffic_sign"].split(";"))))):
                     return [(3091, 1, T_(u"Incorrect number \"%s\"", tags[i]))]
                 elif m and i=="height" and float(m.group(1)) > 500:
                     return [{"class": 3091, "subclass": 2,


### PR DESCRIPTION
plugins/Number.py

According to the wiki, maxspeed=implicit is a valid value
when used with traffic_sign=maxspeed:
http://wiki.openstreetmap.org/wiki/Key:traffic_sign