### PR TITLE
Remove too generic 8400 from FINESS

### DIFF
--- a/merge_data/healthcare_FR_finess.mapping.json
+++ b/merge_data/healthcare_FR_finess.mapping.json
@@ -69,49 +69,7 @@
   },
   {
     "categories": [
-      "128",
-      "129",
-      "142",
-      "143",
-      "156",
-      "161",
-      "223",
-      "268",
-      "269",
-      "270",
-      "294",
-      "347",
-      "362",
-      "365",
-      "366",
-      "412",
-      "415",
-      "425",
-      "430",
-      "433",
-      "438",
-      "444",
-      "604",
-      "636"
-    ],
-    "items": [
-      8400
-    ],
-    "missing_osm": false,
-    "classes": 20,
-    "level": 3,
-    "title": "Établissements de soins autres que les hôpitaux",
-    "tags_select": {
-      "healthcare": "yes"
-    },
-    "tags_generate1": {},
-    "tags_generate2": {
-      "healthcare": "yes"
-    }
-  },
-  {
-    "categories": [
-	"603"
+      "603"
     ],
     "items": [
       8400


### PR DESCRIPTION
Remove too generic "Établissements de soins autres que les hôpitaux non intégré" from FINESS

I will pass soon this PR, unless a more detailed PR deal with this FINESS code is sumbited.

So we can enable 8400 item with "Maison de santé non intégré"

http://osmose.openstreetmap.fr/fr/errors/?item=8400&useDevItem=all

cc @pyrog @vinber 
