### PR TITLE
raise_for_status on get_millesime

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -445,8 +445,9 @@ class SourceDataGouv(Source):
         super().__init__(**kwargs)
 
     def get_millesime(self) -> datetime.datetime:
-        last_modified = downloader.get(f"{self.data_gouv_api_base}/datasets/{self.dataset}/resources/{self.resource}/").json()["last_modified"]
-        return datetime.datetime.fromisoformat(last_modified)
+        response = downloader.get(f"{self.data_gouv_api_base}/datasets/{self.dataset}/resources/{self.resource}/")
+        response.raise_for_status()
+        return datetime.datetime.fromisoformat(response.json()["last_modified"])
 
 
 class SourcePublicLu(SourceDataGouv):
@@ -473,8 +474,9 @@ class SourceOpenDataSoft(Source):
         super().__init__(**kwargs)
 
     def get_millesime(self) -> datetime.datetime:
-        last_modified = downloader.get(f"{self.base_url}/api/datasets/1.0/{self.dataset}").json()["metas"]["data_processed"]
-        return datetime.datetime.fromisoformat(last_modified)
+        response = downloader.get(f"{self.base_url}/api/datasets/1.0/{self.dataset}")
+        response.raise_for_status()
+        return datetime.datetime.fromisoformat(response.json()["metas"]["data_processed"])
 
 
 class SourceHttpLastModified(Source):


### PR DESCRIPTION
Fixes #1211

Raise an exception early when the millesime can't be fetched because of an HTTP error.