### PR TITLE
configure 1G /dev/shmem size for postgresql

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.3'
 
 services:
   postgis:
+    shm_size: 1g
     image: mdillon/postgis:11-alpine
     volumes:
       - type: bind


### PR DESCRIPTION
Default docker limit of 64M is too small and PostgreSQL faces out of memory errors when executing large queries. Increasing limit to 1G to have enough headroom for PostgreSQL.