### PR TITLE
revert to long form for mounts to allow changing

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     shm_size: 1g
     image: postgis/postgis:13-3.0-alpine
     volumes:
-      - ./postgis-init.sh:/docker-entrypoint-initdb.d/postgis-init.sh:ro
+      - type: bind
+        source: ./postgis-init.sh
+        target: /docker-entrypoint-initdb.d/postgis-init.sh
       - pgdata:/var/lib/postgresql/data
       ## Alternate, to keep the data outside of container
       #- ./postgresql-data:/var/lib/postgresql/data
@@ -28,8 +30,13 @@ services:
     depends_on:
       - postgis
     volumes:
-      - ../osmose_config_password.py:/opt/osmose-backend/osmose_config_password.py:ro
-      - ./work:/data/work/osmose
+      - type: bind
+        source: ../osmose_config_password.py
+        target: /opt/osmose-backend/osmose_config_password.py
+        read_only: true
+      - type: bind
+        source: ./work
+        target: /data/work/osmose
     environment:
       - DB_HOST=postgis
       - JUPYTER_RUNTIME_DIR=/tmp


### PR DESCRIPTION
long form is not only more readable, but also allows to change the mounts by adding additional compose configs, specifically when replacing mounts by tmpfs.