### PR TITLE
Update KOpeningHours to get several bugfixes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium
-git+https://invent.kde.org/libraries/kopeninghours.git@76175b9
+git+https://invent.kde.org/libraries/kopeninghours.git@74bd4c5
 libarchive
 
 # Tests


### PR DESCRIPTION
Most notably https://invent.kde.org/libraries/kopeninghours/-/merge_requests/58
to add support for "Oct 1-Nov Su[-4] 09:00-12:00" (which people use
even if it's not in the official spec, because the JS implementation
supports it).

This also includes many other fixes that make the parser more tolerant,
turning parse errors into normalization suggestions.