### PR TITLE
Prevent false positives tag typo (`rhn_ref` etc.)

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -87,7 +87,7 @@ FROM
             'operator:rcn', 'operator:rhn', 'operator:rin', 'operator:rmn', 'operator:rpn', 'operator:rwn',
             'rcn_ref', 'rhn_ref', 'rin_ref', 'rmn_ref', 'rpn_ref', 'rwn_ref',
             'expected_rcn_route_relations', 'expected_rhn_route_relations', 'expected_rin_route_relations',
-            'expected_rmn_route_relations', 'expected_rpn_route_relations', 'expected_rwn_route_relations',
+            'expected_rmn_route_relations', 'expected_rpn_route_relations', 'expected_rwn_route_relations'
         ) AND
         NOT key LIKE 'AND_%'
     ) AS keys

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -79,7 +79,15 @@ FROM
             'lock', 'rock',
             'reg_name', 'ref_name',
             'massage', 'message',
-            'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9' -- Tiger mess
+            'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
+
+            -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:
+            'rcn', 'rhn', 'rin', 'rmn', 'rpn', 'rwn',
+            'rcn:name', 'rhn:name', 'rin:name', 'rmn:name', 'rpn:name', 'rwn:name',
+            'operator:rcn', 'operator:rhn', 'operator:rin', 'operator:rmn', 'operator:rpn', 'operator:rwn',
+            'rcn_ref', 'rhn_ref', 'rin_ref', 'rmn_ref', 'rpn_ref', 'rwn_ref',
+            'expected_rcn_route_relations', 'expected_rhn_route_relations', 'expected_rin_route_relations',
+            'expected_rmn_route_relations', 'expected_rpn_route_relations', 'expected_rwn_route_relations',
         ) AND
         NOT key LIKE 'AND_%'
     ) AS keys


### PR DESCRIPTION
Excludes a number of tags used in mapping regional hiking/cycling/etc from the typo query. routes from being seen as typos. The lesser used tags, such as `rhn_ref` (for horse riding routes) got flagged as possible typos of the more common ones (i.e., `rwn_ref`).

I know of six types of regional routing network that are currently in active use on OSM:

* `rcn` (cycling)
* `rhn` (horse riding)
* `rin` (inline skating)
* `rmn` (motorboating)
* `rpn` (canoeing/kayaking)
* `rwn` (walking/hiking)

This PR takes the most common tags used in these networks, and excludes them from the query following the example of the existing exclusions in `sql10`.

--- 

[This issue was spotted in the Dutch OSM community](https://forum.openstreetmap.org/viewtopic.php?id=70162).

---

I think this PR should properly exclude those tags from the typo analysis, but I couldn't find a place to add a test that verifies this in the pytest suite. Does this analyser have any unit tests?

Could someone confirm that this PR works ~and perhaps show me how to cover it with a unit test~?