### PR TITLE
[WIP] Add end user documentation into analysers

### DIFF
--- a/analysers/Analyser.py
+++ b/analysers/Analyser.py
@@ -25,6 +25,8 @@ except ImportError:
     import __builtin__ as builtins
 
 import hashlib
+import os
+from inspect import getframeinfo, stack
 from modules import OsmoseErrorFile
 from modules import OsmoseTranslation
 from modules import SourceVersion
@@ -62,6 +64,22 @@ class Analyser(object):
 
     def timestamp(self):
         return None
+
+    def def_class(self, **kwargs):
+        # Check keys
+        diff_keys = set(kwargs.keys()) - set(['item', 'id', 'level', 'tags', 'title', 'detail', 'fix', 'trap', 'example', 'source', 'ressource'])
+        if len(diff_keys) > 0:
+            raise Exception('Unknow key ' + ', '.join(diff_keys))
+
+        if 'source' not in kwargs:
+            caller = getframeinfo(stack()[1][0])
+            kwargs['source'] = '{0}/analysers/{1}#L{2}'.format(self.config.source_url, os.path.basename(caller.filename), caller.lineno)
+
+        return kwargs
+
+    def merge_doc(self, *docs):
+        langs = set(sum(map(lambda d: list(d.keys()), docs), []))
+        return dict(map(lambda l: [l, '\n'.join(map(lambda d: d.get(l, d.get('en')), docs))], langs))
 
     def open_error_file(self):
         if self.config.dst:

--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -836,25 +836,28 @@ class Analyser_Merge(Analyser_Osmosis):
         self.mapping = mapping
 
         if hasattr(self, 'missing_official'):
-            self.classs[self.missing_official["class"]] = self.missing_official
+            self.classs[self.missing_official.get('id', self.missing_official.get('class'))] = self.missing_official
         else:
             self.missing_official = None
         if hasattr(self, 'missing_osm'):
-            self.classs[self.missing_osm["class"]] = self.missing_osm
+            self.classs[self.missing_osm.get('id', self.missing_osm.get('class'))] = self.missing_osm
         else:
             self.missing_osm = None
         if hasattr(self, 'possible_merge'):
-            self.classs[self.possible_merge["class"]] = self.possible_merge
+            self.classs[self.possible_merge.get('id', self.possible_merge.get('class'))] = self.possible_merge
         else:
             self.possible_merge = None
         if hasattr(self, 'moved_official'):
-            self.classs[self.moved_official["class"]] = self.moved_official
+            self.classs[self.moved_official.get('id', self.moved_official.get('class'))] = self.moved_official
         else:
             self.moved_official = None
         if hasattr(self, 'update_official'):
-            self.classs[self.update_official["class"]] = self.update_official
+            self.classs[self.update_official.get('id', self.update_official.get('class'))] = self.update_official
         else:
             self.update_official = None
+
+        for (id, c) in self.classs.items():
+            c['resource'] = url
 
         if not isinstance(self.mapping.select.tags, list):
             self.mapping.select.tags = [self.mapping.select.tags]
@@ -941,7 +944,7 @@ class Analyser_Merge(Analyser_Osmosis):
         self.run(sql11)
         if self.missing_official:
             self.run(sql12, lambda res: {
-                "class": self.missing_official["class"],
+                "class": self.missing_official.get('id', self.missing_official.get('class')),
                 "subclass": str(stablehash64("%s%s%s"%(res[0],res[1],res[3]))),
                 "self": lambda r: [0]+r[1:],
                 "data": [self.node_new, self.positionAsText],
@@ -960,7 +963,7 @@ class Analyser_Merge(Analyser_Osmosis):
                 } )
                 # Invalid OSM
                 self.run(sql23 % {"official": table, "joinClause": joinClause}, lambda res: {
-                    "class": self.missing_osm["class"],
+                    "class": self.missing_osm.get('id', self.missing_osm.get('class')),
                     "subclass": str(stablehash64(res[5])) if self.mapping.osmRef != "NULL" else None,
                     "data": [self.typeMapping[res[1]], None, self.positionAsText]
                 } )
