### PR TITLE
Improve the oh_sanitizer module

### DIFF
--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -56,13 +56,17 @@ rule_modifier : OPEN [" " COMMENT] -> rule_modifier_open
               | COMMENT -> rule_modifier_comment
 
 selector_sequence : ALWAYS_OPEN -> always_open
-                  | range_selectors [" " time_selector]
+                  | small_range_selectors
+                  | range_selectors [ " " time_selector]
                   | time_selector
 
 //
 
 %ignore " "
 COLON : ":"
+
+small_range_selectors.2 : weekday_selector [" "] [COLON] " " time_selector
+
 range_selectors : [year_selector] [monthday_selector] [week_selector] [COLON] [weekday_selector]
 
 //

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -93,18 +93,24 @@ day_offset : " " PLUS_OR_MINUS INT (" day" ["s"] | " d")
 
 //
 
-time_selector : timespan (("," | "/")? timespan)*
-timespan : time DASH time
+time_selector : full_timespan " " time_selector
+              | timespan (("," | "/") time_selector)?
+full_timespan : time DASH time -> timespan
+timespan : full_timespan
+         | time
 time : hour_minutes | variable_time
 
 HOUR : /([01][0-9]|2[0-4]|[0-9])/
 MINUTE : /([0-5][0-9]|[0-9])/
+HOURMINUTES : /([01][0-9]|2[0-4]|[0-9])([0-5][0-9]|[0-9])/
 TIME_SEPARATOR : ":"i | "."i | "h"i
 H_SUFFIX : "h"i
 
-hour_minutes : HOUR [TIME_SEPARATOR] MINUTE [AM | PM]
+hour_minutes : hms
+             | HOUR TIME_SEPARATOR MINUTE [AM | PM]
              | hour_am_pm_minutes
              | HOUR [H_SUFFIX] [AM | PM]
+hms.2 : HOURMINUTES [AM | PM]
 hour_am_pm_minutes.2 : HOUR [H_SUFFIX] (AM | PM) MINUTE -> hour_minutes
 
 variable_time : EVENT

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -4,19 +4,19 @@
 //   abbreviations.
 // - For English, French and Spanish
 WDAY_MO : "Monday"i | "Lundi"i | "Lunes"i
-        | "Mon"i | "Mo"i
+        | "Mon"i | "Mo"i | "Lu"i
 WDAY_TU : "Tuesday"i | "Mardi"i | "Martes"i
-        | "Tue"i | "Tu"i
+        | "Tue"i | "Tu"i | "Ma"i
 WDAY_WE : "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i)
-        | "Wed"i | "We"i
+        | "Wed"i | "We"i | "Me"i
 WDAY_TH : "Thursday"i | "Jeudi"i | "Jueves"i
-        | "Thu"i | "Th"i
+        | "Thu"i | "Th"i | "Je"i
 WDAY_FR : "Friday"i | "Vendredi"i | "Viernes"i
-        | "Fri"i | "Fr"i
+        | "Fri"i | "Fr"i | "Ve"i
 WDAY_SA : "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i)
         | "Sat"i | "Sa"i
 WDAY_SU : "Sunday"i | "Dimanche"i | "Domingo"i
-        | "Sun"i | "Su"i
+        | "Sun"i | "Su"i | "Di"i
 
 wday.1 : WDAY_MO | WDAY_TU | WDAY_WE | WDAY_TH | WDAY_FR | WDAY_SA | WDAY_SU
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -32,7 +32,7 @@ COMMENT : ESCAPED_STRING
 
 //
 
-time_domain : rule_sequence (RULE_SEPARATOR rule_sequence)*
+time_domain : rule_sequence (RULE_SEPARATOR " "* rule_sequence)*
 
 rule_sequence : selector_sequence
               | selector_sequence " " rule_modifier

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -94,6 +94,7 @@ HOUR_MINUTES_H : "h"i
 hour_minutes : INT ":" INT
              | INT HOUR_MINUTES_H INT
              | INT HOUR_MINUTES_H
