### PR TITLE
Analyser for carpool parkings in France

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -298,7 +298,7 @@ WHERE
 """
 
 class Source:
-    def __init__(self, attribution = None, millesime = None, encoding = "utf-8", file = None, fileUrl = None, fileUrlCache = 30, zip = None, gzip = False, filter = None, universalNewLine = False):
+    def __init__(self, attribution = None, millesime = None, encoding = "utf-8", file = None, fileUrl = None, fileUrlCache = 30, zip = None, gzip = False, filter = None):
         """
         Describe the source file.
         @param encoding: file charset encoding
@@ -308,7 +308,6 @@ class Source:
         @param zip: extract file from zip
         @param gzip: uncompress as gzip
         @param filter: lambda expression applied on text file before loading
-        @param universalNewLine: for text file having new-line character in unquoted field
         """
         self.attribution = attribution
         self.millesime = millesime
@@ -319,7 +318,6 @@ class Source:
         self.zip = zip
         self.gzip = gzip
         self.filter = filter
-        self.universalNewLine = universalNewLine
 
         if self.file:
             if not os.path.isabs(self.file):
@@ -346,11 +344,11 @@ class Source:
             # Do nothing about ZIP
             return downloader.path(self.fileUrl, self.fileUrlCache)
 
-    def open(self):
+    def open(self, mode='rb'):
         if self.file:
             f = bz2.BZ2File(self.file)
         elif self.fileUrl:
-            f = downloader.urlopen(self.fileUrl, self.fileUrlCache, mode=('rU' if self.universalNewLine else 'rb'))
+            f = downloader.urlopen(self.fileUrl, self.fileUrlCache, mode=mode)
             if self.zip:
                 z = zipfile.ZipFile(f, 'r').open(self.zip)
                 f = io.BytesIO(z.read())
@@ -360,7 +358,7 @@ class Source:
                 f = io.BytesIO(d.read())
                 f.seek(0)
 
-        f = io.StringIO(f.read().encode("utf-8").decode(self.encoding) if self.universalNewLine else f.read().decode(self.encoding, 'ignore'))
+        f = io.StringIO(f.read().encode("utf-8").decode(self.encoding) if mode == 'rU' else f.read().decode(self.encoding, 'ignore'))
         f.seek(0)
         if self.filter:
             f = io.StringIO(self.filter(f.read()))
@@ -390,7 +388,7 @@ class Parser:
         pass
 
 class CSV(Parser):
-    def __init__(self, source, separator = u',', null = u'', header = True, quote = u'"', csv = True):
+    def __init__(self, source, separator = u',', null = u'', header = True, quote = u'"', csv = True, universalNewLine = False):
         """
         Describe the CSV file format, mainly for postgres COPY command in order to load data, but also for other thing, like load header.
         Setting param as None disable parameter into the COPY command.
@@ -400,6 +398,7 @@ class CSV(Parser):
         @param header: CSV have header row
         @param quote: one char string delimiter
         @param csv: load file as CSV on COPY command
