### PR TITLE
Add warning for combined `merge_to_*` turn lanes

### DIFF
--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -69,13 +69,13 @@ the number of lanes.'''))
 as the destination lane and the `merge_to_right` must be on the *left
 side* and `the merge_to_left` on the *right side*.'''))
         self.errors[316011] = self.def_class(item = 3160, level = 3, tags = ['highway', 'fix:chair'],
-            title = T_('Combined merge and turn lane'),
+            title = T_('Merge lane and other turn lane in a single lane'),
             detail = T_(
-'''It is unlikely that merge_to_* and a regular turn are indicated on a single lane.'''))
+'''It is unlikely that merge_to_* and another turn lane value are indicated on a single lane.'''))
         self.errors[316012] = self.def_class(item = 3160, level = 2, tags = ['highway', 'fix:chair'],
-            title = T_('Combined `none` and indicated turn'),
+            title = T_('Indicated turn lane together with `none`'),
             detail = T_(
-'''A `none` (or empty value) turn lane cannot be combined with other types of turns within the same lane.'''))
+'''A `none` (or empty value) turn lane cannot be combined with other types of turn lanes within the same lane.'''))
 
     def way(self, data, tags, nds):
         if not "highway" in tags:
@@ -122,14 +122,14 @@ side* and `the merge_to_left` on the *right side*.'''))
                         elif (not unknown_turn_lanes_value and len(settt) > 1 and ("none" in settt or "" in settt)):
                             # A single turn lane containing both `none` and `something`
                             if (not ("none" in settt and "" in settt and len(settt) == 2)):
-                                err.append({"class": 316012, "subclass": 3 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined none and indicated turn: \"{0}\"", tt)})
+                                err.append({"class": 316012, "subclass": 3 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined none and indicated turn lane: \"{0}\"", tt)})
 
                         elif (not unknown_turn_lanes_value and len(settt) > 1 and
                               ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
                                ("merge_to_right" in settt and not "merge_to_left" in settt) or
                                ("merge_to_left" in settt and not "merge_to_right" in settt))):
                             # A combination of merge_to_* with a turn (other than another merge_to_*)
-                            err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
+                            err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Merge together with another turn lane: \"{0}\"", tt)})
 
                         i += 1
                     if not unknown_turn_lanes_value:

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -105,14 +105,20 @@ side* and `the merge_to_left` on the *right side*.'''))
                     unknown = False
                     i = 0
                     for tt in ttt:
+                        hasTurn = False
+                        hasMerge = False
                         for t in set(tt.split(";")):
                             if t not in ["left", "slight_left", "sharp_left", "through", "right", "slight_right", "sharp_right", "reverse", "merge_to_left", "merge_to_right", "none", ""]:
                                 unknown = True
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
                             if (t == "merge_to_left" and i == 0) or (t == "merge_to_right" and i == len(ttt) - 1):
                                 err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
-                            elif (not unknown and t != tt and t[0:9] == "merge_to_"):
-                                # merge_to_* ;-separated with another turn
+                            elif (not unknown and t[0:9] == "merge_to_"):
+                                hasMerge = True
+                            elif (not unknown):
+                                hasTurn = True
+                            if (not unknown and hasMerge and hasTurn):
+                                # a combination of merge_to_* with a turn (other than another merge_to_*)
                                 err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
                         i += 1
                     if not unknown:
@@ -333,6 +339,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "oneway": "yes", "lanes": "3", "turn:lanes": "left|left;right|merge_to_left"},
                   {"highway": "residential", "oneway": "yes", "lanes": "3", "turn:lanes": "left|left;left|merge_to_left"},
                   {"highway": "residential", "oneway": "yes", "lanes": "2", "turn:lanes": "left|"},
