### PR TITLE
Blacklist source:date and opening_hours:* from TagFix_DuplicateValue

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -50,7 +50,8 @@ similar.'''),
             'ref', 'created_by', 'is_in',
             'CLC:id', 'GNS:id', 'tmc', 'tiger:cfcc', 'statscan:rbuid',
             'source:geometry:date', 'source:geometry:ref', # Belgium, Flanders
-            'opening_hours', 'service_times', 'collection_times', 'opening_hours:kitchen',
+            'source:date',
+            'service_times', 'collection_times',
             'phone', 'contact:phone', 'fax', 'contact:fax',
             'url',
             'technology', 'cables', 'position', 'passenger', 'couplings:diameters',
@@ -74,6 +75,7 @@ similar.'''),
             re.compile('.+:conditional'),
             re.compile('railway:signal:.+'),
             re.compile('turn:lanes.*'),
+            re.compile('opening_hours(:.+)?'),
        ))
 
     # http://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Python


### PR DESCRIPTION
Examples that currently trigger this warning:

- source:date=2016-11-09;2014-08-09
- opening_hours:covid19=Tu 11:00-19:00; We 12:00-19:00; Th-Fr 12:00-19:00; Sa 12:00-17:00

I made opening_hours a regex as there's also (from the wiki: https://wiki.openstreetmap.org/wiki/Key:opening_hours)
- opening_hours:covid19=*
- opening_hours:office=*
- opening_hours:atm=*
- opening_hours:kitchen=*
- opening_hours:reception=*
- opening_hours:workshop=*