### PR TITLE
Add plugin for checking interval:conditional tag

### DIFF
--- a/plugins/TagFix_IntervalConditional.py
+++ b/plugins/TagFix_IntervalConditional.py
@@ -25,31 +25,31 @@ class TagFix_IntervalConditional(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
-        self.errors[32502] = { "item": 3250, "level": 3, "tag": ["value", "fix:chair", "public_transport"], "desc": T_(u"Invalid Conditional Intervals") }
+        self.errors[32502] = { 'item': 3250, 'level': 3, 'tag': ['value', 'fix:chair', 'public_transport'], 'desc': T_(u'Invalid Conditional Intervals') }
         self._th = Main()
 
     def check_tags(self, tags):
-        if "interval" not in tags and "interval:conditional" not in tags:
+        if 'interval' not in tags and 'interval:conditional' not in tags:
             return
 
         # Analyse all tags related to transport hours (interval, interval:conditional, opening_hours)
         parsedData = self._th.tagsToHoursObject(tags)
 
         # Check validity of interval tag
-        if parsedData["defaultInterval"] == "invalid":
-            return { "class": 32502, "subclass": 1, "text": T_(u"Invalid interval tag format") }
+        if parsedData['defaultInterval'] == 'invalid':
+            return { 'class': 32502, 'subclass': 1, 'text': T_(u'Invalid interval tag format') }
 
         # Check validity of interval:conditional tag
-        if parsedData["otherIntervals"] == "invalid":
-            return { "class": 32502, "subclass": 2, "text": T_(u"Conditional intervals tag is not valid") }
+        if parsedData['otherIntervals'] == 'invalid':
+            return { 'class': 32502, 'subclass': 2, 'text': T_(u'Conditional intervals tag is not valid') }
 
         # Check presence of interval tag if interval:conditional is defined
-        if type(parsedData["otherIntervals"]) is list and parsedData["defaultInterval"] == "unset":
-            return { "class": 32502, "subclass": 3, "text": T_(u"An interval:conditional tag is defined without a default interval tag") }
+        if type(parsedData['otherIntervals']) is list and parsedData['defaultInterval'] == 'unset':
+            return { 'class': 32502, 'subclass': 3, 'text': T_(u'An interval:conditional tag is defined without a default interval tag') }
 
         # Check combination of opening_hours, interval and interval:conditional
-        if "opening_hours" in tags and type(parsedData["opens"]) is dict and parsedData["allComputedIntervals"] == "invalid":
-            return { "class": 32502, "subclass": 4, "text": T_(u"Conditional intervals does not fit into opening hours") }
+        if 'opening_hours' in tags and type(parsedData['opens']) is dict and parsedData['allComputedIntervals'] == 'invalid':
+            return { 'class': 32502, 'subclass': 4, 'text': T_(u'Conditional intervals does not fit into opening hours') }
 
 
     def relation(self, data, tags, members):
@@ -64,11 +64,11 @@ class Test(TestPluginCommon):
         a = TagFix_IntervalConditional(None)
         a.init(None)
 
-        self.check_err(a.relation(None, {"interval": "not minutes"}, None))# Invalid interval=*
-        self.check_err(a.relation(None, {"interval": "01:30", "interval:conditional": "Invalid conditional"}, None)) # Invalid interval:conditional=*
-        self.check_err(a.relation(None, {"interval:conditional": "15 @ (Mo-Sa 10:00-18:00)"}, None)) # interval:conditional without interval
-        self.check_err(a.relation(None, {"opening_hours": "Mo-Fr 05:00-23:00", "interval": "15", "interval:conditional": "5 @ (Mo-Sa 12:00-15:00)"}, None)) # interval:conditional don"t fit in opening_hours
+        self.check_err(a.relation(None, {'interval': 'not minutes'}, None))
+        self.check_err(a.relation(None, {'interval': '01:30', 'interval:conditional': 'Invalid conditional'}, None))
+        self.check_err(a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 10:00-18:00)'}, None))
+        self.check_err(a.relation(None, {'opening_hours': 'Mo-Fr 05:00-23:00', 'interval': '15', 'interval:conditional': '5 @ (Mo-Sa 12:00-15:00)'}, None))
 
-        assert not a.relation(None, {"interval": "00:10"}, None)
-        assert not a.relation(None, {"interval": "00:10", "interval:conditional": "15 @ (Mo-Sa 15:00-17:00)"}, None)
-        assert not a.relation(None, {"opening_hours": "Mo-Su 05:00-23:00", "interval": "00:10", "interval:conditional": "15 @ (Mo-Sa 15:00-17:00)"}, None)
+        assert not a.relation(None, {'interval': '00:10'}, None)
+        assert not a.relation(None, {'interval': '00:10', 'interval:conditional': '15 @ (Mo-Sa 15:00-17:00)'}, None)
+        assert not a.relation(None, {'opening_hours': 'Mo-Su 05:00-23:00', 'interval': '00:10', 'interval:conditional': '15 @ (Mo-Sa 15:00-17:00)'}, None)

--- a/plugins/TagFix_IntervalConditional.py
+++ b/plugins/TagFix_IntervalConditional.py
@@ -43,13 +43,9 @@ class TagFix_IntervalConditional(Plugin):
         if parsedData['otherIntervals'] == 'invalid':
             return { 'class': 32502, 'subclass': 2, 'text': T_(u'Conditional intervals tag is not valid') }
 
-        # Check presence of interval tag if interval:conditional is defined
-        if type(parsedData['otherIntervals']) is list and parsedData['defaultInterval'] == 'unset':
-            return { 'class': 32502, 'subclass': 3, 'text': T_(u'An interval:conditional tag is defined without a default interval tag') }
-
         # Check combination of opening_hours, interval and interval:conditional
         if 'opening_hours' in tags and type(parsedData['opens']) is dict and parsedData['allComputedIntervals'] == 'invalid':
-            return { 'class': 32502, 'subclass': 4, 'text': T_(u'Conditional intervals does not fit into opening hours') }
+            return { 'class': 32502, 'subclass': 3, 'text': T_(u'Conditional intervals does not fit into opening hours') }
 
 
     def relation(self, data, tags, members):

--- a/plugins/TagFix_IntervalConditional.py
+++ b/plugins/TagFix_IntervalConditional.py
@@ -25,7 +25,7 @@ class TagFix_IntervalConditional(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
-        self.errors[32502] = { "item": 3250, "level": 3, "tag": ["value", "fix:chair"], "desc": T_(u"Invalid Conditional Intervals") }
+        self.errors[32502] = { "item": 3250, "level": 3, "tag": ["value", "fix:chair", "public_transport"], "desc": T_(u"Invalid Conditional Intervals") }
         self._th = Main()
 
     def check_tags(self, tags):

--- a/plugins/TagFix_IntervalConditional.py
+++ b/plugins/TagFix_IntervalConditional.py
@@ -62,7 +62,6 @@ class Test(TestPluginCommon):
 
         self.check_err(a.relation(None, {'interval': 'not minutes'}, None))
         self.check_err(a.relation(None, {'interval': '01:30', 'interval:conditional': 'Invalid conditional'}, None))
-        self.check_err(a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 10:00-18:00)'}, None))
         self.check_err(a.relation(None, {'opening_hours': 'Mo-Fr 05:00-23:00', 'interval': '15', 'interval:conditional': '5 @ (Mo-Sa 12:00-15:00)'}, None))
 
         assert not a.relation(None, {'interval': '00:10'}, None)

--- a/plugins/TagFix_IntervalConditional.py
+++ b/plugins/TagFix_IntervalConditional.py
@@ -1,0 +1,77 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyright Adrien Pavie 2019                                           ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+from plugins.Plugin import Plugin
+
+try:
+    from transporthours.main import Main
+    module_transporthours = True
+except ImportError as e:
+    print(e)
+    module_transporthours = False
+
+class TagFix_IntervalConditional(Plugin):
+
+    def init(self, logger):
+        if not module_transporthours:
+            return False
+        Plugin.init(self, logger)
+        self.errors[32502] = {"item": 3250, "level": 3, "tag": ["value", "fix:chair"], "desc": T_(u"Invalid Conditional Intervals")}
+
+    def check_tags(self, tags):
+        if 'interval:conditional' not in tags:
+            return
+
+        th = Main()
+
+        # Check interval:conditional by itself
+        try:
+            interval_cond_obj = th.intervalConditionalStringToObject(tags['interval:conditional'])
+        except Exception as e:
+            return {"class": 32502, "subclass": 1, 'text': {'en': str(e)}}
+
+        # Check combination of interval:conditional + opening_hours
+        if 'opening_hours' in tags:
+            parsedData = th.tagsToHoursObject(tags)
+            if parsedData['allComputedIntervals'] == 'invalid':
+                return {"class": 32502, "subclass": 2, 'text': {'en': "Conditional interval definition doesn't fit in opening hours"}}
+
+
+    def relation(self, data, tags, members):
+        return self.check_tags(tags)
+
+
+###########################################################################
+from plugins.Plugin import TestPluginCommon
+
+class Test(TestPluginCommon):
+    def test(self):
+        a = TagFix_IntervalConditional(None)
+        a.init(None)
+
+        self.check_err(a.relation(None, {'interval:conditional': 'Mo-Sa 15:00-17:00'}, None))
+        self.check_err(a.relation(None, {'interval:conditional': 'BLA @ (Mo-Sa 15:00-17:00)'}, None))
+        self.check_err(a.relation(None, {'interval:conditional': '00:15 @ (Mo-Sa 15:00-17:00); OUPS'}, None))
+        self.check_err(a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 15:00-17:00)', 'opening_hours': 'Mo-Sa 16:30-18:30'}, None))
+
+        assert not a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 15:00-17:00)'}, None)
+        assert not a.relation(None, {'interval:conditional': '00:15 @ Mo-Sa 15:00-17:00'}, None)
+        assert not a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 15:00-17:00); 20 @ (Su 20:00-03:00)'}, None)
+        assert not a.relation(None, {'interval:conditional': '15 @ (Mo-Sa 15:00-17:00)', 'opening_hours': 'Mo-Sa 05:00-22:00'}, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ regex
 lark-parser >=  0.6, < 0.7
 requests
 backports.csv
+transporthours


### PR DESCRIPTION
Created a plugin to check `interval:conditional` tag using [transport-hours-py](https://github.com/Jungle-Bus/transport-hours-py) library :
- Syntax of tag should be correct regarding wiki doc
- Defined hour ranges should fit inside `opening_hours` ones if existing

This is mainly used on public transport routes, and this analyze will be useful for Jungle Bus team @nlehuby 

By the way, thanks for working on Docker README, this is really helpful and comprehensive :+1: 