### PR TITLE
Fix insertion into official tables (*_off)

### DIFF
--- a/modules/PointInPolygon.py
+++ b/modules/PointInPolygon.py
@@ -28,8 +28,7 @@ class PointInPolygon:
 
     def __init__(self, polygon_id, cache_delay=60):
         polygon_url = "http://polygons.openstreetmap.fr/"
-        url = polygon_url + "index.py?id="+str(polygon_id)
-        s = downloader.urlread(url, cache_delay)
+        # See also: polygon_url + "index.py?id=" + polygon_id
         url = polygon_url + "get_wkt.py?params=0&id="+str(polygon_id)
         s = downloader.urlread(url, cache_delay)
         if s.startswith("SRID="):


### PR DESCRIPTION
The commit 2b47b7b87043c broke the insertion of data into so called "official table" because Analyser_Osmosis.run0() can not be called from its callback.

The consequence is that inexistent error get reported.
E.g. http://osmose.openstreetmap.fr/fr/map/#zoom=17&lat=50.5476813&lon=3.0393326&item=7150&level=3

http://osmose.openstreetmap.fr/fr/errors/graph.png?source=7406&item=7150&class=2
