### PR TITLE
New public transport analysis

### DIFF
--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -427,6 +427,7 @@ $$;
 sql101 = """
 CREATE TEMP TABLE route_linestring AS
 SELECT id,
+       relations.tags->'route' AS public_transport_mode,
        ST_Transform(generate_linestring_geom(id), {0}) AS geom
 FROM relations
 WHERE relations.tags->'type' = 'route'
@@ -500,6 +501,7 @@ JOIN (
 ) AS y ON platform_that_can_project.route_id = y.route_id 
 WHERE ST_DWithin(route_linestring.geom, platform_that_can_project.stop, 50) AND
   NOT ST_Intersects(ST_Buffer(route_linestring.geom,50,'side=right'), platform_that_can_project.stop) AND
+  route_linestring.public_transport_mode IN ('bus', 'trolleybus', 'coach', 'share_taxi', 'school_bus') AND
   platform_that_can_project.stop_order <> last_platform AND
   platform_that_can_project.stop_order <> 1
 """

--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -490,9 +490,18 @@ SELECT
   platform_that_can_project.stop_id, 
   ST_AsText(ST_Transform(platform_that_can_project.stop, 4326))
 FROM platform_that_can_project
-JOIN route_linestring ON route_linestring.id = platform_that_can_project.route_id    
+JOIN route_linestring ON route_linestring.id = platform_that_can_project.route_id   
+JOIN (
+  SELECT 
+    platform_that_can_project.route_id AS route_id,
+    MAX(platform_that_can_project.stop_order) AS last_platform
+  FROM platform_that_can_project 
+  GROUP BY platform_that_can_project.route_id
+) AS y ON platform_that_can_project.route_id = y.route_id 
 WHERE ST_DWithin(route_linestring.geom, platform_that_can_project.stop, 50) AND
-  NOT ST_Intersects(ST_Buffer(route_linestring.geom,50,'side=right'), platform_that_can_project.stop)
+  NOT ST_Intersects(ST_Buffer(route_linestring.geom,50,'side=right'), platform_that_can_project.stop) AND
+  platform_that_can_project.stop_order <> last_platform AND
+  platform_that_can_project.stop_order <> 1
 """
 
 class Analyser_Osmosis_Relation_Public_Transport(Analyser_Osmosis):


### PR DESCRIPTION
new public transport analysis that checks 
- the order of the stops 
- the side of the street

It mostly works, but with some rough angles ... help welcomed to fine tune ;)

First, it computes the shape of each route as a linestring when possible : 
it takes the ways in the relation in their order and try to make a linestring with it.
The only magic is with the un-cut roundabout : as they are closed way and don't fit in the linestring, it skips them (which is not great, see below). 

_For the order of the stops analysis:_
Each platform is projected on the route geom (to create a kind of OSM `stop_position`). Then we have an error if the order of the platform in the route relation is not the same as the order of the computed stop_position on the route linestring.

Mostly tested on buses.

_For the side of street analysis_ (only for street served transport):
It makes a buffer on the right side of the linestring geom (because as we drive on the right, the bus stop are always on the right side of the road)

![image](https://user-images.githubusercontent.com/919962/115999707-13072680-a5ed-11eb-9403-34947fcf81b9.png)
> (the buffer is actually bigger than on the picture, to stay coherent with the analysis "The stop or platform is too far from the track of this route")

Then we have an error if the platform is not inside the buffer.
> this one is ok:
![image](https://user-images.githubusercontent.com/919962/115999719-1f8b7f00-a5ed-11eb-9564-d11dd52778f8.png)

> this one is an issue:
![image](https://user-images.githubusercontent.com/919962/115999727-24e8c980-a5ed-11eb-944c-9d713053f5d7.png)


I've spotted two types of false positives:
The edges of the route relation: this seems quite frequent to have the start of the linestring not fully aligned with the stop.
![image](https://user-images.githubusercontent.com/919962/115999747-38943000-a5ed-11eb-8075-5ca531a1878a.png)

I've chosen to ignore the first and last stop from the analysis because I don't know how to handle this in a better way. **Ideas welcomed** ;)

The stops on un-cut roundabout: as I simplify the roundabout when they are closed way, if there is a stop on the roundabout, it is very likely to not fit in the computed buffer:
![image](https://user-images.githubusercontent.com/919962/115999762-4c3f9680-a5ed-11eb-841b-416bd05bef21.png)

> example of false positive:
![image](https://user-images.githubusercontent.com/919962/115999769-506bb400-a5ed-11eb-81e7-0e21c0cd2ee8.png)

I guess the solution here would be to cut the roundabout when making the route linestring, but I didn't manage to dot it. **Help welcomed** ;)
**EDIT**: I finally managed to cut the roundabout :tada: no more false positives here!


It needs to be reversed in countries that drives on the other side (take a left buffer if the bus stops are on the left side of the street). I guess we already have this kind of info as country config in Osmose, but I didn't find out how to do it : **help needed here too** !
**EDIT**: done :heavy_check_mark: 