### PR TITLE
Housenumber check for LU and CH

### DIFF
--- a/plugins/TagFix_Housenumber.py
+++ b/plugins/TagFix_Housenumber.py
@@ -24,6 +24,8 @@ from plugins.Plugin import Plugin
 
 class TagFix_Housenumber(Plugin):
 
+    not_for = ("RU", "BG")
+
     def init(self, logger):
         Plugin.init(self, logger)
         self.errors[10] = {"item": 2060, "level": 3, "tag": ["addr", "fix:survey"], "desc": T_(u"addr:housenumber does not start by a number")}
@@ -49,8 +51,6 @@ class TagFix_Housenumber(Plugin):
 
     def node(self, data, tags):
         err = []
-        if self.Country in ('RU', 'BG'):  # Countries with no house numbers
-            return []
         if "addr:housenumber" in tags and (len(tags["addr:housenumber"]) == 0 or not (housenumberRegexByCountry[self.Country].match(tags["addr:housenumber"]))):
             err.append((10, 1, {}))
 

--- a/plugins/TagFix_Housenumber.py
+++ b/plugins/TagFix_Housenumber.py
@@ -84,7 +84,7 @@ class Test(TestPluginCommon):
         a = TagFix_Housenumber(None)
 
         class _config:
-            options = {"country": "CZ"}
+            options = {"country": "XY"}
 
         class father:
             config = _config()
@@ -106,7 +106,7 @@ class Test(TestPluginCommon):
         assert not a.way(None, {"addr:interpolation": "4", "addr:inclusion": "actual"}, None)
         assert a.way(None, {"addr:interpolation": "invalid"}, None)
 
-        assert not a.way(None, {"addr:housenumber": "ev.387"}, None)  # In CZ
+        assert a.way(None, {"addr:housenumber": "ev.387"}, None)  # CZ housenumbers not valid outside CZ
 
         assert a.node(None, {"addr:housenumber": "корпус"})
 
@@ -123,3 +123,49 @@ class Test(TestPluginCommon):
         a.init(None)
 
         assert not a.node(None, {"addr:housenumber": "корпус"})
+
+    def test_CH(self)
+        a = TagFix_Housenumber(None)
+
+        class _config:
+            options = {"country": "CH"}
+
+        class father:
+            config = _config()
+
+        a.father = father()
+        a.init(None)
+
+        assert not a.node(None, {"addr:housenumber": "313A"})
+
+    def test_CZ(self)
+        a = TagFix_Housenumber(None)
+
+        class _config:
+            options = {"country": "CZ"}
+
+        class father:
+            config = _config()
+
+        a.father = father()
+        a.init(None)
+
+        assert not a.way(None, {"addr:housenumber": "ev.387"}, None)  # In CZ
+
+
+    def test_LU(self)
+        a = TagFix_Housenumber(None)
+
+        class _config:
+            options = {"country": "CH"}
+
+        class father:
+            config = _config()
+
+        a.father = father()
+        a.init(None)
+
+        assert not a.node(None, {"addr:housenumber": "42A-44A"})
+        assert not a.node(None, {"addr:housenumber": "42BIS"})
+
+

--- a/plugins/TagFix_Housenumber.py
+++ b/plugins/TagFix_Housenumber.py
@@ -157,7 +157,7 @@ class Test(TestPluginCommon):
         a = TagFix_Housenumber(None)
 
         class _config:
-            options = {"country": "CH"}
+            options = {"country": "LU"}
 
         class father:
             config = _config()


### PR DESCRIPTION
Hello,

This adds regex checks for house numbers in two countries, and refactors the code to make the addition of new countries easier.

Additionally, this cleans up the plugin's code according to PEP8.

@ltog helped out with the original idea, the implementation, and the Swiss regex.

This is my first real PR to Osmose, please be critical and generous in your feedback :)