+        @param universalNewLine: for text file having new-line character in unquoted field
         """
         self.source = source
         self.separator = separator
@@ -407,16 +406,21 @@ class CSV(Parser):
         self.have_header = header
         self.quote = quote
         self.csv = csv
+        self.universalNewLine = universalNewLine
 
         self.f = None
 
+    def _open(self):
+        mode='rU' if self.universalNewLine else 'rb'
+        self.f = self.f or self.source.open(mode=mode)
+
     def header(self):
-        self.f = self.source.open()
+        self._open()
         if self.have_header:
             return csv.reader(self.f, delimiter=self.separator, quotechar=self.quote).next()
 
     def import_(self, table, srid, osmosis):
-        self.f = self.f or self.source.open()
+        self._open()
         copy = "COPY %s FROM STDIN WITH %s %s %s %s %s" % (
             table,
             ("DELIMITER AS '%s'" % self.separator) if self.separator != None else "",

--- a/analysers/analyser_merge_carpool_FR.py
+++ b/analysers/analyser_merge_carpool_FR.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Adrien PAVIE 2019                                          ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge import Analyser_Merge, Source, CSV, Load, Mapping, Select, Generate
+
+
+class Analyser_Merge_Carpool_FR(Analyser_Merge):
+    def __init__(self, config, logger = None):
+        self.missing_official = {"item":"8130", "class": 31, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking not integrated") }
+        self.possible_merge   = {"item":"8131", "class": 33, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking integration suggestion") }
+        self.update_official  = {"item":"8132", "class": 34, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking update") }
+        Analyser_Merge.__init__(self, config, logger,
+            u"https://www.data.gouv.fr/fr/datasets/base-nationale-consolidee-des-lieux-de-covoiturage",
+            u"Base nationale consolidée des lieux de covoiturage",
+            CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019",
+                    fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d"), separator = u";"),
+            Load("Xlong", "Ylat",
+                select = {
+                    "ouvert": u"true"}),
+            Mapping(
+                select = Select(
+                    types = ["nodes", "ways"],
+                    tags = [{"amenity": "parking", "carpool": "yes"}, {"amenity":"car_pooling"}, {"amenity":"parking", "carpool":"designated"}]),
+                osmRef = "ref:FR:BNCLC",
+                conflationDistance = 300,
+                generate = Generate(
+                    static1 = {"amenity": "parking", "carpool": "designated"},
+                    static2 = {"source": self.source},
+                    mapping1 = {
+                        "ref:FR:BNCLC": "id_lieu",
+                        "name": "nom_lieu",
+                        "capacity": "nbre_pl",
+                        "capacity:disabled": "nbre_pmr",
+                        "lit": lambda res: "yes" if res["lumiere"] == "true" else ("no" if res["lumiere"] == false else None)},
+                    text = lambda tags, fields: {"en": u"Carpool parking %s" % fields[u"nom_lieu"]} )))

--- a/analysers/analyser_merge_carpool_FR.py
+++ b/analysers/analyser_merge_carpool_FR.py
@@ -31,8 +31,8 @@ class Analyser_Merge_Carpool_FR(Analyser_Merge):
         Analyser_Merge.__init__(self, config, logger,
             u"https://www.data.gouv.fr/fr/datasets/base-nationale-consolidee-des-lieux-de-covoiturage",
             u"Base nationale consolidée des lieux de covoiturage",
-            CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019", encoding = "utf-8-sig", universalNewLine = True,
-                    fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d"), separator = u";"),
+            CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019", encoding = "utf-8-sig",
+                    fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d"), separator = u";", universalNewLine = True),
             Load("Xlong", "Ylat",
                 select = {
                     "ouvert": u"true"}),

--- a/analysers/analyser_merge_carpool_FR.py
+++ b/analysers/analyser_merge_carpool_FR.py
@@ -25,13 +25,13 @@ from .Analyser_Merge import Analyser_Merge, Source, CSV, Load, Mapping, Select, 
 
 class Analyser_Merge_Carpool_FR(Analyser_Merge):
     def __init__(self, config, logger = None):
-        self.missing_official = {"item":"8130", "class": 31, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking not integrated") }
-        self.possible_merge   = {"item":"8131", "class": 33, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking integration suggestion") }
-        self.update_official  = {"item":"8132", "class": 34, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking update") }
+        self.missing_official = {"item":"8130", "class": 41, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking not integrated") }
+        self.possible_merge   = {"item":"8131", "class": 43, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking integration suggestion") }
+        self.update_official  = {"item":"8132", "class": 44, "level": 3, "tag": ["merge", "parking", "carpool"], "desc": T_(u"Carpool parking update") }
         Analyser_Merge.__init__(self, config, logger,
             u"https://www.data.gouv.fr/fr/datasets/base-nationale-consolidee-des-lieux-de-covoiturage",
             u"Base nationale consolidée des lieux de covoiturage",
-            CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019",
+            CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019", encoding = "utf-8-sig", universalNewLine = True,
                     fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d"), separator = u";"),
             Load("Xlong", "Ylat",
                 select = {
@@ -50,5 +50,5 @@ class Analyser_Merge_Carpool_FR(Analyser_Merge):
                         "name": "nom_lieu",
                         "capacity": "nbre_pl",
                         "capacity:disabled": "nbre_pmr",
-                        "lit": lambda res: "yes" if res["lumiere"] == "true" else ("no" if res["lumiere"] == false else None)},
-                    text = lambda tags, fields: {"en": u"Carpool parking %s" % fields[u"nom_lieu"]} )))
+                        "lit": lambda res: "yes" if res["lumiere"] == "true" else ("no" if res["lumiere"] == "false" else None)},
+                    text = lambda tags, fields: T_f(u"Carpool parking {0}", fields[u"nom_lieu"]) )))

--- a/analysers/analyser_merge_carpool_FR.py
+++ b/analysers/analyser_merge_carpool_FR.py
@@ -32,7 +32,8 @@ class Analyser_Merge_Carpool_FR(Analyser_Merge):
             u"https://www.data.gouv.fr/fr/datasets/base-nationale-consolidee-des-lieux-de-covoiturage",
             u"Base nationale consolidée des lieux de covoiturage",
             CSV(Source(attribution = u"Transport.data.gouv.fr", millesime = "09/2019", encoding = "utf-8-sig",
-                    fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d"), separator = u";", universalNewLine = True),
+                    fileUrl = u"https://www.data.gouv.fr/fr/datasets/r/e0962ca4-2fb9-4257-a569-56704df3243d",
+                    filter = lambda text: text.replace('\r', '\n')), separator = u";"),
             Load("Xlong", "Ylat",
                 select = {
                     "ouvert": u"true"}),


### PR DESCRIPTION
Hello,

I would like to add this analyser, which enable conflation with unified carpool parking dataset ([BNCLC](https://www.data.gouv.fr/fr/datasets/base-nationale-consolidee-des-lieux-de-covoiturage/)). Everything might be set correctly, but I still run into an issue when launching code on Docker :

```
2019-10-09 14:48:17   error: error on analyse merge_carpool_FR...
2019-10-09 14:48:17     Traceback (most recent call last):
2019-10-09 14:48:17       File "./osmose_run.py", line 230, in execc
2019-10-09 14:48:17         analyser_obj.analyser()
2019-10-09 14:48:17       File "/opt/osmose-backend/analysers/Analyser_Osmosis.py", line 192, in analyser
2019-10-09 14:48:17         self.analyser_osmosis_common()
2019-10-09 14:48:17       File "/opt/osmose-backend/analysers/Analyser_Merge.py", line 867, in analyser_osmosis_common
2019-10-09 14:48:17         table = self.load.run(self, self.parser, self.mapping, self.config.db_user, self.__class__.__name__.lower()[15:], self.analyser_version())
2019-10-09 14:48:17       File "/opt/osmose-backend/analysers/Analyser_Merge.py", line 631, in run
2019-10-09 14:48:17         header = parser.header()
2019-10-09 14:48:17       File "/opt/osmose-backend/analysers/Analyser_Merge.py", line 413, in header
2019-10-09 14:48:17         return csv.reader(self.f, delimiter=self.separator, quotechar=self.quote).next()
2019-10-09 14:48:17       File "/usr/local/lib/python3.7/site-packages/backports/csv.py", line 415, in __next__
2019-10-09 14:48:17         self.parse_process_char(c)
2019-10-09 14:48:17       File "/usr/local/lib/python3.7/site-packages/backports/csv.py", line 269, in parse_process_char
2019-10-09 14:48:17         return switch[self.state](c)
2019-10-09 14:48:17       File "/usr/local/lib/python3.7/site-packages/backports/csv.py", line 382, in _parse_eat_crnl
2019-10-09 14:48:17         raise Error('new-line character seen in unquoted field - do you '
2019-10-09 14:48:17     _csv.Error: new-line character seen in unquoted field - do you need to open the file in universal-newline mode?
```

It might be related to the input file having some line return in it in quoted fields, but I don't know if any option is existing in Osmose to handle this properly.

Regards,

Adrien.