### PR TITLE
Fix running with --analyser option

### DIFF
--- a/osmose_run.py
+++ b/osmose_run.py
@@ -826,14 +826,14 @@ if __name__ == "__main__":
     analysers = {}
     for fn in os.listdir(analysers_path):
         if fn.startswith("analyser_") and fn.endswith(".py"):
-            if options.analyser and fn[:-3] not in options.analyser:
+            if options.analyser and fn[9:-3] not in options.analyser:
                 continue
-            logger.log("  load "+fn[:-3])
+            logger.log("  load "+fn[9:-3])
             analysers[fn[:-3]] = __import__(fn[:-3])
     if options.analyser:
         count = 0
         for k in options.analyser:
-            if k not in analysers:
+            if ("analyser_%s" % k) not in analysers:
                 logger.log(logger.log_av_b+"not found "+k+logger.log_ap)
                 count += 1
         # user is passing only non-existent analysers


### PR DESCRIPTION
Currently, running a single analyser with the --analyser option does not work:

    $ ./osmose_run.py --country=france_local_db --analyser=merge_heritage_FR_merimee
    2017-05-19 17:23:11 loading analyses 
    2017-05-19 17:23:11 not found merge_heritage_FR_merimee
    No valid analysers specified

yet, it is among existing analyser:

    $ ./osmose_run.py --list-analyser | grep merimee
    merge_heritage_FR_merimee
