### PR TITLE
remove false positives for old railway which are now highways

### DIFF
--- a/plugins/Construction2.validator.mapcss
+++ b/plugins/Construction2.validator.mapcss
@@ -33,8 +33,8 @@ meta[lang=fr] {
 
 way[highway][construction][highway!=construction][construction!=minor],
 way[highway][proposed][highway!=proposed],
-way[railway][construction][railway!=construction|abandoned|razed|dismantled][construction!=minor],
-way[railway][proposed][railway!=proposed|abandoned|razed|dismantled|disused] {
+way[railway][construction][railway!=construction][railway!=abandoned][railway!=razed][railway!=dismantled][construction!=minor],
+way[railway][proposed][railway!=proposed][railway!=abandoned][railway!=razed][railway!=dismantled][railway!=disused] {
     throwError: tr("Inconsistent tagging of {0}", "{1.key}");
     -osmoseItemClassLevel: "4070/40701/1";
 

--- a/plugins/Construction2.validator.mapcss
+++ b/plugins/Construction2.validator.mapcss
@@ -33,8 +33,8 @@ meta[lang=fr] {
 
 way[highway][construction][highway!=construction][construction!=minor],
 way[highway][proposed][highway!=proposed],
-way[railway][construction][railway!=construction][construction!=minor],
-way[railway][proposed][railway!=proposed] {
+way[railway][construction][railway!=construction|abandoned|razed|dismantled][construction!=minor],
+way[railway][proposed][railway!=proposed|abandoned|razed|dismantled|disused] {
     throwError: tr("Inconsistent tagging of {0}", "{1.key}");
     -osmoseItemClassLevel: "4070/40701/1";
 


### PR DESCRIPTION
This is mostly relevant for cycleways which follow (or are planned to follow) old railway routes.
as

This change should remove these false positives but I'm unsure if I did it correctly so please check and correct me