+             | INT AM_PM -> hour_am_pm
              | INT ":" INT AM_PM -> hour_minutes_am_pm
              | INT HOUR_MINUTES_H AM_PM INT -> hour_minutes_am_pm
              | INT HOUR_MINUTES_H AM_PM -> hour_minutes_am_pm

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -73,7 +73,7 @@ weekday_selector : (weekday_sequence | holiday ("," holiday)*) -> weekday_or_hol
                  | holiday ("," holiday)* " " weekday_sequence -> holiday_in_weekday_sequence_selector
 weekday_sequence : weekday_range ("," weekday_range)*
 weekday_range : wday [wday_nth_sequence]
-              | wday "-" wday
+              | wday DASH wday
 holiday : PUBLIC_HOLIDAY
         | SCHOOL_HOLIDAY
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -1,13 +1,22 @@
 // Longer matches must come first so put them in the following order:
-// - Full name then two-letter abbreviation
+// - Full name, three-letter abbreviation, then two-letter abbreviation
+//   Note: Make sure to avoid collision with month names for three-letter
+//   abbreviations.
 // - For English, French and Spanish
-WDAY_MO : "Monday"i | "Lundi"i | "Lunes"i | "Mo"i
-WDAY_TU : "Tuesday"i | "Mardi"i | "Martes"i | "Tu"i
-WDAY_WE : "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i) | "We"i
-WDAY_TH : "Thursday"i | "Jeudi"i | "Jueves"i | "Th"i
-WDAY_FR : "Friday"i | "Vendredi"i | "Viernes"i | "Fr"i
-WDAY_SA : "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i) | "Sa"i
-WDAY_SU : "Sunday"i | "Dimanche"i | "Domingo"i | "Su"i
+WDAY_MO : "Monday"i | "Lundi"i | "Lunes"i
+        | "Mon"i | "Mo"i
+WDAY_TU : "Tuesday"i | "Mardi"i | "Martes"i
+        | "Tue"i | "Tu"i
+WDAY_WE : "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i)
+        | "Wed"i | "We"i
+WDAY_TH : "Thursday"i | "Jeudi"i | "Jueves"i
+        | "Thu"i | "Th"i
+WDAY_FR : "Friday"i | "Vendredi"i | "Viernes"i
+        | "Fri"i | "Fr"i
+WDAY_SA : "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i)
+        | "Sat"i | "Sa"i
+WDAY_SU : "Sunday"i | "Dimanche"i | "Domingo"i
+        | "Sun"i | "Su"i
 
 wday.1 : WDAY_MO | WDAY_TU | WDAY_WE | WDAY_TH | WDAY_FR | WDAY_SA | WDAY_SU
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -27,7 +27,7 @@ EVENT.2 : "dawn"i | "sunrise"i | "sunset"i | "dusk"i
 EASTER : "easter"i
 OPEN : "open"i
 CLOSED : "closed"i
-OFF : "off"i
+OFF : "off"i | "fermé"i
 ALWAYS_OPEN.2 : "24/7"
 WEEK.2 : "week "i
 AM : "AM"i | "a.m."i

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -95,9 +95,11 @@ day_offset : " " PLUS_OR_MINUS INT (" day" ["s"] | " d")
 
 time_selector : full_timespan " " time_selector
               | timespan (("," | "/") time_selector)?
-full_timespan : time DASH time -> timespan
+
+PLUS : "+"
+full_timespan : time DASH time [PLUS] -> timespan
 timespan : full_timespan
-         | time
+         | time [PLUS]
 time : hour_minutes | variable_time
 
 HOUR : /([01][0-9]|2[0-4]|[0-9])/

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -35,6 +35,7 @@ AM_PM : "AM"i | "PM"i
 %import common.INT
 
 PLUS_OR_MINUS : "+" | "-"
+DASH : "-" | "–"
 
 RULE_SEPARATOR : ";" | "," | "||"
 
@@ -88,7 +89,7 @@ day_offset : " " PLUS_OR_MINUS INT (" day" ["s"] | " d")
 //
 
 time_selector : timespan (("," | "/")? timespan)*
-timespan : time "-" time
+timespan : time DASH time
 time : hour_minutes | variable_time
 HOUR_MINUTES_H : "h"i
 hour_minutes : INT ":" INT

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -113,7 +113,7 @@ year_selector : year_range ("," year_range)*
 year_range : year
            | year "-" year
            | year "-" year "/" INT
