### PR TITLE
Plugin to find wayside_crosses without material

### DIFF
--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -50,5 +50,5 @@ if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate'''))
 
     def node(self, data, tags):
         if tags["historic"]=="wayside_cross" and "material" not in tags:
-           return {"class": 800, "subclass": 0, "text": title}
+           return {"class": 800, "subclass": 0}
     

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -2,9 +2,7 @@
 
 ###########################################################################
 ##                                                                       ##
-## Copyrights:                                                           ##
-##            Etienne Chové <chove@crans.org> 2009                       ##
-##            Morray 2020                                                ##
+## Copyrights: Morray 2020                                               ##
 ##                                                                       ##
 ## This program is free software: you can redistribute it and/or modify  ##
 ## it under the terms of the GNU General Public License as published by  ##

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -2,7 +2,9 @@
 
 ###########################################################################
 ##                                                                       ##
-## Copyrights Etienne Chové <chove@crans.org> 2009                       ##
+## Copyrights:                                                           ##
+##            Etienne Chové <chove@crans.org> 2009                       ##
+##            Morray 2020                                                ##
 ##                                                                       ##
 ## This program is free software: you can redistribute it and/or modify  ##
 ## it under the terms of the GNU General Public License as published by  ##
@@ -22,7 +24,7 @@
 from plugins.Plugin import Plugin
 
 
-class historic_wayside_cross_material(Plugin):
+class Historic_Wayside_cross_without_material(Plugin):
 
     only_for = ["DE", "AT", "CH"]
 
@@ -42,7 +44,9 @@ if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate.'''))
             detail = T_(
 '''Check if tag `material=*` is filled for `historic=wayside_cross` objects.'''),
             fix = T_(
-'''Add tag `material=*` or change object type as appropriate.'''),
+'''Add tag `material=*` or change object type as appropriate. Also take the 
+oportunity to add other meta-data as `religion`, `denomination`, `start_date`, 
+`inscritption`, ...'''),
             trap = T_(
 '''The tag `historic=wayside_cross` is sometimes misused. Please x-check
 if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate'''))

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -1,0 +1,59 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Etienne Chové <chove@crans.org> 2009                       ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from plugins.Plugin import Plugin
+
+
+class historic_wayside_cross_material(Plugin):
+
+    only_for = ["DE", "AT", "CH"]
+
+    def init(self, logger):
+        Plugin.init(self, logger)
+        self.errors[800] = self.def_class(item = 9200, level = 1, tags = ['historic', 'fix:survey'],
+            title = T_('Wayside_cross node without material tag'),
+            detail = T_(
+'''The tag `historic=wayside_cross` can always be used in combination with
+the tag `material=*`.'''),
+            fix = T_(
+'''Fill the tag `material=*` as specific as possible.'''),
+            trap = T_(
+'''The tag `historic=wayside_cross` is sometimes misused. Please x-check
+if historic=wayside_shrine or summit:cross=yes is mor appropiate.'''))
+        doc = dict(
+            detail = T_(
+'''Check if tag `material=*` is filled for `historic=wayside_cross` objects.'''),
+            fix = T_(
+'''Add tag `material=*` or change object type as appropriate.'''),
+            trap = T_(
+'''The tag `historic=wayside_cross` is sometimes misused. Please x-check
+if historic=wayside_shrine or summit:cross=yes is mor appropiate'''))
+
+
+    def node(self, data, tags):
+        keys = tags.keys()
+        if u"historic" in tags:
+            if u"wayside_cross" in keys:
+                if u"material" not in tags:
+                    return {"class": 800, "subclass": 0, "text": T_(u"Node with historic=%s without material tag", tags[u"historic"])}
+
+
+

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -49,6 +49,6 @@ if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate'''))
 
 
     def node(self, data, tags):
-        keys = tags.keys()
-        if "historic" in tags and "wayside_cross" in keys and "material" not in tags:
-           return {"class": 800, "subclass": 0, "text": T_("Node with `historic=wayside_cross` without `material=*` tag")}
+        if tags["historic"]=="wayside_cross" and "material" not in tags:
+           return {"class": 800, "subclass": 0, "text": title}
+    

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -29,7 +29,7 @@ class historic_wayside_cross_material(Plugin):
     def init(self, logger):
         Plugin.init(self, logger)
         self.errors[800] = self.def_class(item = 9200, level = 1, tags = ['historic', 'fix:survey'],
-            title = T_('Wayside_cross node without material tag'),
+            title = T_('Wayside cross node without `material` tag'),
             detail = T_(
 '''The tag `historic=wayside_cross` can always be used in combination with
 the tag `material=*`.'''),
@@ -37,7 +37,7 @@ the tag `material=*`.'''),
 '''Fill the tag `material=*` as specific as possible.'''),
             trap = T_(
 '''The tag `historic=wayside_cross` is sometimes misused. Please x-check
-if historic=wayside_shrine or summit:cross=yes is mor appropiate.'''))
+if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate.'''))
         doc = dict(
             detail = T_(
 '''Check if tag `material=*` is filled for `historic=wayside_cross` objects.'''),
@@ -45,15 +45,10 @@ if historic=wayside_shrine or summit:cross=yes is mor appropiate.'''))
 '''Add tag `material=*` or change object type as appropriate.'''),
             trap = T_(
 '''The tag `historic=wayside_cross` is sometimes misused. Please x-check
-if historic=wayside_shrine or summit:cross=yes is mor appropiate'''))
+if `historic=wayside_shrine` or `summit:cross=yes` is more appropiate'''))
 
 
     def node(self, data, tags):
         keys = tags.keys()
-        if u"historic" in tags:
-            if u"wayside_cross" in keys:
-                if u"material" not in tags:
-                    return {"class": 800, "subclass": 0, "text": T_(u"Node with historic=%s without material tag", tags[u"historic"])}
-
-
-
+        if "historic" in tags and "wayside_cross" in keys and "material" not in tags:
+           return {"class": 800, "subclass": 0, "text": T_("Node with `historic=wayside_cross` without `material=*` tag")}

--- a/plugins/Historic_Wayside_cross_without_material.py
+++ b/plugins/Historic_Wayside_cross_without_material.py
@@ -28,7 +28,7 @@ class Historic_Wayside_cross_without_material(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
-        self.errors[800] = self.def_class(item = 9200, level = 1, tags = ['historic', 'fix:survey'],
+        self.errors[303241] = self.def_class(item = 3032, level = 1, tags = ['historic', 'fix:survey'],
             title = T_('Wayside cross node without `material` tag'),
             detail = T_(
 '''The tag `historic=wayside_cross` can always be used in combination with


### PR DESCRIPTION
Plugin to find wayside_crosses without material restricted to DE, AT, and CH for the start. Code inspired by plugins/Administrative_INSEE_Name.py