### PR TITLE
docker: upgrade after installing packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
                                 postgresql-contrib \
                                 postgresql-9.5-postgis-2.2 \
                                 openjdk-8-jre-headless && \
+    apt-get -y dist-upgrade && \
     apt-get clean
 
 RUN mkdir -p /data/work/osmose


### PR DESCRIPTION
As even a just updated base image can contain upgradeable packages do force a package upgrade to have latest security fixes in the image.