### PR TITLE
catch matching exception instead of base class

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -43,7 +43,7 @@ from modules import SourceVersion
 
 try:
     from pyproj import Transformer
-except:
+except ImportError:
     # No available in py2
     Transformer = None
 


### PR DESCRIPTION
as we are expecting an ImportError in py2, handle it.
fixes a warning of https://lgtm.com/rules/6780080/
