### PR TITLE
Fix boolean expression in 20800

### DIFF
--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -181,7 +181,7 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
             err.append({"class": 30320, "subclass": 1000, "text": T_(u"Use tag \"toll\" instead of \"fee\""),
                         "fix": {"-": ["fee"], "+": {"toll": tags["fee"]}} })
 
-        if tags.get("junction") not in (None, "yes") and (u"highway" not in tags or "area:highway" not in tags):
+        if tags.get("junction") not in (None, "yes") and u"highway" not in tags and "area:highway" not in tags:
             err.append({"class": 20800, "subclass": 0})
 
         if u"oneway" in tags and not (u"highway" in tags or u"railway" in tags or u"aerialway" in tags or u"waterway" in tags or u"aeroway" in tags or u"piste:type" in tags):

--- a/tests/results/sax.test.FR.xml
+++ b/tests/results/sax.test.FR.xml
@@ -5642,58 +5642,6 @@
 <nd ref="677588987" />
 </way>
 </error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269031" version="1" timestamp="2011-06-04T00:12:33Z" changeset="8335277" uid="205520" user="bumf">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311333022" />
-<nd ref="1311333100" />
-<nd ref="1311332810" />
-<nd ref="1311333121" />
-<nd ref="1311332925" />
-<nd ref="1311333097" />
-<nd ref="1311332869" />
-<nd ref="1311333046" />
-<nd ref="1311332848" />
-<nd ref="1311332840" />
-<nd ref="1311333020" />
-<nd ref="1311333165" />
-<nd ref="1311333053" />
-<nd ref="1311333112" />
-<nd ref="1311333044" />
-<nd ref="1311333028" />
-<nd ref="1311332903" />
-<nd ref="1311332786" />
-<nd ref="1311333022" />
-</way>
-</error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="707" subclass="0">
 <location lat="0" lon="0" />
 <way id="140008031" version="5" timestamp="2014-01-01T15:47:59Z" changeset="19747010" uid="10610" user="RedFox">

--- a/tests/results/sax.test.Lang_fr.xml
+++ b/tests/results/sax.test.Lang_fr.xml
@@ -5226,58 +5226,6 @@
 <nd ref="602655388" />
 </way>
 </error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269031" version="1" timestamp="2011-06-04T00:12:33Z" changeset="8335277" uid="205520" user="bumf">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311333022" />
-<nd ref="1311333100" />
-<nd ref="1311332810" />
-<nd ref="1311333121" />
-<nd ref="1311332925" />
-<nd ref="1311333097" />
-<nd ref="1311332869" />
-<nd ref="1311333046" />
-<nd ref="1311332848" />
-<nd ref="1311332840" />
-<nd ref="1311333020" />
-<nd ref="1311333165" />
-<nd ref="1311333053" />
-<nd ref="1311333112" />
-<nd ref="1311333044" />
-<nd ref="1311333028" />
-<nd ref="1311332903" />
-<nd ref="1311332786" />
-<nd ref="1311333022" />
-</way>
-</error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="1398494170" subclass="2648775107729083293">
 <location lat="0" lon="0" />
 <way id="199358242" version="2" timestamp="2013-01-03T16:28:03Z" changeset="14514520" uid="1183576" user="GOSBH">

--- a/tests/results/sax.test.Lang_fr_nl.xml
+++ b/tests/results/sax.test.Lang_fr_nl.xml
@@ -4930,58 +4930,6 @@
 <nd ref="602655388" />
 </way>
 </error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269031" version="1" timestamp="2011-06-04T00:12:33Z" changeset="8335277" uid="205520" user="bumf">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311333022" />
-<nd ref="1311333100" />
-<nd ref="1311332810" />
-<nd ref="1311333121" />
-<nd ref="1311332925" />
-<nd ref="1311333097" />
-<nd ref="1311332869" />
-<nd ref="1311333046" />
-<nd ref="1311332848" />
-<nd ref="1311332840" />
-<nd ref="1311333020" />
-<nd ref="1311333165" />
-<nd ref="1311333053" />
-<nd ref="1311333112" />
-<nd ref="1311333044" />
-<nd ref="1311333028" />
-<nd ref="1311332903" />
-<nd ref="1311332786" />
-<nd ref="1311333022" />
-</way>
-</error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="9001002" subclass="2039567622">
 <location lat="0" lon="0" />
 <relation id="537967" version="19" timestamp="2014-01-05T14:23:40Z" changeset="19823745" uid="10610" user="RedFox">

