### PR TITLE
Improve parsing of mhs:inscription_date from the Mériméee dataset

### DIFF
--- a/analysers/analyser_merge_heritage_FR_merimee.py
+++ b/analysers/analyser_merge_heritage_FR_merimee.py
@@ -30,6 +30,15 @@ class Analyser_Merge_Heritage_FR_Merimee(Analyser_Merge):
         self.missing_osm      = {"item":"7080", "class": 2, "level": 3, "tag": ["merge"], "desc": T_(u"Historical monument without ref:mhs or invalid") }
         self.possible_merge   = {"item":"8011", "class": 3, "level": 3, "tag": ["merge"], "desc": T_(u"Historical monument, integration suggestion") }
         self.update_official  = {"item":"8012", "class": 4, "level": 3, "tag": ["merge"], "desc": T_(u"Historical monument update") }
+
+        def parseDPRO(dpro):
+            ret = None;
+            # Match YYYY ou YYYY/MM ou YYYY/MM/DD
+            match = re.match("^(\d{4}(?:/\d{2}(?:/\d{2})?)?) :", dpro);
+            if match:
+                ret = match.group(1).replace("/", "-");
+            return ret;
+
         Analyser_Merge.__init__(self, config, logger,
             "https://www.data.gouv.fr/fr/datasets/monuments-historiques-liste-des-immeubles-proteges-au-titre-des-monuments-historiques/",
             u"Monuments Historiques : liste des Immeubles protégés au titre des Monuments Historiques",
@@ -53,7 +62,7 @@ class Analyser_Merge_Heritage_FR_Merimee(Analyser_Merge):
                     static2 = {"source:heritage": self.source},
                     mapping1 = {
                         "ref:mhs": "REF",
-                        "mhs:inscription_date": lambda res: u"%s" % res["PPRO"][-4:],
+                        "mhs:inscription_date": lambda res: parseDPRO(res["DPRO"]),
                         "heritage": lambda res: 2 if u"classement par arrêté" in res["PPRO"] else 3 if u"inscription par arrêté" in res["PPRO"] else None},
                     mapping2 = {"name": "TICO"},
                     tag_keep_multiple_values = ["heritage:operator"],


### PR DESCRIPTION
### Improvement
- The full YYYY-MM-DD day is now parsed when available.
- The first inscription date is proposed (e.g monument PA00097106 has
  now the date 1976-02-24 instead of 2007)
Issue #140

### A few statistics

* No change (inscription date is still a year): 1396
* Day is extracted with the same year as previously: 37382
* Day is extracted with a different year: 2914
    Among these, 5 dates of the current process is anterior to the date of new extracted date
    
           ref     | old      | new
       ------------+----------+------------------
        PA00088653 | 1848     | 1862
        PA00100544 | 1862     | 1875
        PA00090241 | 1881     | 1889
        PA00102755 | 1960     | 1961-11-06
        PA63000112 | 2009     | 2012-09-10 (2009 is an error in the Mérimée base)
        
* Day is extracted where an invalid year was previously extracted: 36

           ref     | inscription_date | inscription_date
       ------------+------------------+------------------
        PA00083847 | 008£             | 2007-07-25
        PA00080835 | 009£             | 1948-09-27
        PA00101166 | 07££             | 1929-10-03
        PA80000053 | 07££             | 2006-01-19
        PA00092499 | 116)             | 1986-12-15
        PA00100892 | 136)             | 1962-03-05
        PA00100567 | 15).             | 1948-10-20
        PA63000091 |  200             | 2008-04-07
        PA87000032 |  209             | 2009-04-28
        PA00092497 | 224)             | 1986-12-15
        PA00092496 | 271)             | 1986-12-15
        PA00100890 |  55)             | 1962-03-05
        PA00110695 | 903£             | 1903-07-11
        PA00089903 | 906)             | 1962-08-14
        PA00135568 | 949.             | 1949-09-19
        PA00101798 | 993.             | 1992-06-17
        PA00097158 | 993.             | 1927-11-05
        PA00099637 | 993.             | 1991-09-19
        PA00101435 | 993.             | 1992-08-07
        PA00101730 | 993.             | 1992-07-23
        PA00101791 | 993.             | 1992-06-17
        PA00125315 | 993.             | 1993-09-24
        PA00125364 | 993.             | 1993-02-02
        PA00099290 | 993.             | 1926-04-17
        PA00115676 | 995.             | 1928-09-19
        PA00092498 |  A2)             | 1986-12-15
        PA00086773 | e) )             | 2006-02-06
        PA00086789 | e) )             | 2006-02-06
        PA00086775 | e) )             | 2006-02-06
        PA75200001 | e) )             | 2006-02-06
        PA00086791 | e) )             | 2006-02-06
        PA00086790 | e) )             | 2006-02-06
        PA00103697 | iane             | 1935-04-05
        PA00097246 | lain             | 1991-05-10
        PA00084511 | rits             | 1953-10-01
        PA00116318 | se).             | 1862

