### PR TITLE
Dynamic millesime for merge analysers using IGN BDTOPO

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -487,6 +487,12 @@ class SourceHttpLastModified(Source):
             downloader.HTTP_DATE_FMT,
         )
 
+class SourceIGN(Source):
+    """Get millesime from IGN BDTOPO MetaData"""
+    def get_millesime(self) -> datetime.datetime:
+        response = downloader.get("https://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/meta.json")
+        response.raise_for_status()
+        return datetime.datetime.fromisoformat(response.json()["millesime"])
 
 class Parser:
     def header(self):
@@ -1154,7 +1160,7 @@ OpenData and OSM.'''))
             typeSelect = {'N': 'NULL', 'W': 'NULL', 'R': 'NULL'}
             typeGeom = {'N': 'NULL', 'W': 'NULL', 'R': 'NULL'}
             typeShape = {'N': 'NULL', 'W': 'NULL', 'R': 'NULL'}
-        self.logger.log(u"Retrive OSM item")
+        self.logger.log(u"Retrieve OSM item")
         where = Select.where_tags(self.conflate.select.tags)
         self.run("CREATE TEMP TABLE osm_item AS " +
             ("UNION ALL".join(

--- a/analysers/analyser_merge_cemetery_FR.py
+++ b/analysers/analyser_merge_cemetery_FR.py
@@ -21,7 +21,7 @@
 ###########################################################################
 
 from modules.OsmoseTranslation import T_
-from .Analyser_Merge import Analyser_Merge, Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import Analyser_Merge, SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Public_Cemetery_FR(Analyser_Merge):
@@ -33,7 +33,7 @@ class Analyser_Merge_Public_Cemetery_FR(Analyser_Merge):
         self.init(
             "https://ign.fr",
             "IGN-Cimetière",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/cimetiere.gpkg.gz")),
             LoadGeomCentroid(
                 select = {"etat_de_l_objet": "En service"}),

--- a/analysers/analyser_merge_man_made_FR.py
+++ b/analysers/analyser_merge_man_made_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge_Dynamic import Analyser_Merge_Dynamic, SubAnalyser_Merge_Dynamic
-from .Analyser_Merge import Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Man_Made_FR(Analyser_Merge_Dynamic):
@@ -132,7 +132,7 @@ class SubAnalyser_Merge_Man_Made_FR(SubAnalyser_Merge_Dynamic):
         self.init(
             "https://ign.fr",
             "IGN-Construction ponctuelle",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/construction_ponctuelle.gpkg.gz")),
             LoadGeomCentroid(
                 select = select),

--- a/analysers/analyser_merge_natural_FR.py
+++ b/analysers/analyser_merge_natural_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge_Dynamic import Analyser_Merge_Dynamic, SubAnalyser_Merge_Dynamic
-from .Analyser_Merge import Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Natural_FR(Analyser_Merge_Dynamic):
@@ -275,7 +275,7 @@ class SubAnalyser_Merge_Orography_FR(SubAnalyser_Merge_Dynamic):
         self.init(
             "https://ign.fr",
             "IGN-Détail orographique",
-            GPKG(Source(attribution = "IGN", millesime = "12/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/detail_orographique.gpkg.gz")),
             LoadGeomCentroid(
                 select = select),

--- a/analysers/analyser_merge_poi_FR.py
+++ b/analysers/analyser_merge_poi_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge_Dynamic import Analyser_Merge_Dynamic, SubAnalyser_Merge_Dynamic
-from .Analyser_Merge import Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_POI_FR(Analyser_Merge_Dynamic):
@@ -304,7 +304,7 @@ class SubAnalyser_Merge_POI_FR(SubAnalyser_Merge_Dynamic):
         self.init(
             "https://ign.fr",
             "IGN-Zone d'activité ou d'intérêt",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/zone_d_activite_ou_d_interet.gpkg.gz")),
             LoadGeomCentroid(
                 select = select),

--- a/analysers/analyser_merge_reservoir_FR.py
+++ b/analysers/analyser_merge_reservoir_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge_Dynamic import Analyser_Merge_Dynamic, SubAnalyser_Merge_Dynamic
-from .Analyser_Merge import Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Reservoir_FR(Analyser_Merge_Dynamic):
@@ -71,7 +71,7 @@ class SubAnalyser_Merge_Reservoir_FR(SubAnalyser_Merge_Dynamic):
         self.init(
             "https://ign.fr",
             "IGN-Construction ponctuelle",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/reservoir.gpkg.gz")),
             LoadGeomCentroid(
                 select = select),

--- a/analysers/analyser_merge_water_FR.py
+++ b/analysers/analyser_merge_water_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge_Dynamic import Analyser_Merge_Dynamic, SubAnalyser_Merge_Dynamic
-from .Analyser_Merge import Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Water_FR(Analyser_Merge_Dynamic):
@@ -125,7 +125,7 @@ class SubAnalyser_Merge_Water_FR(SubAnalyser_Merge_Dynamic):
         self.init(
             "https://ign.fr",
             "IGN-Détail Hydrographique",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/detail_hydrographique.gpkg.gz")),
             LoadGeomCentroid(
                 select = select),

--- a/analysers/disabled/analyser_merge_highway_ref_FR.py
+++ b/analysers/disabled/analyser_merge_highway_ref_FR.py
@@ -21,7 +21,7 @@
 ###########################################################################
 
 from modules.OsmoseTranslation import T_
-from .Analyser_Merge import Analyser_Merge, Source, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
+from .Analyser_Merge import Analyser_Merge, SourceIGN, GPKG, LoadGeomCentroid, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Highway_Ref_FR(Analyser_Merge):
@@ -33,7 +33,7 @@ class Analyser_Merge_Highway_Ref_FR(Analyser_Merge):
         self.init(
             "https://ign.fr",
             "IGN-Point de repère",
-            GPKG(Source(attribution = "IGN", millesime = "09/2020", gzip = True,
+            GPKG(SourceIGN(attribution = "IGN", gzip = True,
                     fileUrl = "http://files.opendatarchives.fr/professionnels.ign.fr/bdtopo/latest/geopackage/point_de_repere.gpkg.gz")),
             LoadGeomCentroid(
                 where = lambda res: res["route"][0] in ('A', 'D', 'N'),


### PR DESCRIPTION
Currently, the millesime of all the merge analysers using teh IGN BDTOPO files is not up-to-date (2020-09 instead of 2020-12). So I have implemented the extraction of the millesime from the MetaData of the GPKG files.

It is not well-optimized, since the GPKG file is read twice, firstly to extract the millesime, secondly to import the data into the database. Is this acceptable?