### PR TITLE
Add timeout to 2 hours on SQL requests

### DIFF
--- a/modules/OsmOsis.py
+++ b/modules/OsmOsis.py
@@ -47,6 +47,7 @@ class OsmOsis:
                     time.sleep(1)
         psycopg2.extras.register_hstore(self._PgConn)
         self._PgCurs = self._PgConn.cursor()
+        self._PgCurs.execute("SET LOCAL statement_timeout = '2h';")
         if schema_path:
             self._PgCurs.execute("SET search_path TO %s,public;" % schema_path)
 


### PR DESCRIPTION
Note that it doesn't apply to import by osmosis, which is using direct SQL
requests to postgresql.