### PR TITLE
Add source to Analyser_Merge_Charging_station_FR

### DIFF
--- a/analysers/analyser_merge_charging_station_FR.py
+++ b/analysers/analyser_merge_charging_station_FR.py
@@ -63,6 +63,7 @@ with `capacity=6` can sometimes match to 3 charging station with `capacity=2`'''
                     static1={
                         "amenity": "charging_station",
                         "motorcar": "yes"},
+                    static2={"source": self.source},
                     mapping1={
                         "operator": "n_operateur",
                         "network": "n_enseigne",


### PR DESCRIPTION
Implement a source attribute for the Analyser_Merge_Charging_station_FR

The dataset used for this analyser is an aggregation of multiple other open datasets, that provides an acceptable but not perfect attribution for each data point : a link to the original dataset on data.gouv.fr.

I believe that is sufficient for Osmose to comply with the license.