### PR TITLE
Improve missing oneway check #1123

### DIFF
--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -1033,9 +1033,6 @@
     ],
     "conflation": 200,
     "title": "one-directional roads",
-    "only_for": [
-      "NL"
-    ],
     "object": [
       "regulatory--no-entry--g1"
     ],

--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -1041,8 +1041,16 @@
     ],
     "select_tags": [
       {
+        "waterway": null,
+        "oneway": null
+      },
+      {
         "highway": null,
         "oneway": null
+      },
+      {
+        "highway": null,
+        "oneway:conditional": null
       },
       {
         "highway": null,
@@ -1105,9 +1113,7 @@
         "access:backward": null
       }
     ],
-    "generate_tags": {
-      "oneway": "yes"
-    }
+    "generate_tags": {}
   },
   {
     "item": 8300,


### PR DESCRIPTION
- Missing detection of `oneway` on `waterway` (example: http://osmose.openstreetmap.fr/en/error/a61ce93c-4264-25e9-3f8f-7cc0576ee71e - although not tagged yet as such)
- Add missing `oneway:conditional` check (although the ones I found also have (or should have had) `oneway:bicycle=no`, taginfo suggests there's 2k ways with `oneway:conditional`)
- Remove suggestion to add `oneway=yes` (as sometimes oneway:* tags should be used)