### PR TITLE
Remove material from simple value tag

### DIFF
--- a/plugins/TagFix_MultipleValue.py
+++ b/plugins/TagFix_MultipleValue.py
@@ -44,10 +44,10 @@ WHERE
     NOT key LIKE 'CLC:%' AND
     NOT key LIKE 'seamark:%' AND
     key NOT IN (
-    -- Accept multiple vaues
-    'opening_hours', 'description', 'bus_routes', 'phone', 'created_by', 'comment', 'day_off', 'day_on', 'destination', 'fixme', 'FIXME', 'access', 'is_in', 'alt_name', 'boundary', 'fee', 'id', 'marked_trail', 'sport', 'shop', 'school:FR', 'hour_off', 'hour_on', 'old_name', 'operator', 'park_ride', 'antenna', 'brewery', 'collection_times', 'cuisine', 'exit_to', 'towards', 'traffic_sign', 'url', 'brand', 'service',
+    -- Accept multiple values
+    'opening_hours', 'description', 'bus_routes', 'phone', 'created_by', 'comment', 'day_off', 'day_on', 'destination', 'fixme', 'FIXME', 'access', 'is_in', 'alt_name', 'boundary', 'fee', 'id', 'marked_trail', 'sport', 'shop', 'school:FR', 'hour_off', 'hour_on', 'old_name', 'operator', 'park_ride', 'antenna', 'brewery', 'collection_times', 'cuisine', 'exit_to', 'towards', 'traffic_sign', 'url', 'brand', 'service', 'material',
     -- No multiple value
-    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name','maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'material', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
+    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name','maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
     value LIKE '%;%'
 ;
 """
@@ -70,7 +70,7 @@ class TagFix_MultipleValue(Plugin):
                     'landuse', 'lanes', 'layer',
                     'left:city', 'left:country', 'left:departement', 'left:village',
                     'leisure',
-                    'material', 'maxspeed', 'motorcar', 'mtb:scale',
+                    'maxspeed', 'motorcar', 'mtb:scale',
                     'name', 'natural',
                     'oneway',
                     'power',


### PR DESCRIPTION
Material can contain multiple values, for instance when using key bicycle_parking