### PR TITLE
wait for PostgreSQL to be available

### DIFF
--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -4,6 +4,12 @@ set -x
 
 /etc/init.d/postgresql start
 
+TIMER="5"
+until runuser -l postgres -c 'pg_isready' 2>/dev/null; do
+  >&2 echo "PostgrSQL not yet available. Sleeping for $TIMER seconds..."
+  sleep $TIMER
+done
+
 cd /opt/osmose-backend
 
 sudo -u osmose ./osmose_run.py $@


### PR DESCRIPTION
I experienced PostgreSQL not being available once the init returned.
This leads to the next commands failing. Adding a loop to wait for PostgreSQL to
be ready before continuing with Osmose.