### PR TITLE
Traffic light fix

### DIFF
--- a/merge_data/mapillary-street-objects.mapping.json
+++ b/merge_data/mapillary-street-objects.mapping.json
@@ -86,7 +86,7 @@
       },
       {
         "highway": "crossing",
-        "flashing_lights": "None"
+        "flashing_lights": null
       },
       {
         "railway": "level_crossing",


### PR DESCRIPTION
Fixed flashing_lights' property in merge_data/mapillary-street-objects.mapping.json.
Has been changed from "None" to null.