--- a/tests/results/sax.test.xml
+++ b/tests/results/sax.test.xml
@@ -4916,58 +4916,6 @@
 <nd ref="602655388" />
 </way>
 </error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269031" version="1" timestamp="2011-06-04T00:12:33Z" changeset="8335277" uid="205520" user="bumf">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311333022" />
-<nd ref="1311333100" />
-<nd ref="1311332810" />
-<nd ref="1311333121" />
-<nd ref="1311332925" />
-<nd ref="1311333097" />
-<nd ref="1311332869" />
-<nd ref="1311333046" />
-<nd ref="1311332848" />
-<nd ref="1311332840" />
-<nd ref="1311333020" />
-<nd ref="1311333165" />
-<nd ref="1311333053" />
-<nd ref="1311333112" />
-<nd ref="1311333044" />
-<nd ref="1311333028" />
-<nd ref="1311332903" />
-<nd ref="1311332786" />
-<nd ref="1311333022" />
-</way>
-</error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="9001002" subclass="2039567622">
 <location lat="0" lon="0" />
 <relation id="537967" version="19" timestamp="2014-01-05T14:23:40Z" changeset="19823745" uid="10610" user="RedFox">

--- a/tests/results/sax.test_resume.xml
+++ b/tests/results/sax.test_resume.xml
@@ -4585,32 +4585,6 @@
 </node>
 </error>
 <delete type="way" id="24552698" />
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="9001002" subclass="2039567622">
 <location lat="0" lon="0" />
 <relation id="537967" version="19" timestamp="2014-01-05T14:23:40Z" changeset="19823745" uid="10610" user="RedFox">

--- a/tests/results/sax.test_resume_full.xml
+++ b/tests/results/sax.test_resume_full.xml
@@ -4916,58 +4916,6 @@
 <nd ref="602655388" />
 </way>
 </error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269031" version="1" timestamp="2011-06-04T00:12:33Z" changeset="8335277" uid="205520" user="bumf">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311333022" />
-<nd ref="1311333100" />
-<nd ref="1311332810" />
-<nd ref="1311333121" />
-<nd ref="1311332925" />
-<nd ref="1311333097" />
-<nd ref="1311332869" />
-<nd ref="1311333046" />
-<nd ref="1311332848" />
-<nd ref="1311332840" />
-<nd ref="1311333020" />
-<nd ref="1311333165" />
-<nd ref="1311333053" />
-<nd ref="1311333112" />
-<nd ref="1311333044" />
-<nd ref="1311333028" />
-<nd ref="1311332903" />
-<nd ref="1311332786" />
-<nd ref="1311333022" />
-</way>
-</error>
-<error class="20800" subclass="0">
-<location lat="0" lon="0" />
-<way id="116269034" version="2" timestamp="2013-01-04T20:36:30Z" changeset="14530762" uid="233248" user="zors1843">
-<tag k="highway" v="primary" />
-<tag k="junction" v="roundabout" />
-<nd ref="1311332853" />
-<nd ref="1311333147" />
-<nd ref="1311333167" />
-<nd ref="1311332801" />
-<nd ref="1311333160" />
-<nd ref="1311332938" />
-<nd ref="1311333158" />
-<nd ref="1311332782" />
-<nd ref="1311332808" />
-<nd ref="1311332963" />
-<nd ref="1311332955" />
-<nd ref="2095457231" />
-<nd ref="1311332950" />
-<nd ref="1311333029" />
-<nd ref="1311332975" />
-<nd ref="1311332885" />
-<nd ref="1311332992" />
-<nd ref="1311332796" />
-<nd ref="1311332853" />
-</way>
-</error>
 <error class="9001002" subclass="2039567622">
 <location lat="0" lon="0" />
 <relation id="537967" version="19" timestamp="2014-01-05T14:23:40Z" changeset="19823745" uid="10610" user="RedFox">


### PR DESCRIPTION
If only `highway=*` or `area:highway=*` is used (not both), the 20800 class error is triggered (all roundabouts for example).

This PR requires that both `highway=*` and `area:highway=*` are unset to trigger the error.

See also :
#823 

https://github.com/osm-fr/osmose-backend/commit/3126e1045d36206bcef9c2b13324622da40e35ab#diff-9e304dd3fdef0c5cbd496492c166a748R184