### PR TITLE
osmosis need integer for maxInterval

### DIFF
--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -297,7 +297,7 @@ class OsmOsisManager:
         elif line.startswith("maxInterval"):
             if "geofabrik" in conf.download["diff"]:
                 # on daily diffs provided by Geofabrik, we should apply only one diff at a time
-                sys.stdout.write("maxInterval=" + str(round(60*60*24/2))) # 1/2 day at most
+                sys.stdout.write("maxInterval=" + str(60*60*24//2)) # 1/2 day at most
             else:
                 sys.stdout.write("maxInterval=" + str(7*60*60*24)) # 7 day at most
         else:

--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -297,7 +297,7 @@ class OsmOsisManager:
         elif line.startswith("maxInterval"):
             if "geofabrik" in conf.download["diff"]:
                 # on daily diffs provided by Geofabrik, we should apply only one diff at a time
-                sys.stdout.write("maxInterval=" + str(60*60*24/2)) # 1/2 day at most
+                sys.stdout.write("maxInterval=" + str(round(60*60*24/2))) # 1/2 day at most
             else:
                 sys.stdout.write("maxInterval=" + str(7*60*60*24)) # 7 day at most
         else:


### PR DESCRIPTION
osmosis need integer for maxInterval for configuration.txt, with python3.6, the current code produces:

maxInterval=43200.0

for geofabrik with diffs, which ends osmosis import via error:
java.lang.NumberFormatException: For input string: "43200.0"