-year.2 : /([0-9]{4})+/
+year.2 : /[0-9]{4}/
 
 //
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -96,15 +96,17 @@ day_offset : " " PLUS_OR_MINUS INT (" day" ["s"] | " d")
 time_selector : timespan (("," | "/")? timespan)*
 timespan : time DASH time
 time : hour_minutes | variable_time
-HOUR_MINUTES_H : "h"i
-hour_minutes : INT ":" INT
-             | INT HOUR_MINUTES_H INT
-             | INT HOUR_MINUTES_H
-             | INT (AM | PM) -> hour_am_pm
-             | INT ":" INT (AM | PM) -> hour_minutes_am_pm
-             | INT HOUR_MINUTES_H (AM | PM) INT -> hour_minutes_am_pm
-             | INT HOUR_MINUTES_H (AM | PM) -> hour_minutes_am_pm
-             | INT
+
+HOUR : /([01][0-9]|2[0-4]|[0-9])/
+MINUTE : /([0-5][0-9]|[0-9])/
+TIME_SEPARATOR : ":"i | "h"i
+H_SUFFIX : "h"i
+
+hour_minutes : HOUR [TIME_SEPARATOR] MINUTE [AM | PM]
+             | hour_am_pm_minutes
+             | HOUR [H_SUFFIX] [AM | PM]
+hour_am_pm_minutes.2 : HOUR [H_SUFFIX] (AM | PM) MINUTE -> hour_minutes
+
 variable_time : EVENT
               | "(" EVENT PLUS_OR_MINUS hour_minutes ")"
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -104,11 +104,15 @@ year.2 : /([0-9]{4})+/
 monthday_selector : monthday_range ("," monthday_range)*
 monthday_range : monthday_date  // "Dec 25"
                | monthday_date "-" monthday_date  // "Jan 1-Feb 1"
-monthday_date : [year " "] MONTH " " INT -> monthday_date_monthday
-              | [year " "] MONTH " " INT "-" INT -> monthday_date_day_to_day
+monthday_date : monthday_date_day
               | [year " "] MONTH -> monthday_date_month
               | [year " "] EASTER -> monthday_date_easter
               | [year " "] EASTER day_offset -> monthday_date_easter
+
+// Boost the priority so the day range of "Apr 10-15 off" is not mistaken for
+// a bad form of timespan and converted to "Apr 10:00-15:00 off".
+monthday_date_day.8 : [year " "] MONTH " " INT -> monthday_date_monthday
+                    | [year " "] MONTH " " INT "-" INT -> monthday_date_day_to_day
 
 //
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -1,22 +1,24 @@
 // Longer matches must come first so put them in the following order:
 // - Full name, three-letter abbreviation, then two-letter abbreviation
 //   Note: Make sure to avoid collision with month names for three-letter
-//   abbreviations.
-// - For English, French and Spanish
-WDAY_MO : "Monday"i | "Lundi"i | "Lunes"i
-        | "Mon"i | "Mo"i | "Lu"i
-WDAY_TU : "Tuesday"i | "Mardi"i | "Martes"i
-        | "Tue"i | "Tu"i | "Ma"i
-WDAY_WE : "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i)
-        | "Wed"i | "We"i | "Me"i
-WDAY_TH : "Thursday"i | "Jeudi"i | "Jueves"i
-        | "Thu"i | "Th"i | "Je"i
-WDAY_FR : "Friday"i | "Vendredi"i | "Viernes"i
-        | "Fri"i | "Fr"i | "Ve"i
-WDAY_SA : "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i)
-        | "Sat"i | "Sa"i
-WDAY_SU : "Sunday"i | "Dimanche"i | "Domingo"i
-        | "Sun"i | "Su"i | "Di"i
+//         abbreviations.
+// - For English, French, Italian and Spanish
+//   Note: Make sure to avoid collisions between languages for the
+//         abbreviations.
+WDAY_MO : "Monday"i | "Lundi"i | "Lunedi"i | "Lunes"i
+        | "Mon"i | "Lun"i | "Mo"i | "Lu"i
+WDAY_TU : "Tuesday"i | "Mardi"i | "Martedì"i | "Martes"i
+        | "Tue"i | "Tu"i | "Ma"i // Note: "Mar" would collide with March
+WDAY_WE : "Wednesday"i | "Mercredi"i | "Mercoledì"i | ("Miércoles"i | "Miercoles"i)
+        | "Wed"i | "Mer"i | "We"i | "Me"i
+WDAY_TH : "Thursday"i | "Jeudi"i | "Giovedi"i | "Jueves"i
+        | "Thu"i | "Gio"i | "Th"i | "Je"i
+WDAY_FR : "Friday"i | "Vendredi"i | "Venerdì"i | "Viernes"i
+        | "Fri"i | "Ven"i | "Fr"i | "Ve"i
+WDAY_SA : "Saturday"i | "Samedi"i | "Sabato"i | ("Sábado"i | "Sabado"i)
+        | "Sat"i | "Sab"i | "Sa"i
+WDAY_SU : "Sunday"i | "Dimanche"i | "Domenica"i | "Domingo"i
+        | "Sun"i | "Dom"i | "Su"i | "Di"i
 
 wday.1 : WDAY_MO | WDAY_TU | WDAY_WE | WDAY_TH | WDAY_FR | WDAY_SA | WDAY_SU
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -97,7 +97,7 @@ time_selector : full_timespan " " time_selector
               | timespan (("," | "/") time_selector)?
 
 PLUS : "+"
