### PR TITLE
remove unreachable code

### DIFF
--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -392,8 +392,6 @@ class OsmOsisManager:
 
       raise
 
-    shutil.rmtree(dir_country_tmp, ignore_errors=True)
-
   def check_change(self, conf):
     if not self.check_diff(conf):
       return False


### PR DESCRIPTION
rmtree is never executed here, as either try-block returns in all possible code-paths or an exception is re-raised.
With the rmtree called always on entry of the function it sounds ok, not to call it.