### PR TITLE
Update postgis to 3.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 services:
   postgis:
     shm_size: 1g
-    image: postgis/postgis:13-3.0-alpine
+    image: postgis/postgis:13-3.1-alpine
     volumes:
       - type: bind
         source: ./postgis-init.sh


### PR DESCRIPTION
Verified updated version with Bhutan analysis.
Expectation is to benefit from performance improvements, see
http://blog.cleverelephant.ca/2020/12/waiting-postgis-31-1.html

I grepped the source and none of the deprecated/changed methods are used.
https://git.osgeo.org/gitea/postgis/postgis/raw/tag/3.1.0/NEWS