-full_timespan : time DASH time [PLUS] -> timespan
+full_timespan : time (DASH | COLON) time [PLUS] -> timespan
 timespan : full_timespan
          | time [PLUS]
 time : hour_minutes | variable_time

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -1,11 +1,13 @@
-// Abbr. / Full english name / Full french name / Full spanish name
-WDAY_MO : "Mo"i | "Monday"i | "Lundi"i | "Lunes"i
-WDAY_TU : "Tu"i | "Tuesday"i | "Mardi"i | "Martes"i
-WDAY_WE : "We"i | "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i)
-WDAY_TH : "Th"i | "Thursday"i | "Jeudi"i | "Jueves"i
-WDAY_FR : "Fr"i | "Friday"i | "Vendredi"i | "Viernes"i
-WDAY_SA : "Sa"i | "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i)
-WDAY_SU : "Su"i | "Sunday"i | "Dimanche"i | "Domingo"i
+// Longer matches must come first so put them in the following order:
+// - Full name then two-letter abbreviation
+// - For English, French and Spanish
+WDAY_MO : "Monday"i | "Lundi"i | "Lunes"i | "Mo"i
+WDAY_TU : "Tuesday"i | "Mardi"i | "Martes"i | "Tu"i
+WDAY_WE : "Wednesday"i | "Mercredi"i | ("Miércoles"i | "Miercoles"i) | "We"i
+WDAY_TH : "Thursday"i | "Jeudi"i | "Jueves"i | "Th"i
+WDAY_FR : "Friday"i | "Vendredi"i | "Viernes"i | "Fr"i
+WDAY_SA : "Saturday"i | "Samedi"i | ("Sábado"i | "Sabado"i) | "Sa"i
+WDAY_SU : "Sunday"i | "Dimanche"i | "Domingo"i | "Su"i
 
 wday.1 : WDAY_MO | WDAY_TU | WDAY_WE | WDAY_TH | WDAY_FR | WDAY_SA | WDAY_SU
 

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -30,7 +30,8 @@ CLOSED : "closed"i
 OFF : "off"i
 ALWAYS_OPEN.2 : "24/7"
 WEEK.2 : "week "i
-AM_PM : "AM"i | "PM"i
+AM : "AM"i | "a.m."i
+PM : "PM"i | "p.m."i
 
 %import common.INT
 
@@ -99,10 +100,10 @@ HOUR_MINUTES_H : "h"i
 hour_minutes : INT ":" INT
              | INT HOUR_MINUTES_H INT
              | INT HOUR_MINUTES_H
-             | INT AM_PM -> hour_am_pm
-             | INT ":" INT AM_PM -> hour_minutes_am_pm
-             | INT HOUR_MINUTES_H AM_PM INT -> hour_minutes_am_pm
-             | INT HOUR_MINUTES_H AM_PM -> hour_minutes_am_pm
+             | INT (AM | PM) -> hour_am_pm
+             | INT ":" INT (AM | PM) -> hour_minutes_am_pm
+             | INT HOUR_MINUTES_H (AM | PM) INT -> hour_minutes_am_pm
+             | INT HOUR_MINUTES_H (AM | PM) -> hour_minutes_am_pm
              | INT
 variable_time : EVENT
               | "(" EVENT PLUS_OR_MINUS hour_minutes ")"

