### PR TITLE
Do not warn for wrong layer for culverts. Fixes #934

### DIFF
--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -190,7 +190,7 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         if tags.get("highway") in ("motorway_link", "trunk_link", "primary", "primary_link", "secondary", "secondary_link") and not "maxheight" in tags and not "maxheight:physical" in tags and (("tunnel" in tags and tags["tunnel"] != "no") or tags.get("covered") not in (None, "no")):
             err.append({"class": 71301, "subclass": 0})
 
-        if "waterway" in tags and "level" in tags:
+        if "waterway" in tags and "level" in tags and not ("tunnel" in tags and tags.get('tunnel') == 'culvert'):
             err.append({"class": 30327, "subclass": 0, "fix": [{"-": ["level"]}, {"-": ["level"], "+": {"layer": tags["level"]}}]})
 
         if "highway" in tags and tags.get('junction') == 'roundabout' and tags.get('area') not in (None, 'no', 'false'):

--- a/plugins/TagRemove_Layer.py
+++ b/plugins/TagRemove_Layer.py
@@ -52,7 +52,8 @@ class TagRemove_Layer(Plugin):
             layer = tags.get(u"layer")
             if tags.get(u"landuse"):
                 return {"class": 41101, "subclass": 0}
-            elif tags.get(u"natural") and layer[0] == '-':
+            elif tags.get(u"natural") and layer[0] == '-' \
+                    and not(tags.get(u"natural") == "water" and tags.get(u"tunnel") and tags.get(u"tunnel") == "culvert"):
                 return {"class": 41102, "subclass": 0}
             elif tags.get(u"highway") and tags.get(u"highway") != "steps" and (not tags.get(u"indoor") or tags.get(u"indoor") == "no"):
                 if layer[0] == "-" and (not tags.get(u"tunnel") or tags.get(u"tunnel") == "no"):


### PR DESCRIPTION
I saw #934 and remembered seeing similar problems for natural=water + tunnel=culvert for which I had already a patch ready.

The PR combines a fix for #934 (tunnel=culvert, waterway=ditch, layer=-1) and natural=water + tunnel=culvert.

The latest version did still trigger [a failure](https://travis-ci.com/github/danfos/osmose-backend/jobs/367541646) but that seems to have nothing to do with this patch.