+                  {"highway": "residential", "oneway": "yes", "lanes": "3", "turn:lanes": "left|merge_to_left;merge_to_right|right"},
                   {"highway": "residential", "oneway": "yes", "lanes": "2", "turn:lanes": "|right"},
                   {"highway": "another", "turn:lanes": "merge_to_right|none"},
                   {"highway": "another", "turn:lanes": "reverse|left|left;through||"},

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -68,6 +68,10 @@ the number of lanes.'''))
 '''The `merge_to_right` or `merge_to_left` lane must be on the same way
 as the destination lane and the `merge_to_right` must be on the *left
 side* and `the merge_to_left` on the *right side*.'''))
+        self.errors[316011] = self.def_class(item = 3160, level = 3, tags = ['highway', 'fix:chair'],
+            title = T_('Combined merge and turn lane'),
+            detail = T_(
+'''It is very unlikely that merge_to_* and a regular turn will be combined in one lane.'''))
 
     def way(self, data, tags, nds):
         if not "highway" in tags:
@@ -89,7 +93,7 @@ side* and `the merge_to_left` on the *right side*.'''))
 
         err = []
 
-        # Check trun lanes values
+        # Check turn lanes values
         tl = "turn:lanes" in tags_lanes
         tlf = "turn:lanes:forward" in tags_lanes
         tlb = "turn:lanes:backward" in tags_lanes
@@ -107,6 +111,9 @@ side* and `the merge_to_left` on the *right side*.'''))
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
                             if (t == "merge_to_left" and i == 0) or (t == "merge_to_right" and i == len(ttt) - 1):
                                 err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
+                            elif (t != tt and t[0:9] == "merge_to_"):
+                                # a merge_to_* ;-separated with another turn lane 
+                                err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)}})
                         i += 1
                     if not unknown:
                         # merge_to_left is a on the right and vice versa
@@ -340,6 +347,7 @@ class Test(TestPluginCommon):
                   {"highway": "another", "turn:lanes": "merge_to_left"},
                   {"highway": "another", "turn:lanes": "merge_to_left|none"},
                   {"highway": "another", "turn:lanes": "none|merge_to_right"},
+                  {"highway": "another", "turn:lanes": "merge_to_right;through|through"},
                   {"highway": "another", "turn:lanes": "slight_right|through|right"},
                  ]:
             assert a.way(None, t, None), a.way(None, t, None)

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -105,21 +105,23 @@ side* and `the merge_to_left` on the *right side*.'''))
                     unknown = False
                     i = 0
                     for tt in ttt:
-                        hasTurn = False
-                        hasMerge = False
-                        for t in set(tt.split(";")):
+                        settt = set(tt.split(";"))
+                        for t in settt:
                             if t not in ["left", "slight_left", "sharp_left", "through", "right", "slight_right", "sharp_right", "reverse", "merge_to_left", "merge_to_right", "none", ""]:
                                 unknown = True
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
-                            if (t == "merge_to_left" and i == 0) or (t == "merge_to_right" and i == len(ttt) - 1):
-                                err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
-                            elif (not unknown and t[0:9] == "merge_to_"):
-                                hasMerge = True
-                            elif (not unknown):
-                                hasTurn = True
-                            if (not unknown and hasMerge and hasTurn):
-                                # a combination of merge_to_* with a turn (other than another merge_to_*)
-                                err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
+                                
+                        if ("merge_to_left" in settt and i == 0) or ("merge_to_right" in settt and i == len(ttt) - 1):
+                            # A lane must exist in the merging direction
+                            err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
+                            
+                        elif (not unknown and len(settt) > 1 and \
+                              ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or \
+                               ("merge_to_right" in settt and not "merge_to_left" in settt) or \
+                               ("merge_to_left" in settt and not "merge_to_right" in settt))):
+                            # a combination of merge_to_* with a turn (other than another merge_to_*)
+                            err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
+                            
                         i += 1
                     if not unknown:
                         # merge_to_left is a on the right and vice versa

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -71,7 +71,7 @@ side* and `the merge_to_left` on the *right side*.'''))
         self.errors[316011] = self.def_class(item = 3160, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Combined merge and turn lane'),
             detail = T_(
-'''It is very unlikely that merge_to_* and a regular turn will be combined in one lane.'''))
+'''It is unlikely that merge_to_* and a regular turn are indicated on a single lane.'''))
 
     def way(self, data, tags, nds):
         if not "highway" in tags:
@@ -113,7 +113,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                                 err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
                             elif (t != tt and t[0:9] == "merge_to_"):
                                 # a merge_to_* ;-separated with another turn lane 
-                                err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)}})
+                                err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
                         i += 1
                     if not unknown:
                         # merge_to_left is a on the right and vice versa

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -110,18 +110,18 @@ side* and `the merge_to_left` on the *right side*.'''))
                             if t not in ["left", "slight_left", "sharp_left", "through", "right", "slight_right", "sharp_right", "reverse", "merge_to_left", "merge_to_right", "none", ""]:
                                 unknown = True
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
-                                
+
                         if ("merge_to_left" in settt and i == 0) or ("merge_to_right" in settt and i == len(ttt) - 1):
                             # A lane must exist in the merging direction
                             err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
