### PR TITLE
Do not display unnecessary error message

### DIFF
--- a/osmose_run.py
+++ b/osmose_run.py
@@ -211,7 +211,8 @@ def execc(conf, logger, analysers, options, osmosis_manager):
         logger.log(logger.log_av_r + conf.country + " : " + analyser + logger.log_ap)
 
         password = conf.analyser.get(analyser)
-        if not password or password == "xxx":
+
+        if not options.skip_upload and (not password or password == "xxx"):
             logger.sub().err("No password to upload result to %s" % conf.updt_url)
 
         try:


### PR DESCRIPTION
When osmose_run.py is run with the "--skip-upload", it shouldn't display an error message about missing password for upload.

Note: This is not a big fix for Osmose, but this is my first pull request on GitHub. I need to understand the development flow and get familiar with it.