### PR TITLE
Allow quick fix on post_box_FR analyser

### DIFF
--- a/analysers/analyser_merge_post_box_FR.py
+++ b/analysers/analyser_merge_post_box_FR.py
@@ -49,7 +49,6 @@ class Analyser_Merge_Post_box_FR(Analyser_Merge):
                     tags = {"amenity": "post_box"}),
                 osmRef = "ref",
                 conflationDistance = 50,
-                missing_official_fix = False,
                 mapping = Mapping(
                     static1 = {
                         "amenity": "post_box",


### PR DESCRIPTION
As this analyser is the only one not offering tag suggestions for creating new post boxes, I submit this PR in order to make tools able to get directly post box ref.