### PR TITLE
Ajout item 8400

### DIFF
--- a/merge_data/healthcare_FR_finess.mapping.json
+++ b/merge_data/healthcare_FR_finess.mapping.json
@@ -35,7 +35,7 @@
       "2206"
     ],
     "items": [
-      8330
+      8400
     ],
     "missing_osm": false,
     "classes": 20,


### PR DESCRIPTION
Séparation des Établissements hospitaliers et Établissements de soins autres que les hôpitaux, afin d'isoler sur Osmose les grosses structures.
https://github.com/osm-fr/osmose-backend/issues/666#issuecomment-544594811