### PR TITLE
Analyser_Merge_Poste_FR: remove postcode

### DIFF
--- a/analysers/analyser_merge_poste_FR.py
+++ b/analysers/analyser_merge_poste_FR.py
@@ -68,7 +68,6 @@ class Analyser_Merge_Poste_FR(Analyser_Merge):
                             "post_annex" if res["Libellé_du_site"].endswith(" AP") else # Bureau de poste annexe
                             "post_partner" if res["Libellé_du_site"].endswith(" RP") else # Relais poste commerçant
                             None, # BP: Bureau de poste; other
-                        "addr:postcode": "Code_postal",
                         # localite
                         # pays
                         "atm": lambda res: self.bool[res["Distributeur_de_billets"]],


### PR DESCRIPTION
This tag was used in this integration since at least 2013, when I believe postcodes were not as well mapped, so having a "fallback" from the post office for Nominatim and other geocoders was a good idea.

As far as I know postcodes are [pretty well mapped as areas today in France](http://taginfo.openstreetmap.fr/keys/addr%3Apostcode). So the benefit of this tag are slim, while they :

- May confuse geocoders (prefering such nodes instead of more detailed zones for some reason)
- Incite contributors to add this tag to other post offices or other objects while it's not necessary.

What do you think ?