### PR TITLE
[WIP] analyse merge sirene

### DIFF
--- a/analysers/analyser_merge_shop_FR.py
+++ b/analysers/analyser_merge_shop_FR.py
@@ -49,10 +49,11 @@ class Analyser_Merge_Shop_FR(Analyser_Merge_Dynamic):
 class SubAnalyser_Merge_Shop_FR(SubAnalyser_Merge_Dynamic):
     def __init__(self, config, error_file, logger, items, classs, level, title, selectTags, generateTags):
         classss = int(classs.replace('.', '0')[:-1]) * 100 + ord(classs[-1]) - 65
-        self.missing_official = {"item": items[0], "class": classss+1, "level": level, "tag": ["merge"], "desc": T_(u"%s not integrated", title) }
-        self.missing_osm      = {"item": items[1], "class": classss+2, "level": level, "tag": ["merge"], "desc": T_(u"%s without ref:FR:SIRET or invalid", title) }
-        self.possible_merge   = {"item": items[0][0:-1]+"1", "class": classss+3, "level": level, "tag": ["merge"], "desc": T_(u"%s, integration suggestion", title) }
-        self.update_official  = {"item": items[0][0:-1]+"2", "class": classss+4, "level": level, "tag": ["merge"], "desc": T_(u"%s update", title) }
+        self.missing_official = {"item": items[0], "class": classss+1, "level": level, "tag": ["merge"], "desc": T_(u"%s may be missing", title) }
+        #self.missing_osm      = {"item": items[1], "class": classss+2, "level": level, "tag": ["merge"], "desc": T_(u"%s without ref:FR:SIRET or invalid", title) }
+        #self.possible_merge   = {"item": items[0][0:-1]+"1", "class": classss+3, "level": level, "tag": ["merge"], "desc": T_(u"%s, integration suggestion", title) }
+        #self.update_official  = {"item": items[0][0:-1]+"2", "class": classss+4, "level": level, "tag": ["merge"], "desc": T_(u"%s update", title) }
+
         SubAnalyser_Merge_Dynamic.__init__(self, config, error_file, logger,
             "http://www.sirene.fr/sirene/public/static/open-data",
             u"Sirene",
@@ -64,17 +65,17 @@ class SubAnalyser_Merge_Shop_FR(SubAnalyser_Merge_Dynamic):
                 select = Select(
                     types = ['nodes', 'ways'],
                     tags = selectTags),
-                conflationDistance = 80,
+                conflationDistance = 200,
                 generate = Generate(
                     static1 = generateTags,
                     static2 = {"source": self.source},
                     mapping1 = {
-                        "ref:FR:SIRET": lambda fields: fields["SIREN"] + fields["NIC"],
-                        "ref:FR:RNA": "RNA",
+                        # "ref:FR:SIRET": lambda fields: fields["SIREN"] + fields["NIC"],
+                        # "ref:FR:RNA": "RNA",
                         "name": lambda fields: fields["ENSEIGNE"] or (fields["NOMEN_LONG"] if fields["NJ"] else None),
-                        "short_name": "SIGLE",
-                        "start_date": lambda fields:
-                            "-".join([fields["DDEBACT"][0:4], fields["DDEBACT"][4:6], fields["DDEBACT"][6:8]]) if fields["DDEBACT"] != "19000101" else
-                            "-".join([fields["DCRET"][0:4], fields["DCRET"][4:6], fields["DCRET"][6:8]]) if fields["DCRET"] != "19000101" else
-                            None},
+                        "short_name": "SIGLE"},
+                        # "start_date": lambda fields:
+                        #     "-".join([fields["DDEBACT"][0:4], fields["DDEBACT"][4:6], fields["DDEBACT"][6:8]]) if fields["DDEBACT"] != "19000101" else
+                        #     "-".join([fields["DCRET"][0:4], fields["DCRET"][4:6], fields["DCRET"][6:8]]) if fields["DCRET"] != "19000101" else
+                        #     None},
                 text = lambda tags, fields: {"en": ', '.join(filter(lambda f: f and f != 'None', [fields["ENSEIGNE"] or (fields["NOMEN_LONG"] if fields["NJ"] else None)] + map(lambda k: fields[k], ["L1_DECLAREE", "L2_DECLAREE" ,"L3_DECLAREE", "L4_DECLAREE", "L5_DECLAREE", "L6_DECLAREE", "L7_DECLAREE"])))} )))


### PR DESCRIPTION
Bonjour,

j'ai fait cet été quelques tests d'intégration de la base SIRENE en repartant de l'analyse non activée déjà existante.

J'ai désactivé la conflation sur le numéro SIRET : en effet, il est difficile à contribuer sur le terrain (pas facile à obtenir pour un contributeur, pas présent dans les applications de contribution, etc) et très peu renseigné aujourd'hui.

En conséquence, j'ai limité l'analyse merge pour ne rechercher que des éléments manquants dans OSM mais qui, d'après la base SIRENE, existent (ce qui me semble être déjà un incrément fonctionnel acceptable).

Les résultats obtenus sont très mitigés : 
J'ai pu identifier avec cette analyse des zones où des POIs étaient effectivement manquants dans OSM :+1:

Mais souvent, la qualité de la base SIRENE (qui n'est pas vraiment une base géolocalisée et pas vraiment non plus une base de POI) fait défaut et de très nombreux faux positifs remontent : 
j'ai trouvé des commerces dans la base SIRENE à plus de 200 mètres de leur position réelle, et d'autres qui ne me semblent correspondre à rien d'existant sur le terrain.

Je ne sais pas trop quelle suite donner à cela, mais je me suis dit que le retour d'expérience pouvait peut-être être utile :wink: 