### PR TITLE
Add sax plugin for capacity and its subkeys

### DIFF
--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -83,7 +83,7 @@ class Capacity(Plugin):
                         "class": 30913,
                         "subclass": 1,
                         "text": T_(
-                            'Specific "{0}" value "{1}" is larger than total capacity {2}',
+                            'Specific "{0}" value "{1}" should be lower than total capacity {2}',
                             key,
                             value,
                             total_capacity,

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -130,6 +130,10 @@ class Test(TestPluginCommon):
             a.node(None, {"capacity": "1", "capacity:disabled": "a"}),
             {"class": 30912, "subclass": 5},
         )
+        self.check_err(
+            a.node(None, {"capacity": "1", "capacity:disabled": "2"}),
+            {"class": 30913, "subclass": 1},
+        )
 
         assert not a.node(None, {"amenity": "restaurant"})
         assert not a.node(None, {"capacity": "1"})

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -32,7 +32,7 @@ class Capacity(Plugin):
             tags=["tag"],
             title=T_("Invalid capacity value"),
             detail=T_("""A capacity tag value is incorrect."""),
-            resource="https://wiki.openstreetmap.org/wiki/Key:capacity for more information",
+            resource="https://wiki.openstreetmap.org/wiki/Key:capacity",
         )
 
     def node(self, data, tags):

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -45,7 +45,7 @@ class Capacity(Plugin):
 
     def node(self, data, tags):
         if ("capacity" not in tags
-                # Ignore errors that should be reported by generic prefix analysers
+                # Ignore errors that should be reported by generic analysers
                 or tags["capacity"] == ""):
             return
         try:
@@ -70,6 +70,7 @@ class Capacity(Plugin):
                 # Ignore errors that should be reported by generic prefix analysers
                 or key == "capacity:"
                 or value == ""
+
                 or value in ("yes", "no")
             ):
                 continue
@@ -94,6 +95,7 @@ class Capacity(Plugin):
                         total_capacity,
                     ),
                 }
+
             if capacity_int < 0:
                 return {
                     "class": 30912,
@@ -102,11 +104,9 @@ class Capacity(Plugin):
                 }
 
     def way(self, data, tags, nds):
-        # Same check as node
         return self.node(data, tags)
 
     def relation(self, data, tags, members):
-        # Same check as node
         return self.node(data, tags)
 
 
@@ -130,10 +130,10 @@ class Test(TestPluginCommon):
 
         assert a.node(None, {"amenity": "restaurant"}) is None
         assert a.node(None, {"capacity": "1", "capacity:wheelchair": "1"}) is None
+
         assert a.node(None, {"capacity:": "1"}) is None
         assert a.node(None, {"capacity:": ""}) is None
         assert a.node(None, {"capacity": ""}) is None
 
         assert a.node(None, {"capacity": "1", "capacity:": "a"}) is None
-        assert a.node(None, {"capacity:wheelchair": "1"}) is None
         assert a.node(None, {"capacity:wheelchair": "1"}) is None

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -36,14 +36,12 @@ class Capacity(Plugin):
         )
 
     def node(self, data, tags):
-        try:
-            if tags["capacity"] == "":
+        if ("capacity" not in tags
                 # Ignore errors that should be reported by generic prefix analysers
-                return
-            total_capacity = int(tags["capacity"])
-        except KeyError:
-            # No capacity tag
+                or tags["capacity"] == ""):
             return
