### PR TITLE
init base class in constructor

### DIFF
--- a/analysers/Analyser_Merge_Geocode_Addok_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_Addok_CSV.py
@@ -28,6 +28,7 @@ from .modules import downloader
 class Geocode_Addok_CSV(Source):
 
     def __init__(self, source, columns, logger, citycode = None, delimiter = ',', encoding = 'utf-8'):
+        Source.__init__(self)
         self.source = source
         self.columns = columns
         self.citycode = citycode


### PR DESCRIPTION
I think the base class should also be initialized from the constructor.  As Geocode_Addok_CSV is not accepting keyword arguments for base, calling init with default arguments.