### PR TITLE
Fix / improve turn:lanes sequence validation

### DIFF
--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -353,6 +353,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "oneway": "yes", "lanes": "3", "turn:lanes": "left|merge_to_left;merge_to_right|right"},
                   {"highway": "residential", "oneway": "yes", "lanes": "2", "turn:lanes": "|right"},
                   {"highway": "another", "turn:lanes": "merge_to_right|none"},
+                  {"highway": "another", "turn:lanes": "through|merge_to_right|through"},
                   {"highway": "another", "turn:lanes": "reverse|left|left;through||"},
                   {"highway": "another", "lanes": "3", "source:lanes": "usgs_imagery_2007;survey;image", "source_ref:lanes": "AM909_DSCS7435"},
                   {"highway": "another", "lanes": "1", "lanes:both_ways": "1"},

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -133,17 +133,17 @@ side* and `the merge_to_left` on the *right side*.'''))
 
                         i += 1
                     if not unknown_turn_lanes_value:
-                        # merge_to_left is a on the right and vice versa
                         t = tags_lanes[tl] \
                             .replace("slight_left", "l").replace("sharp_left", "l") \
                             .replace("through", " ") \
                             .replace("slight_right", "r").replace("sharp_right", "r") \
                             .replace("reverse", "U") \
-                            .replace("merge_to_left", "r").replace("merge_to_right", "l") \
+                            .replace("merge_to_left", "M").replace("merge_to_right", "M") \
                             .replace("left", "l").replace("right", "r") \
                             .replace("none", "N").replace(";", "").split("|")
                         t = ''.join(map(lambda e: "N" if len(e) == 0 else " " if e[0] != e[-1] else e[0], map(sorted, t)))
                         t = t.replace('U', '') # Ignore reverse
+                        t = t.replace('M', '') # Ignore merge_to_left/right (handled by error 31600)
                         # Ignore single none on the outside lanes: it could be a bus lane
                         # Treat all other nones as throughs (multiple bus lanes or a dedicated lane in between two turns is unlikely)
                         if t[0:2] == "Nl":

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -151,7 +151,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                             .replace(";", "").split("|")
 
                         # Empty equals a 'none', otherwise sort values within a single lane (as left;right equals right;left)
-                        t = ''.join(map(lambda e: "N" if len(e) == 0 else ''.join(sorted(e)), t))
+                        t = ''.join(map(lambda e: "N" if len(e) == 0 else e[0] if len(e) == 1 else ''.join(sorted(e)), t))
 
                         t = t.replace('-', '') # Ignored values
 

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -107,6 +107,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                 if tl in tags_lanes:
                     ttt = tags_lanes[tl].split("|")
                     unknown_turn_lanes_value = False
+                    bad_turn_lanes_value = False
                     i = 0
                     for tt in ttt:
                         settt = set(tt.split(";"))
@@ -118,11 +119,13 @@ side* and `the merge_to_left` on the *right side*.'''))
                         if ("merge_to_left" in settt and i == 0) or ("merge_to_right" in settt and i == len(ttt) - 1):
                             # A lane must exist in the merging direction
                             err.append({"class": 31600, "subclass": 1 + stablehash64(tl + '|' + tt + '|' + str(i))})
+                            bad_turn_lanes_value = True
 
                         elif (not unknown_turn_lanes_value and len(settt) > 1 and ("none" in settt or "" in settt)):
                             # A single turn lane containing both `none` and `something`
                             if (not ("none" in settt and "" in settt and len(settt) == 2)):
                                 err.append({"class": 316012, "subclass": 3 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Combined none and indicated turn lane: \"{0}\"", tt)})
+                                bad_turn_lanes_value = True
 
                         elif (not unknown_turn_lanes_value and len(settt) > 1 and
                               ((len(settt) > 2 and ("merge_to_right" in settt or "merge_to_left" in settt)) or
@@ -132,7 +135,7 @@ side* and `the merge_to_left` on the *right side*.'''))
                             err.append({"class": 316011, "subclass": 2 + stablehash64(tl + '|' + tt + '|' + str(i)), "text": T_("Merge together with another turn lane: \"{0}\"", tt)})
 
                         i += 1
-                    if not unknown_turn_lanes_value:
+                    if not unknown_turn_lanes_value and not bad_turn_lanes_value:
                         t = tags_lanes[tl] \
                             .replace("slight_left", "l").replace("sharp_left", "l") \
                             .replace("through", " ") \

--- a/plugins/Highway_Lanes.py
+++ b/plugins/Highway_Lanes.py
@@ -143,16 +143,11 @@ side* and `the merge_to_left` on the *right side*.'''))
                         throughvalue = "4"
                         t = tags_lanes[tl] \
                             .replace("reverse", "-") \
-                            .replace("merge_to_right", "-") \
-                            .replace("merge_to_left", "-") \
+                            .replace("merge_to_right", "-").replace("merge_to_left", "-") \
                             .replace("none", "N") \
-                            .replace("sharp_left", "1") \
-                            .replace("slight_left", "3") \
-                            .replace("left", "2") \
+                            .replace("sharp_left", "1").replace("slight_left", "3").replace("left", "2") \
                             .replace("through", throughvalue) \
-                            .replace("slight_right", "5") \
-                            .replace("sharp_right", "7") \
-                            .replace("right", "6") \
+                            .replace("slight_right", "5").replace("sharp_right", "7").replace("right", "6") \
                             .replace(";", "").split("|")
 
                         # Empty equals a 'none', otherwise sort values within a single lane (as left;right equals right;left)


### PR DESCRIPTION
Fixes #873
Fixes #1306

See #1306 for a description of the problem and the three solutions I considered.

**Properly parse `turn:lanes` containing a `;`-separated value.** 
Previously, anything with `;` (`left;through` for example) was converted to a through lane (technically, a space).
Works for most of the cases, as it's usually `left;through` or `through;right` (i.e. `left;through|through|through;right`, becoming `through|through|through` effectively), but fails in less common cases, such as `reverse;left|left` (as per the example in the initial report in 873), which was (incorrectly) converted as if it were `through|left`. (Resolves about 300 of such false positives world-wide)

Additionally, this caused it to miss (false negative) cases like `left;right|through` (traffic going right crosses the through lane) as this was - incorrectly - converted to `through|through` effectively. Now it also warns for this. Finds a few hundreds of new cases.

**Differentiate between `sharp_[left/right]`, `[left/right]` and `slight_[left/right]`**
A sharp turn cannot cross a slight turn lane, for example, without traffic collisions.
Finds approximately 100 new cases worldwide

**Allow merge lanes everywhere**
(Except when there's no lane in the merging direction of course: error 31600 takes care of that)
Fixes the false positive for i.e. https://www.openstreetmap.org/way/815893616, where various merges occur after a lift gate in between lanes. (Hint: check the satellite image from PDOK to see the situation).
Fixes about 50 false positives worldwide

*Note: due to my upcoming holidays, a response might be delayed by several weeks*