### PR TITLE
Let FANTOIR B to W type also include islet

### DIFF
--- a/plugins/TagFix_MultipleTag_FR.py
+++ b/plugins/TagFix_MultipleTag_FR.py
@@ -73,8 +73,8 @@ class TagFix_MultipleTag_FR(Plugin):
                     err.append({"class": 206013, "subclass": 1, "text": T_(u"FANTOIR numeric type is for ways")})
             #elif fantoir_key == "A":
             elif fantoir_key >= "B" and fantoir_key <= "W":
-                if tags.get("place") not in ("locality", "hamlet", "isolated_dwelling", "neighbourhood") and tags.get("railway") != "station" and tags.get("leisure") not in ("park", "garden"):
-                    err.append({"class": 206013, "subclass": 1, "text": T_(u"FANTOIR B to W type is for locality, hamlet, isolated_dwelling or neighbourhood")})
+                if tags.get("place") not in ("locality", "hamlet", "isolated_dwelling", "neighbourhood", "islet") and tags.get("railway") != "station" and tags.get("leisure") not in ("park", "garden"):
+                    err.append({"class": 206013, "subclass": 1, "text": T_(u"FANTOIR B to W type is for locality, hamlet, isolated_dwelling, islet or neighbourhood")})
 
         return err
 


### PR DESCRIPTION
I was seeing these three reported problems:

http://osmose.openstreetmap.fr/en/map/#item=2060&zoom=17&lat=45.703616&lon=-0.329429&level=3&tags=&fixable=

So "FANTOIR B to W type is for locality, hamlet, isolated_dwelling or neighbourhood"

While I do not understand the "FANTOIR B to W type" an islet is also an isolated_dwelling (https://wiki.openstreetmap.org/wiki/Tag:place%3Dislet) so it seems like a good idea to me to include islet also in the list.