### PR TITLE
Analyser Merge TBM - fix

### DIFF
--- a/analysers/analyser_merge_public_transport_FR_tbm.py
+++ b/analysers/analyser_merge_public_transport_FR_tbm.py
@@ -42,7 +42,7 @@ class Analyser_Merge_Public_Transport_FR_TBM(Analyser_Merge):
                 generate = Generate(
                     static1 = {
                         "highway": "bus_stop",
-                        "public_transport": "stop_position",
+                        "public_transport": "platform",
                         "bus": "yes",
                         "network": "TBM"},
                     static2 = {"source": self.source},


### PR DESCRIPTION
most stops (from the opendata source and from OSM) are on the side of the road (and not in the middle of the road) so they seems to represent `public_transport`= `platform`