### PR TITLE
Add spelling correction for French

### DIFF
--- a/dictionaries/fr/CorrJessie
+++ b/dictionaries/fr/CorrJessie
@@ -649,6 +649,8 @@ Cimtière:Cimetière
 Traversiere:Traversière
 Poincare:Poincaré
 Aeroclub:Aéroclub
+Aeroport:Aéroport
+Aerodrome:Aérodrome
 Zenon:Zénon
 Zeller:Zeller
 Zelande:Zélande


### PR DESCRIPTION
Seems like Aéroport and Aérodrome often miss their accent.