### PR TITLE
remove dead code

### DIFF
--- a/plugins/Name_Dictionary.py
+++ b/plugins/Name_Dictionary.py
@@ -131,13 +131,10 @@ class P_Name_Dictionary(Plugin):
                 else:
                     raise Exception("Could not find correction for %s" % WordComplet)
             else:
-                PbEncodage = False
                 for x in self.DictEncoding:
                     if x in WordComplet:
-                        PbEncodage = True
                         return {"class": 704, "subclass": stablehash(tag), "fix": {"name": initialName.replace(x, self.DictEncoding[x])}}
 
-                if PbEncodage: continue
                 #if WordComplet in self.DictUnknownWords: continue
                 if "0" in WordComplet: continue
                 if "1" in WordComplet: continue


### PR DESCRIPTION
in 563a71768 you changed the code to return on the first match.
This leaves dead code which this change removes to keep the source readable.