### PR TITLE
Name_UpperCase: Add whitelist of some names

### DIFF
--- a/plugins/Name_UpperCase.py
+++ b/plugins/Name_UpperCase.py
@@ -22,6 +22,10 @@
 from plugins.Plugin import Plugin
 import regex as re
 
+# Whitelist of allowed capitals by country code
+UpperCase_WhiteList = {
+    "FR": ["CNFPT", "COSEC", "EHPAD", "MACIF", "MEDEF", "URSSAF"]
+}
 
 class Name_UpperCase(Plugin):
 
@@ -32,11 +36,21 @@ class Name_UpperCase(Plugin):
         self.errors[803] = { "item": 5010, "level": 1, "tag": ["name", "fix:chair"], "desc": T_(u"Name with uppercase") }
         self.UpperTitleCase = re.compile(u".*[\p{Lu}\p{Lt}]{5,}")
         self.RomanNumber = re.compile(u".*[IVXCDLM]{5,}")
+        country = self.father.config.options.get("country")[:2]
+        self.whitelist = UpperCase_WhiteList.get(country, None)
 
     def node(self, data, tags):
         err = []
-        if u"name" in tags and self.UpperTitleCase.match(tags[u"name"]) and not self.RomanNumber.match(tags[u"name"]):
-            err.append({"class": 803})
+        if u"name" in tags:
+            # first check if the name *might* match
+            if self.UpperTitleCase.match(tags[u"name"]) and not self.RomanNumber.match(tags[u"name"]):
+                if self.whitelist is None:
+                    err.append({"class": 803, "text":{"en":tags[u"name"]}})
+                else:
+                    # Check if we match the whitelist and if so re-try
+                    name = " ".join(i for i in tags[u"name"].split() if not i in self.whitelist)
+                    if self.UpperTitleCase.match(name) and not self.RomanNumber.match(name):
+                        err.append({"class": 803, "text":{"en":tags[u"name"]}})
         return err
 
     def way(self, data, tags, nds):
@@ -49,14 +63,21 @@ from plugins.Plugin import TestPluginCommon
 class Test(TestPluginCommon):
     def test(self):
         a = Name_UpperCase(None)
+        class _config:
+            options = {"country": "FR"}
+        class father:
+            config = _config()
+        a.father = father()
         a.init(None)
         for t in [{u"name": u"COL TRÈS HAUTTT"},
+                  {u"name": u"EHPAD MAGEUSCULE"},
                   {u"name": u"AÇǱÞΣSSὩΙST"},
                  ]:
             self.check_err(a.node(None, t), t)
             self.check_err(a.way(None, t, None), t)
 
         for t in [{u"name": u"Col des Champs XIIVVVIM"},
+                  {u"name": u"EHPAD La Madelon"},
                   {u"name": u"ƻאᎯᚦ京"},
                  ]:
             assert not a.node(None, t), t


### PR DESCRIPTION
Some names are meant to be in uppercase. Instead of complaining,
just whitelist them per country.