### PR TITLE
fix unexpected trunc to integer

### DIFF
--- a/analysers/Analyser_Merge_Mapillary.py
+++ b/analysers/Analyser_Merge_Mapillary.py
@@ -31,6 +31,7 @@ from modules.PointInPolygon import PointInPolygon
 from modules import SourceVersion
 from modules import downloader
 from datetime import datetime, timedelta
+from math import ceil
 
 
 class Source_Mapillary(Source):
@@ -74,7 +75,7 @@ class Source_Mapillary(Source):
       b = 0
       for traffic_signs_ in slice(traffic_signs, 10):
         b = b + 1
-        self.logger.log('Batch {0}/{1}: {2}'.format(b, round(len(traffic_signs) / 10 + 0.5), ','.join(traffic_signs_)))
+        self.logger.log('Batch {0}/{1}: {2}'.format(b, ceil(len(traffic_signs) / 10.0), ','.join(traffic_signs_)))
         for bbox in bboxes:
           url = 'https://a.mapillary.com/v3/map_features?bbox={bbox}&client_id={client_id}&layers={layer}&per_page=1000&start_time={start_time}&values={values}'.format(bbox=','.join(map(str, bbox)), layer=self.layer, client_id='MEpmMTFQclBTUWlacjV6RTUxWWMtZzo5OTc2NjY2MmRiMDUwYmMw', start_time=start_time, values=','.join(traffic_signs_))
           self.logger.log(url)


### PR DESCRIPTION
worked only because division truncated to integer, so that
19/10 returned 1 instead of 1.9 which then resulted in 1.5 to
pass to round to return the ceiling.

Instead of writing the round with integer division // I use
the ceil function to express clearer what is meant here.