--- a/modules/oh_sanitizer/field.ebnf
+++ b/modules/oh_sanitizer/field.ebnf
@@ -99,7 +99,7 @@ time : hour_minutes | variable_time
 
 HOUR : /([01][0-9]|2[0-4]|[0-9])/
 MINUTE : /([0-5][0-9]|[0-9])/
-TIME_SEPARATOR : ":"i | "h"i
+TIME_SEPARATOR : ":"i | "."i | "h"i
 H_SUFFIX : "h"i
 
 hour_minutes : HOUR [TIME_SEPARATOR] MINUTE [AM | PM]

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -425,7 +425,7 @@ class TestSanitize(_unittest.TestCase):
         # Time correction
         self.assertEqual(sanitize_field("9:00-12:00"), "09:00-12:00")
         self.assertEqual(sanitize_field("9h-12h5"), "09:00-12:05")
-        self.assertEqual(sanitize_field("8h45 am - 11:45 a.m."), "08:45-11:45")
+        self.assertEqual(sanitize_field("8h45 am - 11.45 a.m."), "08:45-11:45")
         self.assertEqual(sanitize_field("9h p.m. 6 - 10 pm 15"), "21:06-22:15")
         self.assertEqual(sanitize_field("9 am - 12"), "09:00-12:00")
         

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -444,6 +444,7 @@ class TestSanitize(_unittest.TestCase):
         
         # Global
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")
+        self.assertEqual(sanitize_field("Mon-fri 10:00-20:00"), "Mo-Fr 10:00-20:00")
         self.assertEqual(sanitize_field("2020 mo-fr 1000 - 2000 / 22:20-23:00"), "2020 Mo-Fr 10:00-20:00,22:20-23:00")
         self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -195,20 +195,16 @@ class SanitizerTransformer(_lark.Transformer):
         return '-'.join(args)
     
     def wday(self, args):
-        day = args[0]
         DAYS = {
-            "Mo": ["mo", "monday", "lundi", "lunes"],
-            "Tu": ["tu", "tuesday", "mardi", "martes"],
-            "We": ["we", "wednesday", "mercredi", "miercoles", u"miércoles"],
-            "Th": ["th", "thursday", "jeudi", "jueves"],
-            "Fr": ["fr", "friday", "vendredi", "viernes"],
-            "Sa": ["sa", "saturday", "samedi", "sabado", u"sábado"],
-            "Su": ["su", "sunday", "dimanche", "domingo"]
+            'WDAY_MO': 'Mo',
+            'WDAY_TU': 'Tu',
+            'WDAY_WE': 'We',
+            'WDAY_TH': 'Th',
+            'WDAY_FR': 'Fr',
+            'WDAY_SA': 'Sa',
+            'WDAY_SU': 'Su',
         }
-        for normalized_day, localized_days in DAYS.items():
-            if day.lower() in localized_days:
-                return normalized_day
-        # Should not come here.
+        return DAYS[args[0].type]
     
     # Year
     def year(self, args):

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -9,9 +9,6 @@ import lark as _lark
 from lark.lexer import Token as _Token
 
 
