### PR TITLE
Have natural=water follow waterway=* on checking for layer.

### DIFF
--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -34,7 +34,9 @@ class TagFix_MultipleTag(Plugin):
         self.errors[30323] = self.def_class(item = 3032, level = 3, tags = ['tag', 'fix:chair'],
             title = T_('Watch multiple tags'))
         self.errors[30327] = self.def_class(item = 3032, level = 2, tags = ['tag', 'fix:chair'],
-            title = T_('Waterway with level'))
+            title = T_('Waterway with level'),
+            detail = T_('Level should be used for buildings, shops, amenities, etc.'),
+            trap = T_('Remove level and check if layer is needed instead'))
         self.errors[303210] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Fence with material tag, better use fence_type tag'))
         self.errors[20800] = self.def_class(item = 2080, level = 1, tags = ['tag', 'highway', 'roundabout', 'fix:chair'],

--- a/tests/results/sax.test.FR.xml
+++ b/tests/results/sax.test.FR.xml
@@ -1711,6 +1711,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2469,7 +2471,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2595,7 +2597,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2613,7 +2615,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2631,7 +2633,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test.Lang_fr.xml
+++ b/tests/results/sax.test.Lang_fr.xml
@@ -1613,6 +1613,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2336,7 +2338,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2462,7 +2464,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2480,7 +2482,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2498,7 +2500,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test.Lang_fr_nl.xml
+++ b/tests/results/sax.test.Lang_fr_nl.xml
@@ -1469,6 +1469,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2192,7 +2194,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2318,7 +2320,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2336,7 +2338,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2354,7 +2356,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test.xml
+++ b/tests/results/sax.test.xml
@@ -1469,6 +1469,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2192,7 +2194,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2318,7 +2320,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2336,7 +2338,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2354,7 +2356,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test_resume.xml
+++ b/tests/results/sax.test_resume.xml
@@ -1469,6 +1469,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2192,7 +2194,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2318,7 +2320,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2336,7 +2338,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2354,7 +2356,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test_resume_empty.xml
+++ b/tests/results/sax.test_resume_empty.xml
@@ -1469,6 +1469,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2192,7 +2194,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2318,7 +2320,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2336,7 +2338,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2354,7 +2356,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />

--- a/tests/results/sax.test_resume_full.xml
+++ b/tests/results/sax.test_resume_full.xml
@@ -1469,6 +1469,8 @@
 <classtext lang="pt" title="Hidrovia com etiqueta de level (nível)" />
 <classtext lang="uk" title="Водний шлях з level" />
 <classtext lang="zh_CN" title="水平与等级" />
+<detail lang="en" title="Level should be used for buildings, shops, amenities, etc." />
+<trap lang="en" title="Remove level and check if layer is needed instead" />
 </class>
 <class id="30328" item="3032" source="http://example.com/plugins/Bicycle.validator.mapcss" level="2" tag="tag,highway,cycleway,fix:chair">
 <classtext lang="cs" title="{0.key}={0.value} s {1.key}={1.value}" />
@@ -2192,7 +2194,7 @@
 <class id="41100" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L48" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="Dlouhý vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Langes Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Long Waterway above ground and no bridge" />
+<classtext lang="en" title="Long Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial larga sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی طولانی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau au dessus du sol et sans pont" />
@@ -2318,7 +2320,7 @@
 <class id="41107" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L42" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Waterway underground and no tunnel" />
+<classtext lang="en" title="Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau souterrain sans tunnel" />
@@ -2336,7 +2338,7 @@
 <class id="41108" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L44" level="2" tag="highway,fix:chair">
 <classtext lang="cs" title="dlouhý vodní tok pod zemí a žádný tunel" />
 <classtext lang="de" title="Langes Fließgewässer unterirdisch und kein Tunnel" />
-<classtext lang="en" title="Long Waterway underground and no tunnel" />
+<classtext lang="en" title="Long Waterway/water underground and no tunnel" />
 <classtext lang="es" title="Vía fluvial larga subterránea y sin túnel" />
 <classtext lang="fa" title="راه آبی طولانی زیر زمین است اما تونلی وجود ندارد" />
 <classtext lang="fr" title="Long cours d’eau souterrain sans tunnel" />
@@ -2354,7 +2356,7 @@
 <class id="41109" item="4110" source="http://example.com/plugins/TagRemove_Layer.py#L46" level="3" tag="highway,fix:chair">
 <classtext lang="cs" title="vodní tok nad zemí a žádný most" />
 <classtext lang="de" title="Fließgewässer über Grund und keine Brücke" />
-<classtext lang="en" title="Waterway above ground and no bridge" />
+<classtext lang="en" title="Waterway/water above ground and no bridge" />
 <classtext lang="es" title="Vía fluvial sobre el suelo y sin puente" />
 <classtext lang="fa" title="راه آبی بالای سطح زمین است اما پلی وجود ندارد" />
 <classtext lang="fr" title="Cours d’eau au dessus du sol et sans pont" />


### PR DESCRIPTION
First try in #937 but could not update that PR anymore because I did rebase.

Did analyze #934 further and saw at least one problem was for waterway=* + tunnel=culvert + level=-1. The problem here is the key level, that should be layer instead. This patch adds details to clarify that.

The other problem is for natural=water + tunnel=culvert + level=-1, this patch makes natural=water follow waterway=* on checking layer as that code has already all the good things.

Did check [natural=*](https://wiki.openstreetmap.org/wiki/Key:natural) but only for natural-water layer=* makes sense to me.