@@ -976,7 +979,7 @@ class Analyser_Merge(Analyser_Osmosis):
                     possible_merge_joinClause.append("missing_official.tags->'%(tag)s' = missing_osm.tags->'%(tag)s'" % {"tag": self.mapping.extraJoin})
                 possible_merge_joinClause = " AND\n".join(possible_merge_joinClause) + "\n"
                 self.run(sql30 % {"joinClause": possible_merge_joinClause, "orderBy": possible_merge_orderBy}, lambda res: {
-                    "class": self.possible_merge["class"],
+                    "class": self.possible_merge.get('id', self.possible_merge.get('class')),
                     "subclass": str(stablehash64("%s%s"%(res[0],str(res[3])))),
                     "data": [self.typeMapping[res[1]], None, self.positionAsText],
                     "text": self.mapping.generate.text(defaultdict(lambda:None,res[3]), defaultdict(lambda:None,res[4])),
@@ -1009,14 +1012,14 @@ class Analyser_Merge(Analyser_Osmosis):
         # Moved official
         if self.moved_official:
             self.run(sql50 % {"official": table, "joinClause": joinClause}, lambda res: {
-                "class": self.moved_official["class"],
+                "class": self.moved_official.get('id', self.moved_official.get('class')),
                 "data": [self.node_full, self.positionAsText],
             } )
 
         # Update official
         if self.update_official:
             self.run(sql60 % {"official": table, "joinClause": joinClause}, lambda res: {
-                "class": self.update_official["class"],
+                "class": self.update_official.get('id', self.update_official.get('class')),
                 "subclass": str(stablehash64("%s%s"%(res[0],str(res[5])))),
                 "data": [self.typeMapping[res[1]], None, self.positionAsText],
                 "text": self.mapping.generate.text(defaultdict(lambda:None,res[3]), defaultdict(lambda:None,res[5])),

--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -313,11 +313,18 @@ ANALYZE {0}.buildings;
         for id_ in classs:
             data = classs[id_]
             self.error_file.classs(
-                id_,
-                data["item"],
-                data.get("level"),
-                data.get("tag"),
-                data["desc"])
+                id = id_,
+                item = data['item'],
+                level = data['level'],
+                tags = data.get('tags', data.get('tag')),
+                title = data.get('title', data.get('desc')),
+                detail = data.get('detail'),
+                fix = data.get('fix'),
+                trap = data.get('trap'),
+                example = data.get('example'),
+                source = data.get('source'),
+                resource = data.get('resource'),
+            )
 
 
     def analyser_osmosis_common(self):

--- a/analysers/analyser_merge_heritage_FR_merimee.py
+++ b/analysers/analyser_merge_heritage_FR_merimee.py
@@ -27,10 +27,25 @@ from functools import reduce
 
 class Analyser_Merge_Heritage_FR_Merimee(Analyser_Merge):
     def __init__(self, config, logger = None):
-        self.missing_official = {"item":"8010", "class": 1, "level": 3, "tag": ["merge", "building"], "desc": T_f(u"Historical monument not integrated") }
-        self.missing_osm      = {"item":"7080", "class": 2, "level": 3, "tag": ["merge"], "desc": T_f(u"Historical monument without tag \"ref:mhs\" or invalid") }
-        self.possible_merge   = {"item":"8011", "class": 3, "level": 3, "tag": ["merge"], "desc": T_f(u"Historical monument, integration suggestion") }
-        self.update_official  = {"item":"8012", "class": 4, "level": 3, "tag": ["merge"], "desc": T_f(u"Historical monument update") }
+        self.config = config
+        doc = dict(
+            detail = T_(
+'''A historical monument is here but is not mapped. The list of monuments
+comes from the database "Merimee Inventory of monuments" in France by the
+Ministry of Culture.'''),
+            fix = T_(
+'''See [heritage](https://wiki.openstreetmap.org/wiki/Key:heritage) on
+wiki. Add a node or to integrate tags something already existing.'''),
+            trap = T_(
+'''The position of the markers is made by address geocoding, it may be
+located elsewhere. The marker can be a very rough position, located as
+low accuracy to the town. Carefully check the contents of the proposed
+tags, can be curious or unsuitable values. Do not overide tags of UNESCO
+World Heritage.'''))
+        self.missing_official = self.def_class(item = 8010, id = 1, level = 3, tags = ['merge', 'building'], title = T_('Historical monument not integrated'), **doc)
+        self.missing_osm      = self.def_class(item = 7080, id = 2, level = 3, tags = ['merge'], title = T_('Historical monument without tag "ref:mhs" or invalid'), **doc)
+        self.possible_merge   = self.def_class(item = 8011, id = 3, level = 3, tags = ['merge'], title = T_('Historical monument, integration suggestion'), **doc)
+        self.update_official  = self.def_class(item = 8012, id = 4, level = 3, tags = ['merge'], title = T_('Historical monument update'), **doc)
 
         def parseDPRO(dpro):
             ret = None;

--- a/analysers/analyser_osmbin_open_relations.py
+++ b/analysers/analyser_osmbin_open_relations.py
@@ -62,8 +62,12 @@ class Analyser_OsmBin_Open_Relations(Analyser):
     def analyser(self, osmbin_path="/data/work/osmbin/data/"):
         timestamp = datetime.datetime.now()
         self.error_file.analyser(timestamp, self.analyser_version())
-        self.error_file.classs(1, 6010, 3, ["geom","boundary"], T_(u"Open relation type=boundary"))
-        self.error_file.classs(5, 1170, 2, ["geom"], T_(u"Open relation type=multipolygon"))
+        doc = dict(
+            details = T_(
+'''A relation that should be a closed polygon and it is not. An issue is
+reported at each end of open part.'''))
+        self.error_file.classs(id = 1, item = 6010, level = 3, tags = ['geom', 'boundary'], title = T_('Open relation type=boundary'), **docs)
+        self.error_file.classs(id = 5, item = 1170, level = 2, tags = ['geom'], title = T_('Open relation type=multipolygon'), **docs)
         for admin_level in range(0, 15):
             if admin_level <= 6:
                 level = 1
@@ -71,7 +75,7 @@ class Analyser_OsmBin_Open_Relations(Analyser):
                 level = 2
             else:
                 level = 3
-            self.error_file.classs(100 + admin_level, 6010, level, ["geom","boundary"], T_(u"Open relation type=boundary admin_level=%d", admin_level))
+            self.error_file.classs(id = 100 + admin_level, item = 6010, level = level, tags = ['geom', 'boundary'], title = T_(u"Open relation type=boundary admin_level=%d", admin_level), **docs)
 
         self.classs = {"boundary": 1, "multipolygon": 5}
 

--- a/analysers/analyser_osmosis_boundary_intersect.py
+++ b/analysers/analyser_osmosis_boundary_intersect.py
@@ -91,7 +91,18 @@ class Analyser_Osmosis_Boundary_Intersect(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs[1] = {"item":"1060", "level": 2, "tag": ["boundary", "geom", "fix:chair"], "desc": T_(u"Boundary intersection") }
+        self.classs[1] = self.def_class(item = 1060, level = 2, tags = ['boundary', 'geom', 'fix:chair'],
+            title = T_('Boundary intersection'),
+            detail = T_(
+'''Borders crossing.'''),
+            fix = T_(
+'''Check the type of border and keep the best or merged.'''),
+            trap = T_(
+'''The borders are part of relationships, they normally form loops.'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/6/69/Osmose-eg-error-1060.png)
+
+Two definitions of the same border.'''))
         self.callback20 = lambda res: {"class":1, "data":[self.way_full, self.way_full, self.positionAsText]}
 
     def analyser_osmosis_common(self):

--- a/analysers/analyser_osmosis_building_overlaps.py
+++ b/analysers/analyser_osmosis_building_overlaps.py
@@ -158,13 +158,42 @@ class Analyser_Osmosis_Building_Overlaps(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
         self.FR = config.options and ("country" in config.options and config.options["country"].startswith("FR") or "test" in config.options)
-        self.classs_change[1] = {"item":"0", "level": 3, "tag": ["building", "geom", "fix:chair"], "desc": T_(u"Building intersection") }
-        self.classs_change[2] = {"item":"0", "level": 2, "tag": ["building", "geom", "fix:chair"], "desc": T_(u"Large building intersection") }
-        self.classs_change[3] = {"item":"0", "level": 3, "tag": ["building", "geom", "fix:chair"], "desc": T_(u"Building too small") }
-        self.classs_change[4] = {"item":"0", "level": 3, "tag": ["building", "geom", "fix:chair"], "desc": T_(u"Gap between buildings") }
-        self.classs_change[5] = {"item":"0", "level": 1, "tag": ["building", "fix:chair"], "desc": T_(u"Large building intersection cluster") }
+        detail = T_(
+'''In France, probably a building imported from cadastre without the
+[controls
+needed](https://wiki.openstreetmap.org/wiki/France/Cadastre/Import_semi-automatique_des_b%C3%A2timents#Traitements_des_b.C3.A2timents_avec_JOSM_avant_envoi_vers_serveur_OSM).
+Error is frequent on areas where lots of building are drawn manually,
+such as the HOT activations.
+''')
+        self.classs_change[1] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
+            title = T_('Building intersection'),
+            detail = self.merge_doc(detail, T_(
+'''The intersection surface is probably due to inaccuracies in the
+cadastre/import tools.''')))
+        self.classs_change[2] = self.def_class(item = 0, level = 2, tags = ['building', 'geom', 'fix:chair'],
+            title = T_('Large building intersection'),
+            detail = self.merge_doc(detail, T_(
+'''A large overlap. Requires a visual check (Bing, cadastre, on
+site).''')))
+        self.classs_change[3] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
+            title = T_('Building too small'),
+            detail = self.merge_doc(detail, T_(
+'''There is no intersection, but the surface is too small to be a
+building.''')))
+        self.classs_change[4] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
+            title = T_('Gap between buildings'),
+            detail = self.merge_doc(detail, T_(
+'''Space separation is probably due to inaccuracies in the
+cadastre/import tools.''')))
+        self.classs_change[5] = self.def_class(item = 0, level = 1, tags = ['building', 'fix:chair'],
+            title = T_('Large building intersection cluster'),
+            detail = self.merge_doc(detail, T_(
+'''Group of important overlaps. Major problem like a double import.''')))
         if self.FR:
-            self.classs_change[6] = {"item":"1", "level": 3, "tag": ["building", "geom", "fix:chair"], "desc": T_(u"Building in parts") }
+            self.classs_change[6] = self.def_class(item =  1, level = 3, tags = ['building', 'geom', 'fix:chair'],
+                title = T_(u"Building in parts"),
+                detail = detail)
+
         self.callback30 = lambda res: {"class":2 if res[3]>res[4] else 1, "data":[self.way, self.way, self.positionAsText]}
         self.callback40 = lambda res: {"class":3, "data":[self.way, self.positionAsText]}
         self.callback50 = lambda res: {"class":4, "data":[self.way, self.way, self.positionAsText]}

--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -347,17 +347,31 @@ class Analyser_Osmosis_Highway_VS_Building(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[1] = {"item":"1070", "level": 2, "tag": ["highway", "building", "geom", "fix:imagery"], "desc": T_(u"Highway intersecting building") }
-        self.classs_change[2] = {"item":"1070", "level": 2, "tag": ["tree", "building", "geom", "fix:imagery"], "desc": T_(u"Tree intersecting building") }
-        self.classs_change[3] = {"item":"1070", "level": 2, "tag": ["highway", "tree", "geom", "fix:imagery"], "desc": T_(u"Tree and highway too close") }
-        self.classs_change[4] = {"item":"1070", "level": 3, "tag": ["highway", "waterway", "geom", "fix:imagery"], "desc": T_(u"Highway intersecting small water piece") }
-        self.classs_change[5] = {"item":"1070", "level": 2, "tag": ["highway", "waterway", "geom", "fix:imagery"], "desc": T_(u"Highway intersecting large water piece") }
-        self.classs_change[6] = {"item":"1070", "level": 2, "tag": ["power", "building", "geom", "fix:imagery"], "desc": T_(u"Power object intersecting building") }
-        self.classs_change[7] = {"item":"1070", "level": 2, "tag": ["highway", "power", "geom", "fix:imagery"], "desc": T_(u"Power object and highway too close") }
-        self.classs_change[8] = {"item":"1070", "level": 2, "tag": ["highway", "geom", "fix:imagery"], "desc": T_(u"Highway intersecting highway without junction") }
-        self.classs_change[9] = {"item":"1070", "level": 2, "tag": ["highway", "geom", "fix:imagery"], "desc": T_(u"Highway overlaps") }
-        self.classs_change[10] = {"item":"1070", "level": 3, "tag": ["waterway", "geom", "fix:imagery"], "desc": T_(u"Waterway intersecting waterway without junction") }
-        self.classs_change[11] = {"item":"1070", "level": 3, "tag": ["waterway", "geom", "fix:imagery"], "desc": T_(u"Waterway overlaps") }
+        doc = dict(
+            detail = T_(
+'''Objects that can not overlapped are on same location.'''),
+            fix = T_(
+'''Move an object or check the tags.'''),
+            trap = T_(
+'''The object may be missing a tag e.g. `tunnel=*`, `bridge=*`,
+`covered=*` or consider `layer=*` on the buidling where a road or railway
+enters a structure. Warning, information sources can be contradictory in
+time or with spatial offset.'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/d/dc/Osmose-eg-error-1070.png)
+
+Intersection lane / building.'''))
+        self.classs_change[1] = self.def_class(item = 1070, level = 2, tags = ['highway', 'building', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting building'), **doc)
+        self.classs_change[2] = self.def_class(item = 1070, level = 2, tags = ['tree', 'building', 'geom', 'fix:imagery'], title = T_(u'Tree intersecting building'), **doc)
+        self.classs_change[3] = self.def_class(item = 1070, level = 2, tags = ['highway', 'tree', 'geom', 'fix:imagery'], title = T_(u'Tree and highway too close'), **doc)
+        self.classs_change[4] = self.def_class(item = 1070, level = 3, tags = ['highway', 'waterway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting small water piece'), **doc)
+        self.classs_change[5] = self.def_class(item = 1070, level = 2, tags = ['highway', 'waterway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting large water piece'), **doc)
+        self.classs_change[6] = self.def_class(item = 1070, level = 2, tags = ['power', 'building', 'geom', 'fix:imagery'], title = T_(u'Power object intersecting building'), **doc)
+        self.classs_change[7] = self.def_class(item = 1070, level = 2, tags = ['highway', 'power', 'geom', 'fix:imagery'], title = T_(u'Power object and highway too close'), **doc)
+        self.classs_change[8] = self.def_class(item = 1070, level = 2, tags = ['highway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting highway without junction'), **doc)
+        self.classs_change[9] = self.def_class(item = 1070, level = 2, tags = ['highway', 'geom', 'fix:imagery'], title = T_(u'Highway overlaps'), **doc)
+        self.classs_change[10] = self.def_class(item = 1070, level = 3, tags = ['waterway', 'geom', 'fix:imagery'], title = T_(u'Waterway intersecting waterway without junction'), **doc)
+        self.classs_change[11] = self.def_class(item = 1070, level = 3, tags = ['waterway', 'geom', 'fix:imagery'], title = T_(u'Waterway overlaps'), **doc)
         self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.way_full, self.positionAsText]}
         self.callback20 = lambda res: {"class":2, "data":[self.node_full, self.way_full, self.positionAsText]}
         self.callback21 = lambda res: {"class":6, "data":[self.node_full, self.way_full, self.positionAsText]}

--- a/analysers/analyser_osmosis_orphan_nodes_cluster.py
+++ b/analysers/analyser_osmosis_orphan_nodes_cluster.py
@@ -51,7 +51,17 @@ class Analyser_Osmosis_Orphan_Nodes_Cluster(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs[1] = {"item":"1080", "level": 1, "tag": ["geom", "building", "fix:chair"], "desc": T_(u"Orphan nodes cluster") }
+        self.classs[1] = self.def_class(item = 1080, level = 1, tags = ['geom', 'building', 'fix:chair'],
+            title = T_('Orphan nodes cluster'),
+            detail = T_(
+'''Group of nodes without tag and not part of a way.'''),
+            fix = T_(
+'''Find the origin of these nodes. Probably in trouble in import.
+Contact the contributor submiting the nodes.'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/0/0c/Osmose-eg-error-1080.png)
+
+Group of orphan nodes.'''))
 
     def analyser_osmosis_common(self):
         self.run(sql10, lambda res: {"class":1, "subclass":stablehash64(res[0]), "data":[self.positionAsText]} )

--- a/analysers/analyser_osmosis_polygon.py
+++ b/analysers/analyser_osmosis_polygon.py
@@ -77,8 +77,21 @@ class Analyser_Osmosis_Polygon(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[1] = {"item":"1040", "level": 1, "tag": ["geom", "fix:chair"], "desc": T_(u"Invalid polygon") }
-        self.classs_change[2] = {"item":"1040", "level": 1, "tag": ["geom", "fix:chair"], "desc": T_(u"Invalid multipolygon") }
+        doc = dict(
+            detail = T_(
+'''The polygon intersects itself. The marker points directly to the
+error area of the crossing.'''),
+            fix = T_(
+'''Find where the polygon intersects itself (ie it forms an '8 ') and
+correct geometry for a single loop (a '0') or by removing nodes or
+changing the order of these nodes, by adding new nodes or by creating
+multiple polygons.'''),
+            trap = T_(
+'''Make sure the nodes to move do not belong to other way.'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/9/9a/Osmose-eg-error-1040.png)'''))
+        self.classs_change[1] = self.def_class(item = 1040, level = 1, tags = ['geom', 'fix:chair'], title = T_('Invalid polygon'), **doc)
+        self.classs_change[2] = self.def_class(item = 1040, level = 1, tags = ['geom', 'fix:chair'], title = T_('Invalid multipolygon'), **doc)
         self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText], "text": {"en": res[2]}}
         self.callback20 = lambda res: {"class":2, "data":[self.relation, self.positionAsText], "text": {"en": res[2]}}
 

--- a/analysers/analyser_osmosis_roundabout_reverse.py
+++ b/analysers/analyser_osmosis_roundabout_reverse.py
@@ -41,7 +41,24 @@ class Analyser_Osmosis_Roundabout_Reverse(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[1] = {"item":"1050", "level": 1, "tag": ["highway", "roundabout", "fix:chair"], "desc": T_(u"Reverse roundabout") } # FIXME "menu":"rond-point à l'envers", "menu":"reverse roundabout"
+        self.classs_change[1] = self.def_class(item = 1050, level = 1, tags = ['highway', 'roundabout', 'fix:chair'],
+            title = T_('Reverse roundabout'),
+            detail = T_(
+'''The circulation of the roundabout is draw clockwise, but in countries
+where they driveon the right the sense of roundabouts is
+counterclockwise, and vice versa for the other countries.'''),
+            fix = T_(
+'''For roundabout `junction=roundabout`: change the direction by
+reversing the order of nodes in the path. In JOSM, select the roundabout
+and use the tool reverse path (shortcut: 'R').'''),
+            trap = T_(
+'''Make sure that it is a roundabout (for example, no a side way in
+oposite direction around a square or a central roundabout, or driveways
+separated by traffic islands at an intersection without cross).'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/6/68/Osmose-eg-error-1050.png)
+
+Clockwise rotation.'''))
         self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText]}
         if self.config.options.get("driving_side") == "left":
             self.driving_side = "NOT "

--- a/analysers/analyser_sax.py
+++ b/analysers/analyser_sax.py
@@ -489,11 +489,18 @@ class Analyser_Sax(Analyser):
         # Create classes in issues file
         for (cl, item) in sorted(self._Err.items()):
             self.error_file.classs(
-                cl,
-                item["item"],
-                item.get("level"),
-                item.get("tag"),
-                item['desc'])
+                id = cl,
+                item = item['item'],
+                level = item['level'],
+                tags = item.get('tags', item.get('tag')),
+                title = item.get('title', item.get('desc')),
+                detail = item.get('detail'),
+                fix = item.get('fix'),
+                trap = item.get('trap'),
+                example = item.get('example'),
+                source = item.get('source'),
+                resource = item.get('resource'),
+            )
 
     ################################################################################
 

--- a/modules/OsmoseErrorFile.py
+++ b/modules/OsmoseErrorFile.py
@@ -64,16 +64,34 @@ class ErrorFile:
     def analyser_end(self):
         self.outxml.endElement(self.mode)
 
-    def classs(self, id, item, level, tag, langs):
-        options = {"id":str(id), "item": str(item)}
+    def classs(self, id, item, level, tags, title, detail, fix, trap, example, source, resource):
+        options = {
+            'id': str(id),
+            'item': str(item),
+        }
+        if source:
+            options['source'] = str(source)
+        if resource:
+            options['resource'] = str(resource)
         if level:
-            options["level"] = str(level)
-        if tag:
-            options["tag"] = ",".join(tag)
-        self.outxml.startElement("class", options)
-        for lang in sorted(langs.keys()):
-            self.outxml.Element("classtext", {"lang":lang, "title":langs[lang]})
-        self.outxml.endElement("class")
+            options['level'] = str(level)
+        if tags:
+            options['tag'] = ','.join(tags)
+        self.outxml.startElement('class', options)
+        for (key, value) in [
+            ('classtext', title),
+            ('detail', detail),
+            ('fix', fix),
+            ('trap', trap),
+            ('example', example),
+        ]:
+            if value:
+                for lang in sorted(value.keys()):
+                    self.outxml.Element(key, {
+                        'lang': lang,
+                        'title': value[lang]
+                    })
+        self.outxml.endElement('class')
 
     def error(self, classs, subclass, text, res, fixType, fix, geom, allow_override=False):
         if self.filter and not self.filter.apply(classs, subclass, geom):

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -81,6 +81,8 @@ class template_config:
     db_schema_path = None
     db_persistent = False
 
+    source_url = 'https://github.com/osm-fr/osmose-backend/blob/master/'
+
     def __init__(self, country, polygon_id=None, analyser_options=None, download_repo=GEOFABRIK):
         config[country] = self
         self.country          = country

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -178,6 +178,8 @@ def execc(conf, logger, options, osmosis_manager):
             analyser_conf.options = conf.analyser_options
             analyser_conf.polygon_id = conf.polygon_id
 
+            analyser_conf.source_url = conf.source_url
+
             if options.change and xml_change:
                 analyser_conf.src = xml_change
             elif "dst" in conf.download:

--- a/plugins/Plugin.py
+++ b/plugins/Plugin.py
@@ -21,6 +21,9 @@
 
 from modules.Stablehash import stablehash
 
+import os
+from inspect import getframeinfo, stack
+
 
 class Plugin(object):
 
@@ -88,6 +91,13 @@ class Plugin(object):
         @param logger:
         """
         pass
+
+    def def_class(self, **kwargs):
+        if 'source' not in kwargs:
+            caller = getframeinfo(stack()[1][0])
+            kwargs['source'] = '{0}/plugins/{1}#L{2}'.format(self.father.config.source_url, os.path.basename(caller.filename), caller.lineno)
+
+        return self.father.def_class(**kwargs)
 
     def ToolsStripAccents(self, mot):
         mot = mot.replace(u"à", u"a").replace(u"â", u"a")

--- a/plugins/Structural_DuplicateNodes.py
+++ b/plugins/Structural_DuplicateNodes.py
@@ -29,7 +29,28 @@ class Structural_DuplicateNodes(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
-        self.errors[103] = { "item": 1010, "level": 2, "tag": ["geom", "fix:chair"], "desc": T_(u"Duplicated nodes") }
+        self.errors[103] = self.def_class(item = 1010, level = 2, tags = ['geom', 'fix:chair'],
+            title = T_('Duplicated nodes'),
+            detail = T_(
+'''A path passes several times by the same node.'''),
+            fix = T_(
+'''There are several types of issues:
+
+* A way that makes one or more loops; the way must be split into several
+sections.
+* A path that goes back on itself (often at one end); the path must be
+cut to isolate the wrong section and recreated properly afterwards.
+
+There are certainly many other cases. In general, it is better to make
+several roads / areas than a single complex one so that tools working
+with OSM data can function properly.'''),
+            trap = T_(
+'''These errors require a good command of your editing tool. Some
+corrections are not necessarily intuitive.'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/5/5a/Osmose-eg-error-1010.png)
+
+Double polygon connected by a string to remove.'''))
 
     def way(self, data, tags, nds):
         c = {}

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -38,7 +38,25 @@ class TagFix_MultipleTag(Plugin):
         self.errors[71301] = { "item": 7130, "level": 3, "tag": ["tag", "highway", "maxheight", "fix:survey"], "desc": T_(u"Missing maxheight tag") }
         self.errors[21101] = { "item": 2110, "level": 2, "tag": ["tag"], "desc": T_(u"Name present but missing main tag") }
         self.errors[21102] = { "item": 2110, "level": 2, "tag": ["tag"], "desc": T_(u"Missing relation type") }
-        self.errors[1050] = { "item": 1050, "level": 1, "tag": ["highway", "roundabout", "fix:chair"], "desc": T_(u"Reverse roundabout") }
+        self.errors[1050] = self.def_class(item = 1050, level = 1, tags = ['highway', 'roundabout', 'fix:chair'],
+            title = T_('Reverse roundabout'),
+            detail = T_(
+'''The circulation of the roundabout is draw clockwise, but in countries
+where they drive on the right the sense of roundabouts is
+counterclockwise, and vice versa for the other countries.'''),
+            fix = T_(
+'''For the mini roundabouts `highway=mini_roundabout`: the tag
+`direction=*` indicates the direction, in countries driven on the right,
+the default is `direction=anticlockwise`, in this case it is useless as
+tag.'''),
+            trap = T_(
+'''Make sure that it is a roundabout (for example, no a side way in
+oposite direction around a square or a central roundabout, ordriveways
+separated by traffic islands at an intersection without cross).'''),
+            example = T_(
+'''![](https://wiki.openstreetmap.org/w/images/6/68/Osmose-eg-error-1050.png)
+
+Clockwise rotation.'''))
         self.errors[40201] = { "item": 4020, "level": 1, "tag": ["highway", "roundabout"], "desc": T_(u"Roundabout as area") }
         self.errors[21201] = { "item": 2120, "level": 3, "tag": ["indoor"], "desc": T_(u"Level or repeat_on tag missing") }
         self.errors[21202] = { "item": 2120, "level": 3, "tag": ["indoor"], "desc": T_(u"Indoor or buildingpart tag missing") }


### PR DESCRIPTION
Work in Progress, open for comment.

Move the user doc from OSM Wiki to analyser code with goals:

* Maintain the doc
* More doc
* More translation
* Write the doc in markdown, how integrate images ?

Once the doc in the analyser code:

* Send it to the frontend with the computed issues

Once the on the frontend database:

* Display the doc aside the selected issue on the map
* Make the doc available by API
* Push the user to contribute to the doc, not sure how, send it the Githib ?
