### PR TITLE
Add OSM data timestamp to logs

### DIFF
--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -213,6 +213,7 @@ class OsmOsisManager:
     osm_state = OsmPbfReader(dst_pbf, state_file=state_file).timestamp()
 
     giscurs.execute("UPDATE metainfo SET tstamp = %s", [osm_state])
+    self.logger.sub().log("OSM data timestamp: %s" % osm_state)
 
     gisconn.commit()
     giscurs.close()

--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -213,7 +213,7 @@ class OsmOsisManager:
     osm_state = OsmPbfReader(dst_pbf, state_file=state_file).timestamp()
 
     giscurs.execute("UPDATE metainfo SET tstamp = %s", [osm_state])
-    self.logger.sub().log("OSM data timestamp: %s" % osm_state)
+    self.logger.sub().log("OSM data timestamp: {}".format(osm_state))
 
     gisconn.commit()
     giscurs.close()


### PR DESCRIPTION
Adding timestamp of OSM data into the logfile to help debugging why some data did not update as expected