### PR TITLE
Update some translation strings

### DIFF
--- a/analysers/analyser_merge_street_objects.py
+++ b/analysers/analyser_merge_street_objects.py
@@ -45,8 +45,10 @@ class SubAnalyser_Merge_Street_Objects(SubAnalyser_Merge_Dynamic):
     def __init__(self, config, error_file, logger, classs, level, otype, conflation, title, object, selectTags, generateTags, mapping, layer):
         SubAnalyser_Merge_Dynamic.__init__(self, config, error_file, logger)
         self.missing_official = self.def_class(item = 8360, id = classs, level = level, tags = ['merge', 'leisure'],
-            title = T_('Mapillary street object'),
-            detail = T_f('{1} detected nearby, but no \"{0}\" tagging', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
+            title = T_f('Unmapped {0}', title),
+            detail = T_f('Street object ({1}) detected by Mapillary, but no nearby "{0}" tagging.',
+                ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title),
+            fix = T_('Map the corresponding object if the imagery is up-to-date and object detection is correct.'))
 
         self.init(
             "www.mapillary.com",

--- a/analysers/analyser_merge_street_objects.py
+++ b/analysers/analyser_merge_street_objects.py
@@ -45,7 +45,8 @@ class SubAnalyser_Merge_Street_Objects(SubAnalyser_Merge_Dynamic):
     def __init__(self, config, error_file, logger, classs, level, otype, conflation, title, object, selectTags, generateTags, mapping, layer):
         SubAnalyser_Merge_Dynamic.__init__(self, config, error_file, logger)
         self.missing_official = self.def_class(item = 8360, id = classs, level = level, tags = ['merge', 'leisure'],
-            title = T_f('{0} Street object {1} observed around but not associated tags', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
+            title = T_('Mapillary street object'),
+            detail = T_f('{1} detected nearby, but no \"{0}\" tagging', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
 
         self.init(
             "www.mapillary.com",

--- a/analysers/analyser_merge_traffic_signs.py
+++ b/analysers/analyser_merge_traffic_signs.py
@@ -72,8 +72,10 @@ class SubAnalyser_Merge_Traffic_Signs(SubAnalyser_Merge_Dynamic):
     def __init__(self, config, error_file, logger, classs, level, otype, conflation, title, object, selectTags, generateTags, mapping, layer):
         SubAnalyser_Merge_Dynamic.__init__(self, config, error_file, logger)
         self.missing_official = self.def_class(item = 8300, id = classs, level = level, tags = ['merge', 'leisure'],
-            title = T_('Mapillary traffic sign'),
-            detail = T_f('Traffic signs for {1} detected nearby, but no \"{0}\" tagging', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
+            title = T_f('Unmapped {0}', title),
+            detail = T_f('Traffic sign ({1}) detected by Mapillary, but no nearby "{0}" tagging.',
+                ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title),
+            fix = T_('Add the appropriate highway tagging if the imagery is up-to-date and sign detection is correct.'))
 
         self.init(
             "www.mapillary.com",

--- a/analysers/analyser_merge_traffic_signs.py
+++ b/analysers/analyser_merge_traffic_signs.py
@@ -72,7 +72,8 @@ class SubAnalyser_Merge_Traffic_Signs(SubAnalyser_Merge_Dynamic):
     def __init__(self, config, error_file, logger, classs, level, otype, conflation, title, object, selectTags, generateTags, mapping, layer):
         SubAnalyser_Merge_Dynamic.__init__(self, config, error_file, logger)
         self.missing_official = self.def_class(item = 8300, id = classs, level = level, tags = ['merge', 'leisure'],
-            title = T_f('{0} Traffic signs for {1} observed around but not associated tags', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
+            title = T_('Mapillary traffic sign'),
+            detail = T_f('Traffic signs for {1} detected nearby, but no \"{0}\" tagging', ', '.join(map(lambda kv: '%s=%s' % (kv[0], kv[1] if kv[1] else '*'), generateTags.items())), title))
 
         self.init(
             "www.mapillary.com",

--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -349,11 +349,11 @@ class Analyser_Osmosis_Highway_VS_Building(Analyser_Osmosis):
         Analyser_Osmosis.__init__(self, config, logger)
         doc = dict(
             detail = T_(
-'''Objects that can not overlapped are on same location.'''),
+'''Two features overlap with no shared node to indicate a physical connection or tagging to indicate a vertical separation.'''),
             fix = T_(
-'''Move an object or check the tags.'''),
+'''Move a feature if it's in the wrong place. Connect the features if appropriate or update the tags if not.'''),
             trap = T_(
-'''The object may be missing a tag e.g. `tunnel=*`, `bridge=*`,
+'''A feature may be missing a tag e.g. `tunnel=*`, `bridge=*`,
 `covered=*` or consider `layer=*` on the buidling where a road or railway
 enters a structure. Warning, information sources can be contradictory in
 time or with spatial offset.'''),
@@ -368,9 +368,9 @@ Intersection lane / building.'''))
         self.classs_change[5] = self.def_class(item = 1070, level = 2, tags = ['highway', 'waterway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting large water piece'), **doc)
         self.classs_change[6] = self.def_class(item = 1070, level = 2, tags = ['power', 'building', 'geom', 'fix:imagery'], title = T_(u'Power object intersecting building'), **doc)
         self.classs_change[7] = self.def_class(item = 1070, level = 2, tags = ['highway', 'power', 'geom', 'fix:imagery'], title = T_(u'Power object and highway too close'), **doc)
-        self.classs_change[8] = self.def_class(item = 1070, level = 2, tags = ['highway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting highway without junction'), **doc)
+        self.classs_change[8] = self.def_class(item = 1070, level = 2, tags = ['highway', 'geom', 'fix:imagery'], title = T_(u'Highway intersecting highway'), **doc)
         self.classs_change[9] = self.def_class(item = 1070, level = 2, tags = ['highway', 'geom', 'fix:imagery'], title = T_(u'Highway overlaps'), **doc)
-        self.classs_change[10] = self.def_class(item = 1070, level = 3, tags = ['waterway', 'geom', 'fix:imagery'], title = T_(u'Waterway intersecting waterway without junction'), **doc)
+        self.classs_change[10] = self.def_class(item = 1070, level = 3, tags = ['waterway', 'geom', 'fix:imagery'], title = T_(u'Waterway intersecting waterway'), **doc)
         self.classs_change[11] = self.def_class(item = 1070, level = 3, tags = ['waterway', 'geom', 'fix:imagery'], title = T_(u'Waterway overlaps'), **doc)
         self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.way_full, self.positionAsText]}
         self.callback20 = lambda res: {"class":2, "data":[self.node_full, self.way_full, self.positionAsText]}

--- a/analysers/analyser_osmosis_relation_enforcement.py
+++ b/analysers/analyser_osmosis_relation_enforcement.py
@@ -55,7 +55,8 @@ class Analyser_Osmosis_Relation_Enforcement(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
         self.classs[1] = self.def_class(item = 1280, level = 3, tags = ['highway', 'fix:chair'],
-            title = T_('Speed camera should be on the highway or in an enforcement relation'))
+            title = T_('Disconnected speed camera'),
+            fix = T_('Map as a node on the highway or use an enforcement relation'))
 
     def analyser_osmosis_common(self):
         self.run(sql00, lambda res: {"class":1, "data":[self.node_full, self.positionAsText]})

--- a/analysers/analyser_osmosis_relation_enforcement.py
+++ b/analysers/analyser_osmosis_relation_enforcement.py
@@ -56,7 +56,7 @@ class Analyser_Osmosis_Relation_Enforcement(Analyser_Osmosis):
         Analyser_Osmosis.__init__(self, config, logger)
         self.classs[1] = self.def_class(item = 1280, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Disconnected speed camera'),
-            fix = T_('Map as a node on the highway or use an enforcement relation'))
+            fix = T_('Speed camera should be mapped as a node on the highway or use an enforcement relation.'))
 
     def analyser_osmosis_common(self):
         self.run(sql00, lambda res: {"class":1, "data":[self.node_full, self.positionAsText]})

--- a/plugins/Name_Script.py
+++ b/plugins/Name_Script.py
@@ -51,7 +51,7 @@ used.'''),
             fix = T_(
 '''Remove the character.'''))
         self.errors[50703] = self.def_class(item = 5070, level = 2, tags = ['name', 'fix:chair'],
-            title = T_('Symbol char'),
+            title = T_('Unexpected symbol in name'),
             detail = T_(
 '''A symbol is used instead of a letter from the appropriate
 alphabet.'''),

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -28,7 +28,7 @@ class TagFix_BadValue(Plugin):
     def init(self, logger):
         Plugin.init(self, logger)
         self.errors[3040] = self.def_class(item = 3040, level = 1, tags = ['value', 'fix:chair'],
-            title = T_('Bad value in a tag'))
+            title = T_('Bad tag value'))
 
         import re
         self.Values_open = re.compile("^[a-z0-9_]+( *; *[a-z0-9_]+)*$")
@@ -93,12 +93,12 @@ class TagFix_BadValue(Plugin):
                     if tags[k] in self.exceptions_open[k]:
                         # no error if in exception list
                         continue
-                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Bad value for %(key)s=%(val)s", {"key": k, "val": tags[k]})})
+                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Bad tag value: \"%(key)s=%(val)s\"", {"key": k, "val": tags[k]})})
 
         keys = set(keyss) & self.check_list_closed
         for k in keys:
             if tags[k] not in self.allow_closed[k]:
-                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Bad value for %(key)s=%(val)s", {"key": k, "val": tags[k]})})
+                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Bad tag value: \"%(key)s=%(val)s\"", {"key": k, "val": tags[k]})})
 
         return err
 

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -57,7 +57,7 @@ class TagFix_MultipleTag(Plugin):
 '''Missing `maxheight=*` or `maxheight:*` for a tunnel or a way under a
 bridge.'''))
         self.errors[21101] = self.def_class(item = 2110, level = 2, tags = ['tag'],
-            title = T_('Name present but missing main tag'),
+            title = T_('Untagged named object'),
             detail = self.merge_doc(T_(
 '''The object is missing any tag which defines what kind of feature is
 it. Considered main tags are (with derived `disused:` and


### PR DESCRIPTION
Some changes in support of displaying these strings in iD: https://github.com/openstreetmap/iD/pull/7095

I notice the project is using the `.pot` file `msgid` fallback for English translations (mentioned on iD PR, but more relevant to discuss here). Is it worth moving to using the `msgstr` so that English strings can be more easily updated in future? Edit: This can also make the code more readable as you can give strings meaningful identifiers

There are some other strings it would be good to shorten into titles and move details into `fix` or `detail` strings which I haven't currently changed here:
- [ ] "access=yes|permissive allow all transport modes"
- [ ] "Bad usage of area=yes. Object is already an area by nature"
- [ ] "area=yes on object without kind"
- [ ] "Bad usage of area=no. Object must be a surface"
- [ ] "{0} is preferred to {1}"