### PR TITLE
Add check for bicycle=no|use_sidepath in combination with cycleway=

### DIFF
--- a/plugins/Bicycle.validator.mapcss
+++ b/plugins/Bicycle.validator.mapcss
@@ -74,6 +74,22 @@ way[highway=cycleway][cycleway=track] {
     fixRemove: "cycleway";
 }
 
+way[bicycle=~/no|use_sidepath/][cycleway][cycleway!~/no|none|separate/],
+way[bicycle=~/no|use_sidepath/][cycleway:left][cycleway:left!~/no|none|separate/],
+way[bicycle=~/no|use_sidepath/][cycleway:right][cycleway:right!~/no|none|separate/]
+{
+    throwWarning: tr("{0} with {1}", "{0.tag}", "{1.tag}");
+    -osmoseItemClassLevel: "3032/30329/2";
+    -osmoseTags: list("fix:chair");
+
+    assertMatch: "way bicycle=no cycleway=track";
+    assertMatch: "way bicycle=use_sidepath cycleway:left=lane";
+    assertNoMatch: "way bicycle=no cycleway:right=no";
+    assertNoMatch: "way bicycle=use_sidepath cycleway:left=none";
+    assertNoMatch: "way highway=cycleway cycleway=separate";
+    assertNoMatch: "way highway=residential bicycle=use_sidepath";
+}
+
 way[cycleway=~/opposite|opposite_lane/][!oneway],
 way[cycleway=~/opposite|opposite_lane/][oneway=no] {
     throwError: tr("Opposite cycleway without oneway");


### PR DESCRIPTION
Far from sure this is the correct way to add a new test and if the code is correct but I would like to add a check for bicycle=no|use_sidepath in combination with cycleway=, I think the code is reasonable clear on what is it is meant to do.

See https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath on the why:

_Please do not use bicycle=use_sidepath in combination with cycleway=track on the main highway, if there is no separate cycleway drawn on the map. This is confusing for routing engines because bicycle=use_sidepath indicates not to route on the main highway (use the separate cycleway) and this conflicts with the tag cycleway=track, which indicates that bicycles are allowed to route on (bike lanes connected to) the main highway._

The allowed values for cycleway= are based on https://taginfo.openstreetmap.org/keys/cycleway#values

Questions I have:
- Good idea?
- Good to re-use error class 30328, I see that now reporting only "highway=cycleway with cycleway=track", http://osmose.openstreetmap.fr/en/errors/?item=3032&class=30328
- I see there is also a plugins/Bicycle.validator.mapcss file should that also be updated?