+        try:
+            total_capacity = int(tags["capacity"])
         except ValueError:
             return {
                 "class": 35001,

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -1,0 +1,133 @@
+from modules.OsmoseTranslation import T_
+from plugins.Plugin import Plugin
+from plugins.Plugin import TestPluginCommon
+
+###########################################################################
+##                                                                       ##
+## Copyrights Éric Gillet 2020                                           ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+
+class Capacity(Plugin):
+    def init(self, logger):
+        Plugin.init(self, logger)
+
+        self.errors[35001] = self.def_class(
+            item=3500,
+            level=2,
+            tags=["tag"],
+            title=T_("Invalid capacity value"),
+            detail=T_("""A capacity tag value is incorrect."""),
+            resource="https://wiki.openstreetmap.org/wiki/Key:capacity for more information",
+        )
+
+    def node(self, data, tags):
+        try:
+            if tags["capacity"] == "":
+                # Ignore errors that should be reported by generic prefix analysers
+                return
+            total_capacity = int(tags["capacity"])
+        except KeyError:
+            # No capacity tag
+            return
+        except ValueError:
+            return {
+                "class": 35001,
+                "subclass": 0,
+                "text": T_('Invalid "{0}" value: {1}', "capacity", tags["capacity"]),
+            }
+
+        if total_capacity < 0:
+            return {
+                "class": 35001,
+                "subclass": 0,
+                "text": T_('Invalid "{0}" value: {1}', "capacity", total_capacity),
+            }
+
+        for key, value in tags.items():
+            if (
+                not key.startswith("capacity:")
+                # Ignore errors that should be reported by generic prefix analysers
+                or key == "capacity:"
+                or value == ""
+                or value in ("yes", "no")
+            ):
+                continue
+
+            try:
+                capacity_int = int(value)
+            except ValueError:
+                return {
+                    "class": 35001,
+                    "subclass": 0,
+                    "text": T_('Invalid "{0}" value: {1}', key, value),
+                }
+
+            if capacity_int > total_capacity:
+                return {
+                    "class": 35001,
+                    "subclass": 1,
+                    "text": T_(
+                        'Specific "{0}" value {1} is larger than total capacity {2}',
+                        key,
+                        value,
+                        total_capacity,
+                    ),
+                }
+            if capacity_int < 0:
+                return {
+                    "class": 35001,
+                    "subclass": 0,
+                    "text": T_('Invalid "{0}" value: {1}', key, tags["capacity"]),
+                }
+
+    def way(self, data, tags, nds):
+        # Same check as node
+        return self.node(data, tags)
+
+    def relation(self, data, tags, members):
+        # Same check as node
+        return self.node(data, tags)
+
+
+class Test(TestPluginCommon):
+    def test(self):
+        a = Capacity(None)
+        a.init(None)
+
+        self.check_err(a.node(None, {"capacity": "a"}), {"class": 35001, "subclass": 0})
+        self.check_err(
+            a.node(None, {"capacity": "-1"}), {"class": 35001, "subclass": 0}
+        )
+        self.check_err(
+            a.node(None, {"capacity": "1", "capacity:disabled": "-1"}),
+            {"class": 35001, "subclass": 1},
+        )
+        self.check_err(
+            a.node(None, {"capacity": "1", "capacity:disabled": "a"}),
+            {"class": 35001, "subclass": 1},
+        )
+
+        assert a.node(None, {"amenity": "restaurant"}) is None
+        assert a.node(None, {"capacity": "1", "capacity:wheelchair": "1"}) is None
+        assert a.node(None, {"capacity:": "1"}) is None
+        assert a.node(None, {"capacity:": ""}) is None
+        assert a.node(None, {"capacity": ""}) is None
+
+        assert a.node(None, {"capacity": "1", "capacity:": "a"}) is None
+        assert a.node(None, {"capacity:wheelchair": "1"}) is None
+        assert a.node(None, {"capacity:wheelchair": "1"}) is None

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -26,12 +26,20 @@ class Capacity(Plugin):
     def init(self, logger):
         Plugin.init(self, logger)
 
-        self.errors[35001] = self.def_class(
-            item=3500,
+        self.errors[30912] = self.def_class(
+            item=3091,
             level=2,
             tags=["tag"],
             title=T_("Invalid capacity value"),
-            detail=T_("""A capacity tag value is incorrect."""),
+            detail=T_("""Capacity tags should be positive integers."""),
+            resource="https://wiki.openstreetmap.org/wiki/Key:capacity",
+        )
+        self.errors[30913] = self.def_class(
+            item=3091,
+            level=2,
+            tags=["tag"],
+            title=T_("Specific capacity is greater than total capacity"),
+            detail=T_("""A capacity:* value is greater than the total capacity."""),
             resource="https://wiki.openstreetmap.org/wiki/Key:capacity",
         )
 
@@ -44,16 +52,16 @@ class Capacity(Plugin):
             total_capacity = int(tags["capacity"])
         except ValueError:
             return {
-                "class": 35001,
-                "subclass": 0,
-                "text": T_('Invalid "{0}" value: {1}', "capacity", tags["capacity"]),
+                "class": 30912,
+                "subclass": 4,
+                "text": T_('"{0}" value "{1}" is not an integer', "capacity", tags["capacity"]),
             }
 
         if total_capacity < 0:
             return {
-                "class": 35001,
-                "subclass": 0,
-                "text": T_('Invalid "{0}" value: {1}', "capacity", total_capacity),
+                "class": 30913,
+                "subclass": 5,
+                "text": T_('"{0}" value "{1}" is negative', "capacity", total_capacity),
             }
 
         for key, value in tags.items():
@@ -70,14 +78,14 @@ class Capacity(Plugin):
                 capacity_int = int(value)
             except ValueError:
                 return {
-                    "class": 35001,
-                    "subclass": 0,
-                    "text": T_('Invalid "{0}" value: {1}', key, value),
+                    "class": 30912,
+                    "subclass": 4,
+                    "text": T_('"{0}" value "{1}" is not an integer', key, value),
                 }
 
             if capacity_int > total_capacity:
                 return {
-                    "class": 35001,
+                    "class": 30913,
                     "subclass": 1,
                     "text": T_(
                         'Specific "{0}" value {1} is larger than total capacity {2}',
@@ -88,9 +96,9 @@ class Capacity(Plugin):
                 }
             if capacity_int < 0:
                 return {
-                    "class": 35001,
-                    "subclass": 0,
-                    "text": T_('Invalid "{0}" value: {1}', key, tags["capacity"]),
+                    "class": 30912,
+                    "subclass": 5,
+                    "text": T_('"{0}" value "{1}" is negative', key, value),
                 }
 
     def way(self, data, tags, nds):
@@ -107,17 +115,17 @@ class Test(TestPluginCommon):
         a = Capacity(None)
         a.init(None)
 
-        self.check_err(a.node(None, {"capacity": "a"}), {"class": 35001, "subclass": 0})
+        self.check_err(a.node(None, {"capacity": "a"}), {"class": 30912, "subclass": 4})
         self.check_err(
-            a.node(None, {"capacity": "-1"}), {"class": 35001, "subclass": 0}
+            a.node(None, {"capacity": "-1"}), {"class": 30912, "subclass": 5}
         )
         self.check_err(
             a.node(None, {"capacity": "1", "capacity:disabled": "-1"}),
-            {"class": 35001, "subclass": 1},
+            {"class": 30912, "subclass": 5},
         )
         self.check_err(
             a.node(None, {"capacity": "1", "capacity:disabled": "a"}),
-            {"class": 35001, "subclass": 1},
+            {"class": 30912, "subclass": 5},
         )
 
         assert a.node(None, {"amenity": "restaurant"}) is None

--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -71,7 +71,6 @@ class Capacity(Plugin):
                 # Ignore errors that should be reported by generic prefix analysers
                 or key == "capacity:"
                 or value == ""
-
                 or value in ("yes", "no")
             ):
                 continue

--- a/tests/results/sax.test_resume.xml
+++ b/tests/results/sax.test_resume.xml
@@ -1758,6 +1758,14 @@
 <classtext lang="uk" title="Код кольору повинен мати '#' далі 3 або 6 цифр" />
 <classtext lang="zh_CN" title="颜色代码应以“＃”开头，后跟3或6位数字" />
 </class>
+<class id="30912" item="3091" source="http://example.com/plugins/Capacity.py#L35" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Invalid capacity value" />
+<detail lang="en" title="Capacity tags should be positive integers." />
+</class>
+<class id="30913" item="3091" source="http://example.com/plugins/Capacity.py#L43" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Specific capacity is greater than total capacity" />
+<detail lang="en" title="A capacity:* value is greater than the total capacity." />
+</class>
 <class id="30931" item="3093" source="http://example.com/plugins/Website.py#L40" level="2" tag="value,fix:chair">
 <classtext lang="cs" title="URL obsahuje mezeru" />
 <classtext lang="de" title="Der URL enthält ein Leerzeichen" />

--- a/tests/results/sax.test_resume_empty.xml
+++ b/tests/results/sax.test_resume_empty.xml
@@ -1758,6 +1758,14 @@
 <classtext lang="uk" title="Код кольору повинен мати '#' далі 3 або 6 цифр" />
 <classtext lang="zh_CN" title="颜色代码应以“＃”开头，后跟3或6位数字" />
 </class>
+<class id="30912" item="3091" source="http://example.com/plugins/Capacity.py#L35" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Invalid capacity value" />
+<detail lang="en" title="Capacity tags should be positive integers." />
+</class>
+<class id="30913" item="3091" source="http://example.com/plugins/Capacity.py#L43" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Specific capacity is greater than total capacity" />
+<detail lang="en" title="A capacity:* value is greater than the total capacity." />
+</class>
 <class id="30931" item="3093" source="http://example.com/plugins/Website.py#L40" level="2" tag="value,fix:chair">
 <classtext lang="cs" title="URL obsahuje mezeru" />
 <classtext lang="de" title="Der URL enthält ein Leerzeichen" />

--- a/tests/results/sax.test_resume_full.xml
+++ b/tests/results/sax.test_resume_full.xml
@@ -1758,6 +1758,14 @@
 <classtext lang="uk" title="Код кольору повинен мати '#' далі 3 або 6 цифр" />
 <classtext lang="zh_CN" title="颜色代码应以“＃”开头，后跟3或6位数字" />
 </class>
+<class id="30912" item="3091" source="http://example.com/plugins/Capacity.py#L35" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Invalid capacity value" />
+<detail lang="en" title="Capacity tags should be positive integers." />
+</class>
+<class id="30913" item="3091" source="http://example.com/plugins/Capacity.py#L43" resource="https://wiki.openstreetmap.org/wiki/Key:capacity" level="2" tag="tag">
+<classtext lang="en" title="Specific capacity is greater than total capacity" />
+<detail lang="en" title="A capacity:* value is greater than the total capacity." />
+</class>
 <class id="30931" item="3093" source="http://example.com/plugins/Website.py#L40" level="2" tag="value,fix:chair">
 <classtext lang="cs" title="URL obsahuje mezeru" />
 <classtext lang="de" title="Der URL enthält ein Leerzeichen" />


### PR DESCRIPTION
This plugins check that :
* `capacity=*` and `capacity:*=*` values are positive integers
* `capacity:*=*` subvalues are inferior or equal to `capacity=*`

https://wiki.openstreetmap.org/wiki/Key:capacity

I picked 3500 as an item number, but I'm not sure how those should be allocated.