### PR TITLE
Update building check strings

### DIFF
--- a/analysers/analyser_osmosis_building_overlaps.py
+++ b/analysers/analyser_osmosis_building_overlaps.py
@@ -158,41 +158,37 @@ class Analyser_Osmosis_Building_Overlaps(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
         self.FR = config.options and ("country" in config.options and config.options["country"].startswith("FR") or "test" in config.options)
-        detail = T_(
-'''In France, probably a building imported from cadastre without the
-[controls
-needed](https://wiki.openstreetmap.org/wiki/France/Cadastre/Import_semi-automatique_des_b%C3%A2timents#Traitements_des_b.C3.A2timents_avec_JOSM_avant_envoi_vers_serveur_OSM).
-Error is frequent on areas where lots of building are drawn manually,
-such as the HOT activations.
-''')
+        fix = T_(
+'''Fix geometry so that buildings don't overlap, but share nodes if physically joined. \
+If geometry is correct and there's some vertical difference then make use of the `layer` tag to indicate this.''')
+
         self.classs_change[1] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Building intersection'),
-            detail = self.merge_doc(detail, T_(
-'''The intersection surface is probably due to inaccuracies in the
-cadastre/import tools.''')))
+            fix = fix)
         self.classs_change[2] = self.def_class(item = 0, level = 2, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Large building intersection'),
-            detail = self.merge_doc(detail, T_(
-'''A large overlap. Requires a visual check (Bing, cadastre or
-survey).''')))
+            fix = self.merge_doc(fix, '\n\n', T_(
+'''Large intersections may also be a duplicated mapping - in which case delete the less accurate element.''')))
         self.classs_change[3] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Building too small'),
-            detail = self.merge_doc(detail, T_(
-'''There is no intersection, but the surface is too small to be a
-building.''')))
+            detail = T_('The area of this feature is too small to possibly be a building.'),
+            fix = T_(
+'''- Correct the gometry if inaccurately mapped. \
+- Correct the tagging if this isn't a building. \
+- Delete the feature if it's invalid.'''))
         self.classs_change[4] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Gap between buildings'),
-            detail = self.merge_doc(detail, T_(
-'''Space separation is probably due to inaccuracies in the
-cadastre/import tools.''')))
+            detail = T_(
+'''It looks like these buildings should be physically joined, but they don't share nodes to indicate this.'''),
+            fix = T_('Connect the buildings by joining nodes where appropriate.'))
         self.classs_change[5] = self.def_class(item = 0, level = 1, tags = ['building', 'fix:chair'],
             title = T_('Large building intersection cluster'),
-            detail = self.merge_doc(detail, T_(
-'''Group of important overlaps. Major problem like a double import.''')))
+            fix = self.merge_doc(fix, '\n\n', T_(
+'''Large intersections may also be a duplicated mapping - in which case delete the less accurate element.''')))
         if self.FR:
             self.classs_change[6] = self.def_class(item =  1, level = 3, tags = ['building', 'geom', 'fix:chair'],
-                title = T_(u"Building in parts"),
-                detail = detail)
+                title = T_("Building in parts"),
+                fix = T_('Merge the building parts together as appropriate.'))
 
         self.callback30 = lambda res: {"class":2 if res[3]>res[4] else 1, "data":[self.way, self.way, self.positionAsText]}
         self.callback40 = lambda res: {"class":3, "data":[self.way, self.positionAsText]}

--- a/analysers/analyser_osmosis_building_overlaps.py
+++ b/analysers/analyser_osmosis_building_overlaps.py
@@ -167,8 +167,8 @@ If geometry is correct and there's some vertical difference then make use of the
             fix = fix)
         self.classs_change[2] = self.def_class(item = 0, level = 2, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Large building intersection'),
-            fix = self.merge_doc(fix, '\n\n', T_(
-'''Large intersections may also be a duplicated mapping - in which case delete the less accurate element.''')))
+            fix = self.merge_doc(fix, T_(
+'''Large intersections may also be a duplicated mapping - in which case delete the less accurate elements.''')))
         self.classs_change[3] = self.def_class(item = 0, level = 3, tags = ['building', 'geom', 'fix:chair'],
             title = T_('Building too small'),
             detail = T_('The area of this feature is too small to possibly be a building.'),
@@ -184,7 +184,7 @@ If geometry is correct and there's some vertical difference then make use of the
         self.classs_change[5] = self.def_class(item = 0, level = 1, tags = ['building', 'fix:chair'],
             title = T_('Large building intersection cluster'),
             fix = self.merge_doc(fix, T_(
-'''Large intersections may also be a duplicated mapping - in which case delete the less accurate element.''')))
+'''Large intersections may also be a duplicated mapping - in which case delete the less accurate elements.''')))
         if self.FR:
             self.classs_change[6] = self.def_class(item =  1, level = 3, tags = ['building', 'geom', 'fix:chair'],
                 title = T_("Building in parts"),

--- a/analysers/analyser_osmosis_building_overlaps.py
+++ b/analysers/analyser_osmosis_building_overlaps.py
@@ -183,7 +183,7 @@ If geometry is correct and there's some vertical difference then make use of the
             fix = T_('Connect the buildings by joining nodes where appropriate.'))
         self.classs_change[5] = self.def_class(item = 0, level = 1, tags = ['building', 'fix:chair'],
             title = T_('Large building intersection cluster'),
-            fix = self.merge_doc(fix, '\n\n', T_(
+            fix = self.merge_doc(fix, T_(
 '''Large intersections may also be a duplicated mapping - in which case delete the less accurate element.''')))
         if self.FR:
             self.classs_change[6] = self.def_class(item =  1, level = 3, tags = ['building', 'geom', 'fix:chair'],


### PR DESCRIPTION
Previous detail string was not relevant to majority of the world and also not the most useful as it explained why the issue might exist rather than what the issue actually is and how to fix it.

Have instead added fix strings which explain how to resolve intersections for different circumstances. Think the title alone is pretty self explanatory for the intersections.

Have added strings to try and clarify the other issues (gap between buildings and small building).