### PR TITLE
Update to python 3.9 and Debian 11 on Docker and Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: python:3.7
+      image: python:3.9
       env:
         USER: root
 
@@ -62,7 +62,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: python:3.7
+      image: python:3.9
       env:
         USER: root
 
@@ -139,7 +139,7 @@ jobs:
   optional_tests:
     runs-on: ubuntu-latest
     container:
-      image: python:3.7
+      image: python:3.9
       env:
         USER: root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
@@ -22,10 +22,10 @@ RUN apt-get update && \
         postgis \
         postgresql-client \
         protobuf-compiler \
-        python-dev \
-        python-pip \
-        python-setuptools \
-        python-wheel \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
         qtbase5-dev \
         && apt-get clean
 


### PR DESCRIPTION
Since release of Deb 11, CI and Docker stop to work.
CI and Docker require Python 3.7 setup, using the last Debian.

Last Debian is based on Python 3.9. Need to update to Python 3.9 because of  OSM PBF reader python wrapper based on bootstrap binary Debian package.

Partial PR. Fails to compile the OSN PBF reader.
https://github.com/CanalTP/libosmpbfreader/issues/8