### PR TITLE
Fix analyser_merge_street_number wording for Rennes

### DIFF
--- a/analysers/analyser_merge_street_number.py
+++ b/analysers/analyser_merge_street_number.py
@@ -148,5 +148,5 @@ class Analyser_Merge_Street_Number_Rennes(_Analyser_Merge_Street_Number):
             Mapping(
                 generate = Generate(
                     static2 = {"source": self.source},
-                    mapping1 = {"addr:housenumber": lambda res: res["numero"] + (res["suffixe"] if res["suffixe"] else "")},
-                    text = lambda tags, fields: {"en": u"%s%s %s" % (fields["numero"], fields["suffixe"], fields["voie_nom"])} )))
+                    mapping1 = {"addr:housenumber": lambda res: res["numero"] + (" "+res["suffixe"] if res["suffixe"] else "")},
+                    text = lambda tags, fields: {"en": u"%s%s %s" % (fields["numero"], (" "+fields["suffixe"] if fields["suffixe"] else ""), fields["voie_nom"])} )))


### PR DESCRIPTION
Small fix of wording for street numbers in Rennes, which is quite broken for now.

![capture d ecran_2019-01-11_08-56-00](https://user-images.githubusercontent.com/1349014/51020416-bea41e00-157e-11e9-9a49-17ff8591eb9c.png)
