### PR TITLE
Add man_made=piste:halfpipe to exceptions

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -81,7 +81,7 @@ However, this should probably still conform to the typical format used for value
                                  "shop": ( "e-cigarette" ),
                                  "sport": ( "five-a-side", "jiu-jitsu", "pesäpallo", "shot-put" ),
                                  "barrier": ( "full-height_turnstile" ),
-                                 "man_made": ( "MDF" ),
+                                 "man_made": ( "MDF", "piste:halfpipe" ),
                                 }
         self.check_list_closed = set( (
             'area',


### PR DESCRIPTION
See https://github.com/osm-fr/osmose-backend/issues/1293, the `piste` is mentioned on the OSM Wiki as the way to tag: https://wiki.openstreetmap.org/wiki/Key:piste:type#See_also