-                            
-                        elif (not unknown and len(settt) > 1 and \
-                              ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or \
-                               ("merge_to_right" in settt and not "merge_to_left" in settt) or \
+
+                        elif (not unknown and len(settt) > 1 and
+                              ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
+                               ("merge_to_right" in settt and not "merge_to_left" in settt) or
                                ("merge_to_left" in settt and not "merge_to_right" in settt))):
                             # a combination of merge_to_* with a turn (other than another merge_to_*)
                             err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
-                            
+
                         i += 1
                     if not unknown:
                         # merge_to_left is a on the right and vice versa

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -111,7 +111,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
                             if (t == "merge_to_left" and i == 0) or (t == "merge_to_right" and i == len(ttt) - 1):
                                 err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
-                            elif (t != tt and t[0:9] == "merge_to_"):
+                            elif (not unknown and t != tt and t[0:9] == "merge_to_"):
                                 # merge_to_* ;-separated with another turn
                                 err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
                         i += 1

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -113,14 +113,14 @@ side* and `the merge_to_left` on the *right side*.'''))
 
                         if ("merge_to_left" in settt and i == 0) or ("merge_to_right" in settt and i == len(ttt) - 1):
                             # A lane must exist in the merging direction
-                            err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
+                            err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + tt + '|' + str(i))})
 
                         elif (not unknown and len(settt) > 1 and
                               ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
                                ("merge_to_right" in settt and not "merge_to_left" in settt) or
                                ("merge_to_left" in settt and not "merge_to_right" in settt))):
                             # a combination of merge_to_* with a turn (other than another merge_to_*)
-                            err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
+                            err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
 
                         i += 1
                     if not unknown:

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -112,7 +112,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                             if (t == "merge_to_left" and i == 0) or (t == "merge_to_right" and i == len(ttt) - 1):
                                 err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + t + '|' + str(i))})
                             elif (t != tt and t[0:9] == "merge_to_"):
-                                # a merge_to_* ;-separated with another turn lane 
+                                # merge_to_* ;-separated with another turn
                                 err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
                         i += 1
                     if not unknown:

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -102,20 +102,20 @@ side* and `the merge_to_left` on the *right side*.'''))
             for tl in ["turn:lanes", "turn:lanes:forward", "turn:lanes:backward", "turn:lanes:both_ways"]:
                 if tl in tags_lanes:
                     ttt = tags_lanes[tl].split("|")
-                    unknown = False
+                    unknown_turn_lanes_value = False
                     i = 0
                     for tt in ttt:
                         settt = set(tt.split(";"))
                         for t in settt:
                             if t not in ["left", "slight_left", "sharp_left", "through", "right", "slight_right", "sharp_right", "reverse", "merge_to_left", "merge_to_right", "none", ""]:
-                                unknown = True
+                                unknown_turn_lanes_value = True
                                 err.append({"class": 31606, "subclass": 0 + stablehash64(tl + '|' + t + '|' + str(i)), "text": T_("Unknown turn lanes value \"{0}\"", t)})
 
                         if ("merge_to_left" in settt and i == 0) or ("merge_to_right" in settt and i == len(ttt) - 1):
                             # A lane must exist in the merging direction
                             err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + tt + '|' + str(i))})
 
