### PR TITLE
Handle err=3 from pyosmium-up-to-date as an error

### DIFF
--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -424,10 +424,9 @@ class OsmOsisManager:
           cmd += ["--force-update-of-old-planet"]
           cmd += [pbf_file]
           # pyosmium-up-to-date returns:
-          #   - 0 on full update
+          #   - 0 on full update, or if pbf is already up-to-date
           #   - 1 on partial update
-          #   - 3 when no update to be done - TODO: to be removed with pyosmium 3.1.3
-          ret = self.logger.execute_err(cmd, valid_return_code=(0, 1, 3))
+          ret = self.logger.execute_err(cmd, valid_return_code=(0, 1))
 
           if ret == 0 or ret == 1:
             shutil.move(tmp_pbf_file, pbf_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests
 transporthours
 pyproj >= 2.1.0
 Unidecode
-osmium
+osmium >= 3.1.3
 git+https://invent.kde.org/libraries/kopeninghours.git@74bd4c5
 libarchive
 


### PR DESCRIPTION
With pyosmium 3.1.3, pyosmium-up-to-date sends err=0 instead of 3 when pbf
doesn't need any update.