### PR TITLE
Street number in Rennes : remove space between number and suffix

### DIFF
--- a/analysers/analyser_merge_street_number_rennes.py
+++ b/analysers/analyser_merge_street_number_rennes.py
@@ -37,5 +37,5 @@ class Analyser_Merge_Street_Number_Rennes(_Analyser_Merge_Street_Number):
             Mapping(
                 generate = Generate(
                     static2 = {"source": self.source},
-                    mapping1 = {"addr:housenumber": lambda res: res["numero"] + (" "+res["suffixe"] if res["suffixe"] else "")},
-                    text = lambda tags, fields: {"en": u"%s%s %s" % (fields["numero"], (" "+fields["suffixe"] if fields["suffixe"] else ""), fields["voie_nom"])} )))
+                    mapping1 = {"addr:housenumber": lambda res: res["numero"] + (res["suffixe"] if res["suffixe"] else "")},
+                    text = lambda tags, fields: {"en": u"%s%s %s" % (fields["numero"], (fields["suffixe"] if fields["suffixe"] else ""), fields["voie_nom"])} )))


### PR DESCRIPTION
Hello,

This fix is intended to remove space between street number and suffix in Rennes addresses merge analyser. It is intended to conform widely-used rule of not having space.

Regards.