### PR TITLE
function overloading not possible in Python

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -461,6 +461,8 @@ def regexp_match(regexp, string):
 #regexp_match(regexp, string, flags)
 #    Tries to match string against pattern regexp. Returns a list of capture groups in case of success. The first element (index 0) is the complete match (i.e. string). Further elements correspond to the bracketed parts of the regular expression. Flags is a string that may contain "i" (case insensitive), "m" (multiline) and "s" ("dot all") [since 5701] 
 
+#substring(str, idx)	
+#    return the substring of str, starting at index idx (0-indexed) [since 6534] 
 #substring(str, start, end)
 #    return the substring of str, starting at index start (inclusive) up to end (exclusive) (0-indexed) [since 6534] 
 def substring(string, start, end=None):

--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -461,16 +461,10 @@ def regexp_match(regexp, string):
 #regexp_match(regexp, string, flags)
 #    Tries to match string against pattern regexp. Returns a list of capture groups in case of success. The first element (index 0) is the complete match (i.e. string). Further elements correspond to the bracketed parts of the regular expression. Flags is a string that may contain "i" (case insensitive), "m" (multiline) and "s" ("dot all") [since 5701] 
 
-#substring(str, idx)
-#    return the substring of str, starting at index idx (0-indexed) [since 6534] 
-def substring(string, idx):
-    if string != None and idx != None:
-        return str_value(string[idx:])
-
 #substring(str, start, end)
 #    return the substring of str, starting at index start (inclusive) up to end (exclusive) (0-indexed) [since 6534] 
-def substring(string, start, end):
-    if string != None and start != None and end != None:
+def substring(string, start, end=None):
+    if string is not None and start is not None:
         return str_value(string[start:end])
 
 #replace(string, old, new)

--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -461,10 +461,10 @@ def regexp_match(regexp, string):
 #regexp_match(regexp, string, flags)
 #    Tries to match string against pattern regexp. Returns a list of capture groups in case of success. The first element (index 0) is the complete match (i.e. string). Further elements correspond to the bracketed parts of the regular expression. Flags is a string that may contain "i" (case insensitive), "m" (multiline) and "s" ("dot all") [since 5701] 
 
-#substring(str, idx)	
-#    return the substring of str, starting at index idx (0-indexed) [since 6534] 
+#substring(str, idx)
+#    return the substring of str, starting at index idx (0-indexed) [since 6534]
 #substring(str, start, end)
-#    return the substring of str, starting at index start (inclusive) up to end (exclusive) (0-indexed) [since 6534] 
+#    return the substring of str, starting at index start (inclusive) up to end (exclusive) (0-indexed) [since 6534]
 def substring(string, start, end=None):
     if string is not None and start is not None:
         return str_value(string[start:end])


### PR DESCRIPTION
It is not possible to have multiple functions sharing the same name and differing in the parameters.

Removed the not working one and provided an implementation using default parameters to provide the intended signature. Slicing with None as the end parameter works the same way as leaving it out.

Also replaces the test by checking for identity instead of equality to speed it up a bit and comply with PEP8.