### PR TITLE
Add source tag to Analyser_Merge_Emergency_Points_LU

### DIFF
--- a/analysers/analyser_merge_emergency_points_LU.py
+++ b/analysers/analyser_merge_emergency_points_LU.py
@@ -48,6 +48,9 @@ class Analyser_Merge_Emergency_Points_LU(Analyser_Merge):
                     static1={
                         "highway": "emergency_access_point"
                     },
+                    static2={
+                        "source": self.source,
+                    },
                     mapping1={
                         "ref": "NAME",
                         "name": "ZUSATZ"


### PR DESCRIPTION
Similar to #960, implement a source attribute for the Analyser_Merge_Emergency_Points_LU.

I checked and there should not be any other Merge Analyser with missing source tag.