### PR TITLE
Add new analyser_merge for emergency access point dataset in Luxembourg

### DIFF
--- a/analysers/analyser_merge_emergency_points_LU.py
+++ b/analysers/analyser_merge_emergency_points_LU.py
@@ -26,9 +26,9 @@ from .Analyser_Merge import Analyser_Merge, Source, CSV, Load, Mapping, Select, 
 class Analyser_Merge_Emergency_Points_LU(Analyser_Merge):
     def __init__(self, config, logger=None):
         Analyser_Merge.__init__(self, config, logger)
-        self.missing_official = self.def_class(item=9110, id=3, level=3, tags=['merge'],
+        self.missing_official = self.def_class(item=8440, id=3, level=3, tags=['merge'],
                                                title=T_('Emergency point not integrated'))
-        self.possible_merge = self.def_class(item=9111, id=3, level=3, tags=['merge'],
+        self.possible_merge = self.def_class(item=8441, id=3, level=3, tags=['merge'],
                                                title=T_('Emergency point integration suggestion'))
         self.init(
             "https://data.public.lu/fr/datasets/linstallation-des-points-de-secours-rettungspunkte",

--- a/analysers/analyser_merge_emergency_points_LU.py
+++ b/analysers/analyser_merge_emergency_points_LU.py
@@ -42,6 +42,7 @@ class Analyser_Merge_Emergency_Points_LU(Analyser_Merge):
                 select=Select(
                     types=["nodes"],
                     tags={"highway": "emergency_access_point"}),
+                osmRef = "ref",
                 conflationDistance=50,
                 generate=Generate(
                     static1={

--- a/analysers/analyser_merge_emergency_points_LU.py
+++ b/analysers/analyser_merge_emergency_points_LU.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights David Morais Ferreira 2020                                 ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge import Analyser_Merge, Source, CSV, Load, Mapping, Select, Generate
+
+
+class Analyser_Merge_Emergency_Points_LU(Analyser_Merge):
+    def __init__(self, config, logger=None):
+        Analyser_Merge.__init__(self, config, logger)
+        self.missing_official = self.def_class(item=9110, id=3, level=3, tags=['merge'],
+                                               title=T_('Emergency point not integrated'))
+        self.possible_merge = self.def_class(item=9111, id=3, level=3, tags=['merge'],
+                                               title=T_('Emergency point integration suggestion'))
+        self.init(
+            "https://data.public.lu/fr/datasets/linstallation-des-points-de-secours-rettungspunkte",
+            "Points de secours",
+            CSV(Source(attribution="Corps grand-ducal d'incendie et de secours",
+                       fileUrl="https://data.public.lu/fr/datasets/r/b8d9d38a-7894-49fb-ab88-94072fe2c722",
+                       encoding="iso-8859-1"),
+                separator=";"),
+            Load("GEOGRAPHISCHE LÄNGE", "GEOGRAPHISCHE BREITE"),
+            Mapping(
+                select=Select(
+                    types=["nodes"],
+                    tags={"highway": "emergency_access_point"}),
+                conflationDistance=50,
+                generate=Generate(
+                    static1={
+                        "highway": "emergency_access_point"
+                    },
+                    mapping1={
+                        "ref": "NAME",
+                        "name": "ZUSATZ"
+                    }
+                )))

--- a/analysers/analyser_merge_emergency_points_LU.py
+++ b/analysers/analyser_merge_emergency_points_LU.py
@@ -26,7 +26,7 @@ from .Analyser_Merge import Analyser_Merge, Source, CSV, Load, Mapping, Select, 
 class Analyser_Merge_Emergency_Points_LU(Analyser_Merge):
     def __init__(self, config, logger=None):
         Analyser_Merge.__init__(self, config, logger)
-        self.missing_official = self.def_class(item=8440, id=3, level=3, tags=['merge'],
+        self.missing_official = self.def_class(item=8440, id=1, level=3, tags=['merge'],
                                                title=T_('Emergency point not integrated'))
         self.possible_merge = self.def_class(item=8441, id=3, level=3, tags=['merge'],
                                                title=T_('Emergency point integration suggestion'))

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -601,7 +601,8 @@ lithuania = default_country("europe", "lithuania", 72596, {"country": "LT", "lan
 del(lithuania.analyser["osmosis_highway_cul-de-sac_level"]) # follow official highway classification
 del(lithuania.analyser["osmosis_highway_broken_level_continuity"]) # follow official highway classification
 default_country("europe", "latvia", 72594, {"country": "LV","language": "lv", "proj": 32634}, download_repo=GEOFABRIK)
-default_country("europe", "luxembourg", 2171347, {"country": "LU", "language": "fr_LU", "proj": 2169, "boundary_detail_level": 6})
+luxembourg = default_country("europe", "luxembourg", 2171347, {"country": "LU", "language": "fr_LU", "proj": 2169, "boundary_detail_level": 6})
+luxembourg.analyser["merge_emergency_points_LU"] = "xxx"
 default_country("europe", "malta", 365307, {"country": "MT", "language": "en", "driving_side": "left", "proj": 32633})
 default_country("europe", "macedonia", 53293, {"country": "MK", "language": "sq", "proj": 32634})
 default_country("europe", "moldova", 58974, {"country": "MD", "language": "ro", "proj": 32635}, download_repo=GEOFABRIK)


### PR DESCRIPTION
Hello everyone,
This PR contains the implementation for an analyser_merger that imports [the dataset](https://data.public.lu/fr/datasets/linstallation-des-points-de-secours-rettungspunkte/) of all emergency access points in Luxembourg.

Issues/Questions:

1. In `missing_official` and `possible_merge` I was unsure what `id` should be set to. Furthermore, I think that this analyser_merge needs a new `item` number. Do I need `update_official`? I am a bit confused about what these different methods imply.
2. Should I be using the dynamic merger? 


@grischard Do you have any suggestions and/or change requests?

Looking forward to getting this merged into Osmose :)