### PR TITLE
PyKOpeningHours was integrated into KOpeningHours

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,11 @@ jobs:
           protobuf-compiler \
           osmosis \
           cmake \
+          extra-cmake-modules \
           qtbase5-dev \
           flex \
           bison
+
     - uses: actions/checkout@v2
 
     - name: Setup env
@@ -38,6 +40,7 @@ jobs:
         chown $USER /data/work/$USER /data/work/$USER/cache
         # compile osm pbf parser
         cd modules/osm_pbf_parser && make && cd ../../
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -90,9 +93,11 @@ jobs:
           protobuf-compiler \
           osmosis \
           cmake \
+          extra-cmake-modules \
           qtbase5-dev \
           flex \
           bison
+
     - uses: actions/checkout@v2
 
     - name: Setup env
@@ -102,6 +107,7 @@ jobs:
         chown $USER /data/work/$USER /data/work/$USER/cache
         # compile osm pbf parser
         cd modules/osm_pbf_parser && make && cd ../../
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -160,9 +166,11 @@ jobs:
           protobuf-compiler \
           osmosis \
           cmake \
+          extra-cmake-modules \
           qtbase5-dev \
           flex \
           bison
+
     - uses: actions/checkout@v2
 
     - name: Setup env
@@ -172,6 +180,7 @@ jobs:
         chown $USER /data/work/$USER /data/work/$USER/cache
         # compile osm pbf parser
         cd modules/osm_pbf_parser && make && cd ../../
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
     - protobuf-compiler
     # for PyKOpeningHours
     - cmake
+    - extra-cmake-modules
     - qtbase5-dev
     - flex
     - bison

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bison \
         cmake \
+        extra-cmake-modules \
         flex \
         g++ \
         gcc \

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium
-git+git://github.com/dfaure/PyKOpeningHours.git@v1.3.6
+git+https://invent.kde.org/libraries/kopeninghours.git@83f1435
 libarchive
 
 # Tests


### PR DESCRIPTION
at the request/suggestion of the KOpeningHours maintainer.

This brings in some bugfixes as well based on the first
set of results from osmose.

This brings in extra-cmake-modules as a direct dependency
(PyKOpeningHours was previously fetching that on its own,
but this makes less sense for KOpeningHours itself).