### PR TITLE
Avoid false positive detections of railway signals

### DIFF
--- a/merge_data/mapillary-street-objects.mapping.json
+++ b/merge_data/mapillary-street-objects.mapping.json
@@ -87,6 +87,9 @@
       {
         "railway": "level_crossing",
         "crossing:light": "yes"
+      },
+      {
+        "railway": "signal"
       }
     ],
     "generate_tags": {


### PR DESCRIPTION
Prevent false positives due to railway signals. Example: http://osmose.openstreetmap.fr/nl/error/fed5255c-48a9-0e25-56c7-4cc31bc92657
Mapillary flags a signal (correctly) as a traffic light. However, the traffic light applies to trains and is hence tagged as railway=signal