### PR TITLE
3180: Ignore ways with oneway:*=no for innaccessible turn restriction

### DIFF
--- a/analysers/analyser_osmosis_relation_restriction.py
+++ b/analysers/analyser_osmosis_relation_restriction.py
@@ -230,7 +230,8 @@ WHERE
     (
         (ways.tags->'oneway' = 'yes' AND ways.nodes[1] = via.id) OR
         (ways.tags->'oneway' = '-1' AND ways.nodes[array_length(ways.nodes, 1)] = via.id)
-    )
+    ) AND
+    NOT EXISTS (SELECT * FROM each(ways.tags) WHERE key LIKE 'oneway:%' AND value = 'no');
 """
 
 sql41 = """
@@ -265,7 +266,8 @@ WHERE
     (
         (ways.tags->'oneway' = 'yes' AND ways.nodes[array_length(ways.nodes, 1)] = via.id) OR
         (ways.tags->'oneway' = '-1' AND ways.nodes[1] = via.id)
-    )
+    ) AND
+    NOT EXISTS (SELECT * FROM each(ways.tags) WHERE key LIKE 'oneway:%' AND value = 'no');
 """
 
 sql50 = """


### PR DESCRIPTION
Fixes #755 by ignoring highways with any `oneway:*=no` for any vehicle class.

That change removes the following errors :
http://osmose.openstreetmap.fr/fr/error/5722c8e5-4211-0c78-9101-d15063e3bfee
http://osmose.openstreetmap.fr/fr/error/50471d69-52b2-dade-e0da-e6e94d0a509d

While keeping the 5 others active for the `france_rhone_alpes_rhone` "country".