-                        elif (not unknown and len(settt) > 1 and
+                        elif (not unknown_turn_lanes_value and len(settt) > 1 and
                               ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
                                ("merge_to_right" in settt and not "merge_to_left" in settt) or
                                ("merge_to_left" in settt and not "merge_to_right" in settt))):
@@ -123,7 +123,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                             err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
 
                         i += 1
-                    if not unknown:
+                    if not unknown_turn_lanes_value:
                         # merge_to_left is a on the right and vice versa
                         t = tags_lanes[tl] \
                             .replace("slight_left", "l").replace("sharp_left", "l") \

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -72,6 +72,10 @@ side* and `the merge_to_left` on the *right side*.'''))
             title = T_('Combined merge and turn lane'),
             detail = T_(
 '''It is unlikely that merge_to_* and a regular turn are indicated on a single lane.'''))
+        self.errors[316012] = self.def_class(item = 3160, level = 2, tags = ['highway', 'fix:chair'],
+            title = T_('Combined `none` and indicated turn'),
+            detail = T_(
+'''A `none` (or empty value) turn lane cannot be combined with other types of turns within the same lane.'''))
 
     def way(self, data, tags, nds):
         if not "highway" in tags:
@@ -115,11 +119,16 @@ side* and `the merge_to_left` on the *right side*.'''))
                             # A lane must exist in the merging direction
                             err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + tt + '|' + str(i))})
 
+                        elif (not unknown_turn_lanes_value and len(settt) > 1 and ("none" in settt or "" in settt)):
+                            # A single turn lane containing both `none` and `something`
+                            if (not ("none" in settt and "" in settt and len(settt) == 2)):
+                                err.append({"class": 316012, "subclass": 3 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined none and indicated turn: \"{0}\"", tt)})
+
                         elif (not unknown_turn_lanes_value and len(settt) > 1 and
                               ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
                                ("merge_to_right" in settt and not "merge_to_left" in settt) or
                                ("merge_to_left" in settt and not "merge_to_right" in settt))):
-                            # a combination of merge_to_* with a turn (other than another merge_to_*)
+                            # A combination of merge_to_* with a turn (other than another merge_to_*)
                             err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined merge and turn lane: \"{0}\"", tt)})
 
                         i += 1
@@ -356,6 +365,7 @@ class Test(TestPluginCommon):
                   {"highway": "another", "turn:lanes": "merge_to_left"},
                   {"highway": "another", "turn:lanes": "merge_to_left|none"},
                   {"highway": "another", "turn:lanes": "none|merge_to_right"},
+                  {"highway": "another", "turn:lanes": "none;right"},
                   {"highway": "another", "turn:lanes": "merge_to_right;through|through"},
                   {"highway": "another", "turn:lanes": "slight_right|through|right"},
                  ]:


### PR DESCRIPTION
Adds a warning for combined `;`-separated lanes in turn:lanes where one of the options is `merge_to_*`

For example: `turn:lanes=none|none|merge_to_left;slight_right`
https://taginfo.openstreetmap.org/tags/turn%3Alanes=none%7Cnone%7Cmerge_to_left%3Bslight_right#overview

I checked a dozen of them, none of them reflect the actual turn lanes; nearly all are highway exits with another exit upcoming, but no combined arrows on the highway telling people to merge_to_left or turn to right. All of them either have no arrows or the arrows start after the merge_to_left point. About 1000 cases worldwide.

If you feel uncomfortable with this one, feel completely free to reject this pull request; it's just something I noticed yesterday while going through the code and thought I could propose to warn about. I can understand why people would add this (especially on highway entrances with another exit upcoming), but since `turn:lanes` is representing the *indicated* turn lanes and there's no "merge_or_turn" symbol on ways, I think this'll always be an incorrect value of a `turn:lanes` lane...