### PR TITLE
update postgis functions to be compatible with postgis 2.1+

### DIFF
--- a/analysers/analyser_osmosis_broken_highway_level_continuity.py
+++ b/analysers/analyser_osmosis_broken_highway_level_continuity.py
@@ -119,7 +119,7 @@ FROM
 WHERE
     o1.nid != o2.nid AND
     o1.level = o2.level AND
-    ST_Distance_Sphere(o1.geom, o2.geom) < 1000
+    ST_DistanceSphere(o1.geom, o2.geom) < 1000
 GROUP BY
     o1.id,
     o1.level,

--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -256,7 +256,7 @@ HAVING
 sql52 = """
 SELECT
     power_segement.id,
-    ST_AsText(ST_Line_Interpolate_Point(
+    ST_AsText(ST_LineInterpolatePoint(
         power_segement.seg,
         generate_series(1, (power_segement.l / power_segement_stddev.a)::int-1)
             /round(power_segement.l / power_segement_stddev.a)

--- a/analysers/analyser_osmosis_relation_associatedStreet.py
+++ b/analysers/analyser_osmosis_relation_associatedStreet.py
@@ -469,7 +469,7 @@ GROUP BY
     house.type,
     house.geom
 HAVING
-    MIN(ST_Distance_Sphere(house.geom, street.geom)) > 200
+    MIN(ST_DistanceSphere(house.geom, street.geom)) > 200
 """
 
 sqlC0 = """

--- a/analysers/analyser_osmosis_water.py
+++ b/analysers/analyser_osmosis_water.py
@@ -138,7 +138,7 @@ FROM
   LEFT JOIN water ON
     (objects.type != 'W' OR water.id != objects.id) AND
     objects.bbox && water.linestring AND
-    ST_Distance_Sphere(objects.geom, water.linestring) < 20
+    ST_DistanceSphere(objects.geom, water.linestring) < 20
 WHERE
   water IS NULL
 """


### PR DESCRIPTION
Old names are still available in 2.3.0, but issue a warning and seems to be very suboptimal as of performance.
