### PR TITLE
add version from Docker image via environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,8 @@ ENV PYTHONPATH /opt/osmose-backend
 
 ADD . /opt/osmose-backend/
 
+ARG GIT_VERSION
+ENV OSMOSE_VERSION ${GIT_VERSION:-(unknown)}
 ENV LANG en_US.UTF-8
 ENTRYPOINT ["/opt/osmose-backend/tools/docker-entrypoint.sh"]
 CMD bash

--- a/modules/OsmoseErrorFile.py
+++ b/modules/OsmoseErrorFile.py
@@ -57,7 +57,7 @@ class ErrorFile:
         attrs = {}
         attrs["timestamp"] = timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
         attrs["analyser_version"] = str(analyser_version)
-        if hasattr(self.config, "version"):
+        if hasattr(self.config, "version") and self.config.version is not None:
             attrs["version"] = self.config.version
         self.outxml.startElement(self.mode, attrs)
 

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -65,12 +65,14 @@ class analyser_config:
   pass
 
 def get_version():
-    cmd  = ["git", "describe" ,"--dirty"]
-    try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        version = proc.stdout.readlines()[0].strip()
-    except:
-        version = "(unknown)"
+    version = os.getenv('OSMOSE_VERSION')
+    if not version:
+        cmd = ["git", "describe", "--dirty"]
+        try:
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            version = proc.stdout.readlines()[0].strip()
+        except:
+            version = "(unknown)"
     return version
 
 ###########################################################################
@@ -106,10 +108,7 @@ def check(conf, logger, options):
 def execc(conf, logger, options, osmosis_manager):
     err_code = 0
 
-    try:
-      version = get_version()
-    except:
-      version = None
+    version = get_version()
 
     logger.log("osmose backend version: %s" % version)
 


### PR DESCRIPTION
improves  #404 ,

call 

    docker build --build-arg GIT_VERSION=`git describe --dirty`

to pass the current version as environment to the image.