### PR TITLE
Fix analyser merge power substation minor following Enedis opendata update

### DIFF
--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -45,20 +45,16 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes", "ways"],
                     tags = [
-                        {"power": "substation", "substation": "minor_distribution", "operator": False},
-                        {"power": "substation", "substation": "minor_distribution", "operator": "EDF"},
-                        {"power": "substation", "substation": "minor_distribution", "operator": "ERDF"},
-                        {"power": "substation", "substation": "minor_distribution", "operator": "Enedis"},
-                        {"power": None, "transformer": "distribution", "operator": False},
-                        {"power": None, "transformer": "distribution", "operator": "EDF"},
-                        {"power": None, "transformer": "distribution", "operator": "ERDF"},
-                        {"power": None, "transformer": "distribution", "operator": "Enedis"}]),
+                        {"power": "substation", "substation": "minor_distribution", "operator": [False, "EDF", "ERDF", "Enedis"]},
+                        {"power": None, "transformer": "distribution", "operator": [False, "EDF", "ERDF", "Enedis"]},
+                        {"power": "substation", "substation": "distribution", "operator": [False, "EDF", "ERDF", "Enedis"]}]),
                 conflationDistance = 50,
                 mapping = Mapping(
                     static1 = {
                         "power": "substation",
-                        "substation": "minor_distribution",
-                        "voltage": "20000;400",
+                        "voltage": "20000",
                         "operator": "Enedis"},
-                    static2 = {"source": self.source},
+                    static2 = {
+                        "substation": "minor_distribution",
+                        "source": self.source},
                 )))


### PR DESCRIPTION
Enedis had updated its opendata a few weeks ago regarding power distribution substations it operates.
In the past, item 8280 only had opendata for `minor_distribution` substations from Enedis.

Now, Enedis mixes both `distribution` and `minor_distribution` in the same dataset without attribute to distinguish them.
Item 8280, class 11 could be improved a bit as Enedis won't provide additional data that could enable to make it accurate.
Records corresponding to osm's `substation=distribution` currently cause a lot of false positive that couldn't be fixed.

This PR is intended to make this issue http://osmose.openstreetmap.fr/fr/issue/a0d4dee9-fd41-60c8-4e3c-35914c281cdb disappear in regard of this osm object: https://www.openstreetmap.org/node/6512238382

voltage=20000 is now enough instead of voltage=20000;400

Proposed changes would make substation=minor_distribution and substation=distribution selected for conflation with opendata.
New objects to OSM should always be created with `substation=minor_distribution` but existing objects with `substation=distribution` should remain as this and don't move to `substation=minor_distribution`.
Should I move `"substation": "minor_distribution"` from static1 to static2 in Mapping or is it good in static1?

Additionally, what is the purpose of `fix:chair` in item 8281, class 13 at line 32 of this analyser please?