-# TODO: Fix 'Mo,SH'
-
-
 def get_parser():
     """
         Returns a Lark parser able to parse a valid field.
@@ -20,6 +17,9 @@ def get_parser():
     with open(_os.path.join(base_dir, "field.ebnf"), 'rb') as f:
         grammar = f.read().decode("UTF-8")
     return _lark.Lark(grammar, start="time_domain", parser="earley")
+
+
+# TODO: Fix 'Mo,SH'
 
 
 PARSER = get_parser()
@@ -94,6 +94,9 @@ class SanitizerTransformer(_lark.Transformer):
     
     def monthday_range(self, args):
         return '-'.join(args)
+
+    def monthday_date(self, args):
+        return ''.join(args)
     
     def monthday_date_day_to_day(self, args):
         year = args.pop(0) if len(args) == 4 else None

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -65,7 +65,7 @@ class SanitizerTransformer(_lark.Transformer):
         for arg in args:
             if isinstance(arg, _Token):
                 parts.append(
-                    {';': '; ', ',': ', ', '||': ' || '}.get(arg.value.strip())
+                    {';': '; ', ',': ',', '||': ' || '}.get(arg.value.strip())
                 )
             else:
                 parts.append(arg)
@@ -368,7 +368,13 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("Mo-Fr,SH 10:00-20:00"), "Mo-Fr,SH 10:00-20:00")
         self.assertEqual(sanitize_field("Mo-Fr,PH 10:00-20:00"), "Mo-Fr,PH 10:00-20:00")
         self.assertEqual(sanitize_field("Mo-Fr 10:00-12:00,13:00-20:00"), "Mo-Fr 10:00-12:00,13:00-20:00")
-        
+        self.assertEqual(sanitize_field("Mo 10:00-12:00,14:00-18:00; Tu 11:00-13:00,15:00-19:00"), "Mo 10:00-12:00,14:00-18:00; Tu 11:00-13:00,15:00-19:00")
+        # Ideally we would want a space after the comma rule separator in
+        # "off, Mar" and after no other comma. But the space is optional,
+        # getting the parser to correctly identify this case is hard /
+        # impossible, and it's a very rare case anyway.
+        self.assertEqual(sanitize_field("08:00-17:45; Su 08:00-09:00 off, Mar 17:45-19:00"), "08:00-17:45; Su 08:00-09:00 off,Mar 17:45-19:00")
+
         self.assertEqual(sanitize_field("PH 10:00-20:00"), "PH 10:00-20:00")
         self.assertEqual(sanitize_field("SH 10:00-20:00"), "SH 10:00-20:00")
         self.assertEqual(sanitize_field("SH,PH 10:00-20:00"), "SH,PH 10:00-20:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -465,7 +465,7 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("2020 mo-fr 1000 - 2000 / 22:20-23:00"), "2020 Mo-Fr 10:00-20:00,22:20-23:00")
         self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
-        self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
+        self.assertEqual(sanitize_field(u"lundi-vendredi 10h am - 12h / 13h-20h; dimanche fermé"), "Mo-Fr 10:00-12:00,13:00-20:00; Su off")
         self.assertEqual(sanitize_field("lu - je 10h am - 12h / 13h-20h"), "Mo-Th 10:00-12:00,13:00-20:00")
         # FIXME Slashes are used as rule separators too but recognizing those
         # clashes with their use as timespan separators

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -85,6 +85,9 @@ class SanitizerTransformer(_lark.Transformer):
         else:  # "range_selectors time_selector"
             return (args[0] + ' ' + args[1])
     
+    def small_range_selectors(self, args):
+        return args[0] + ' ' + args[-1]
+
     def range_selectors(self, args):
         return ' '.join(args).replace(' :', ':')
     
@@ -436,6 +439,11 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("su,sh off"), "Su,SH off")
         self.assertEqual(sanitize_field("mo-fr CLOSED"), "Mo-Fr closed")
         
+        # Weekday correction
+        self.assertEqual(sanitize_field("Mon-fri 10:00-20:00"), "Mo-Fr 10:00-20:00")
+        self.assertEqual(sanitize_field("Mo-Fr : 10:00-20:00"), "Mo-Fr 10:00-20:00")
+        self.assertEqual(sanitize_field("Lundi - Vendredi: 10:00-20:00"), "Mo-Fr 10:00-20:00")
+
         # Time correction
         self.assertEqual(sanitize_field("9:00-12:00"), "09:00-12:00")
         self.assertEqual(sanitize_field("9h-12h"), "09:00-12:00")
@@ -450,7 +458,6 @@ class TestSanitize(_unittest.TestCase):
         
         # Global
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")
-        self.assertEqual(sanitize_field("Mon-fri 10:00-20:00"), "Mo-Fr 10:00-20:00")
         self.assertEqual(sanitize_field("2020 mo-fr 1000 - 2000 / 22:20-23:00"), "2020 Mo-Fr 10:00-20:00,22:20-23:00")
         self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -269,6 +269,12 @@ class SanitizerTransformer(_lark.Transformer):
             h, m = args[0].value[:2], args[0].value[2:]
         return h.zfill(2) + ':' + m.zfill(2)
     
+    def hour_am_pm(self, args):
+        h = args[0].value
+        if args[1] == "PM":
+            h = str(int(h) + 12)
+        return h.zfill(2) + ':00'
+
     def hour_minutes_am_pm(self, args):
         if len(args) == 3:  # "10:00 am" / "10h am"
             h = args[0].value
@@ -434,8 +440,7 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("9:00-12:00"), "09:00-12:00")
         self.assertEqual(sanitize_field("9h-12h"), "09:00-12:00")
         self.assertEqual(sanitize_field("9:00 am - 12:00 am"), "09:00-12:00")
-        # TODO
-        #self.assertEqual(sanitize_field("9 am - 12 am"), "09:00-12:00")
+        self.assertEqual(sanitize_field("9 am - 12 am"), "09:00-12:00")
         
         # Timespan correction
         self.assertEqual(sanitize_field("09:00-12:00/13:00-19:00"), "09:00-12:00,13:00-19:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -457,6 +457,8 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("09:00-12:00 /13:00-19:00"), "09:00-12:00,13:00-19:00")
         self.assertEqual(sanitize_field(u"Mo 09:00-12:00 14:00-18:00"), "Mo 09:00-12:00,14:00-18:00")
         self.assertEqual(sanitize_field(u"Mo 09:00-12:00 18:00"), "Mo 09:00-12:00,18:00")
+        self.assertEqual(sanitize_field(u"Mo 09h:12h"), "Mo 09:00-12:00")
+        self.assertEqual(sanitize_field(u"Mo 09:00:12:00"), "Mo 09:00-12:00")
         self.assertEqual(sanitize_field(u"Mo–Fr 09:00–12:00"), "Mo-Fr 09:00-12:00")
         
         # Global

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -462,6 +462,9 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lu - je 10h am - 12h / 13h-20h"), "Mo-Th 10:00-12:00,13:00-20:00")
+        # FIXME Slashes are used as rule separators too but recognizing those
+        # clashes with their use as timespan separators
+        #self.assertEqual(sanitize_field("Mo-Fr 06:00-18:00 / Sa 06:00-12:30"), "Mo-Fr 06:00-18:00; Sa 06:00-12:30")
         self.assertEqual(sanitize_field("mo-fr 10h am - 2:00 PM ||Sa-Su 1000-2000"), "Mo-Fr 10:00-14:00 || Sa-Su 10:00-20:00")
         self.assertEqual(sanitize_field('mo-fr 10h-20h open "on appointement"'), 'Mo-Fr 10:00-20:00 open "on appointement"')
         self.assertEqual(sanitize_field("sunrise-( sunset+ 01h10)"), "sunrise-(sunset+01:10)")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -190,9 +190,9 @@ class SanitizerTransformer(_lark.Transformer):
         return ','.join(args)
     
     def weekday_range(self, args):
-        if len(args) == 2 and '[' in args[1]:
-            return ''.join(args)
-        return '-'.join(args)
+        if len(args) == 3:
+            return args[0] + '-' + args[2]
+        return ''.join(args)
     
     def wday(self, args):
         DAYS = {
@@ -446,7 +446,7 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("09:00-12:00/13:00-19:00"), "09:00-12:00,13:00-19:00")
         self.assertEqual(sanitize_field("09 : 00 - 12 : 00 , 13 : 00 - 19 : 00"), "09:00-12:00,13:00-19:00")
         self.assertEqual(sanitize_field("09:00-12:00 /13:00-19:00"), "09:00-12:00,13:00-19:00")
-        self.assertEqual(sanitize_field(u"09:00–12:00"), "09:00-12:00")
+        self.assertEqual(sanitize_field(u"Mo–Fr 09:00–12:00"), "Mo-Fr 09:00-12:00")
         
         # Global
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -251,7 +251,7 @@ class SanitizerTransformer(_lark.Transformer):
         return ','.join(args)
     
     def timespan(self, args):
-        return args[0] + '-' + args[1]
+        return args[0] + '-' + args[2]
     
     def time(self, args):
         return args[0]
@@ -446,6 +446,7 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("09:00-12:00/13:00-19:00"), "09:00-12:00,13:00-19:00")
         self.assertEqual(sanitize_field("09 : 00 - 12 : 00 , 13 : 00 - 19 : 00"), "09:00-12:00,13:00-19:00")
         self.assertEqual(sanitize_field("09:00-12:00 /13:00-19:00"), "09:00-12:00,13:00-19:00")
+        self.assertEqual(sanitize_field(u"09:00–12:00"), "09:00-12:00")
         
         # Global
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -461,6 +461,7 @@ class TestSanitize(_unittest.TestCase):
         self.assertEqual(sanitize_field("2020 mo-fr 1000 - 2000 / 22:20-23:00"), "2020 Mo-Fr 10:00-20:00,22:20-23:00")
         self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
+        self.assertEqual(sanitize_field("lu - je 10h am - 12h / 13h-20h"), "Mo-Th 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("mo-fr 10h am - 2:00 PM ||Sa-Su 1000-2000"), "Mo-Fr 10:00-14:00 || Sa-Su 10:00-20:00")
         self.assertEqual(sanitize_field('mo-fr 10h-20h open "on appointement"'), 'Mo-Fr 10:00-20:00 open "on appointement"')
         self.assertEqual(sanitize_field("sunrise-( sunset+ 01h10)"), "sunrise-(sunset+01:10)")

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -449,6 +449,7 @@ class TestSanitize(_unittest.TestCase):
         # Global
         self.assertEqual(sanitize_field("2010-2020/2 WEEK 1-12/2 mo-fr 10h- 12h am, 1:00 pm - 20:00"), "2010-2020/2 week 1-12/2 Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("2020 mo-fr 1000 - 2000 / 22:20-23:00"), "2020 Mo-Fr 10:00-20:00,22:20-23:00")
+        self.assertEqual(sanitize_field("Monday-friday 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("lundi-vendredi 10h am - 12h / 13h-20h"), "Mo-Fr 10:00-12:00,13:00-20:00")
         self.assertEqual(sanitize_field("mo-fr 10h am - 2:00 PM ||Sa-Su 1000-2000"), "Mo-Fr 10:00-14:00 || Sa-Su 10:00-20:00")
         self.assertEqual(sanitize_field('mo-fr 10h-20h open "on appointement"'), 'Mo-Fr 10:00-20:00 open "on appointement"')

--- a/modules/oh_sanitizer/main.py
+++ b/modules/oh_sanitizer/main.py
@@ -274,21 +274,21 @@ class SanitizerTransformer(_lark.Transformer):
     
     def hour_am_pm(self, args):
         h = args[0].value
-        if args[1] == "PM":
+        if args[1].type == "PM":
             h = str(int(h) + 12)
         return h.zfill(2) + ':00'
 
     def hour_minutes_am_pm(self, args):
         if len(args) == 3:  # "10:00 am" / "10h am"
             h = args[0].value
-            am_pm = args[2].value.upper()
+            am_pm = args[2]
             if args[1].type == "HOUR_MINUTES_H":
                 m = '00'
             else:
                 m = args[1].value
         else:  # "10h00 am"
-            h, m, am_pm = args[0].value, args[2].value, args[3].value.upper()
-        if am_pm == "AM":
+            h, m, am_pm = args[0].value, args[2].value, args[3]
+        if am_pm.type == "AM":
             return h.zfill(2) + ':' + m.zfill(2)
         else:
             return str(int(h)+12).zfill(2) + ':' + m.zfill(2)
@@ -447,8 +447,8 @@ class TestSanitize(_unittest.TestCase):
         # Time correction
         self.assertEqual(sanitize_field("9:00-12:00"), "09:00-12:00")
         self.assertEqual(sanitize_field("9h-12h"), "09:00-12:00")
-        self.assertEqual(sanitize_field("9:00 am - 12:00 am"), "09:00-12:00")
-        self.assertEqual(sanitize_field("9 am - 12 am"), "09:00-12:00")
+        self.assertEqual(sanitize_field("9:00 am - 12:00 a.m."), "09:00-12:00")
+        self.assertEqual(sanitize_field("9 pm - 10 p.m."), "21:00-22:00")
         
         # Timespan correction
         self.assertEqual(sanitize_field("09:00-12:00/13:00-19:00"), "09:00-12:00,13:00-19:00")


### PR DESCRIPTION
This patchset fixes the unit tests, existing functionality, and provides some extensions so Osmose can more often suggest fixes.
Importantly it adds support for time spans with no end time or an open-ended end time (+) as per the opening_hours specification. This should reduce the number of errors (false positives actually) quite significantly (I'd guess at least 30%).
