### PR TITLE
Relax key characters for hazmat:*

### DIFF
--- a/plugins/TagFix_BadKey.py
+++ b/plugins/TagFix_BadKey.py
@@ -60,7 +60,6 @@ separator '_' or ':'. See
                                 "voltage-high", "voltage-low",
                                 "cityracks.housenum", "cityracks.installed", "cityracks.large", "cityracks.rackid", "cityracks.small", "cityracks.street", # NYC amenity=bicycle_parking
                                 "strassen-nrw", # DE import
-                                "ref",
                                 "hazmat",
                              ) )
 
@@ -103,7 +102,6 @@ class Test(TestPluginCommon):
                   "ISO3166-1", "ISO3166-1:alpha2", "nhd-shp:fdate",
                   "railway:memor2+", "railway:tbl1+",
                   "strassen-nrw:abs",
-                  "ref:clochers.org",
                   "hazmat:4.3",
                  ]:
             assert not a.node(None, {k: '1'}), ("key='{0}'".format(k))

--- a/plugins/TagFix_BadKey.py
+++ b/plugins/TagFix_BadKey.py
@@ -60,6 +60,8 @@ separator '_' or ':'. See
                                 "voltage-high", "voltage-low",
                                 "cityracks.housenum", "cityracks.installed", "cityracks.large", "cityracks.rackid", "cityracks.small", "cityracks.street", # NYC amenity=bicycle_parking
                                 "strassen-nrw", # DE import
+                                "ref",
+                                "hazmat",
                              ) )
 
         self.exceptions_whole = set((
@@ -101,6 +103,8 @@ class Test(TestPluginCommon):
                   "ISO3166-1", "ISO3166-1:alpha2", "nhd-shp:fdate",
                   "railway:memor2+", "railway:tbl1+",
                   "strassen-nrw:abs",
+                  "ref:clochers.org",
+                  "hazmat:4.3",
                  ]:
             assert not a.node(None, {k: '1'}), ("key='{0}'".format(k))
 


### PR DESCRIPTION
Exempt ~~`ref:*` and~~ `hazmat:*` from the requirement for alphanumeric subkeys in item 3050, class 30501.

/ref #948