### PR TITLE
docker: enable usage of tmpfs for container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,16 +26,6 @@ RUN mkdir -p /data/work/osmose
 RUN useradd -s /bin/bash -d /data/work/osmose osmose
 RUN chown osmose /data/work/osmose
 
-USER postgres
-RUN /etc/init.d/postgresql start && \
-    createuser osmose && \
-    psql -c "ALTER ROLE osmose WITH PASSWORD '-osmose-';" && \
-    createdb -E UTF8 -T template0 -O osmose osmose && \
-    psql -c "CREATE extension hstore; CREATE extension fuzzystrmatch; CREATE extension unaccent; CREATE extension postgis;" osmose && \
-    psql -c "GRANT SELECT,UPDATE,DELETE ON TABLE spatial_ref_sys TO osmose;" osmose && \
-    psql -c "GRANT SELECT,UPDATE,DELETE,INSERT ON TABLE geometry_columns TO osmose;" osmose
-
-USER root
 ADD . /opt/osmose-backend/
 
 WORKDIR /opt/osmose-backend

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -1,15 +1,46 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 
+# if data directory does not exist, clean up and recreate it
+if [ ! -d "$(pg_conftool -s show data_directory)" ]; then
+   POSTGRES_VERSION=$(psql --version |grep -E -o '[0-9]{1,}\.[0-9]{1,}')
+   pg_dropcluster "$POSTGRES_VERSION" main
+   pg_createcluster "$POSTGRES_VERSION" main
+fi
+
 /etc/init.d/postgresql start
 
+# It can take a bit to start the DB inside the container. Wait for it to be ready...
 TIMER="5"
 until runuser -l postgres -c 'pg_isready' 2>/dev/null; do
   >&2 echo "PostgrSQL not yet available. Sleeping for $TIMER seconds..."
   sleep $TIMER
 done
 
-cd /opt/osmose-backend
+# set up database in case it is not yet existing, eg because container has mounted a tmpfs as db storage path
+# if it is already there the commands will simply complain and continue without changes
+runuser -l postgres -c $'createuser osmose'
+runuser -l postgres -c $'psql -c "ALTER ROLE osmose WITH PASSWORD \'-osmose-\';"'
+runuser -l postgres -c $'createdb -E UTF8 -T template0 -O osmose osmose'
+runuser -l postgres -c $'psql -c "CREATE extension IF NOT EXISTS hstore; CREATE extension IF NOT EXISTS fuzzystrmatch; CREATE extension IF NOT EXISTS unaccent; CREATE extension IF NOT EXISTS postgis;" osmose'
+runuser -l postgres -c $'psql -c "GRANT SELECT,UPDATE,DELETE ON TABLE spatial_ref_sys TO osmose;" osmose'
+runuser -l postgres -c $'psql -c "GRANT SELECT,UPDATE,DELETE,INSERT ON TABLE geometry_columns TO osmose;" osmose'
+# allow optional settings to be made after database creation. SQL string must be provided in environment
+if  [ -v POSTGRESQL_POSTCREATION ]; then
+  printf '%s\n' "$POSTGRESQL_POSTCREATION" | runuser -l postgres -c "psql -d osmose"
+fi
+/etc/init.d/postgresql restart
 
-sudo -E -u osmose ./osmose_run.py $@
+# wait again for database to be available
+until runuser -l postgres -c 'pg_isready' 2>/dev/null; do
+  >&2 echo "PostgrSQL not yet available. Sleeping for $TIMER seconds..."
+  sleep $TIMER
+done
+
+# workaround: when mounting docker with tmpfs on data it fails to set a proper mode on already existing paths, even it ending up as tmpfs
+chown -R osmose /data
+
+cd /opt/osmose-backend || exit 2
+
+sudo -E -u osmose ./osmose_run.py "$@"


### PR DESCRIPTION
Daily processing of larger amounts of data on a SSD system puts a very high write load on the disks.
Small rework of the image/container handling to enable usage of a tmpfs for the database.
With the database on a tmpfs it needs to be created during run-time of the container and no longer in the image.

To use a tmpfs with the container, mount it like --mount type=tmpfs,destination=/data/work/osmose --mount type=tmpfs,destination=/var/lib/postgresql

Without these parameters the behavior would be unchanged (with a small warning printed during start of the container about already configured db).

Further on it is possible to specify the environment POSTGRESQL_POSTCREATION to contain one or multiple lines of SQL commands to be executed after database creation to further tune the database.

Startup script is extended to wait for start/restart of postgresql and some more accurate quoting.
