### PR TITLE
Update mapillary-traffic-signs.mapping.json

### DIFF
--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -1002,7 +1002,7 @@
     "only_for": [
       "CA-ON",
       "CA-QC",
-      "US-OK"
+      "US"
     ],
     "object": [
       "regulatory--stop--g1",


### PR DESCRIPTION
Suggesting stop sign additions seems to be working OK in OK, extending to the rest of the US.