### PR TITLE
use a dev tag for development image

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         PIP_INSTALL: -r requirements-dev.txt
+    image: osm-fr/osmose_backend:dev
     volumes:
       - ..:/opt/osmose-backend
       - ../osmose_config_password-example.py:/opt/osmose-backend/osmose_config_password.py:ro


### PR DESCRIPTION
use a specific tag for development images. This enables coexistence of development and production images on same docker environment