### PR TITLE
Fix links in Name_Toponymy_FR

### DIFF
--- a/plugins/Name_Toponymy_FR.py
+++ b/plugins/Name_Toponymy_FR.py
@@ -35,11 +35,9 @@ class Name_Toponymy_FR(Plugin):
             title = T_('Toponymy'),
             detail = T_(
 '''Apply of "[charte de
-toponymie](education.ign.fr/sites/all/files/charte_toponymie_ign.pdf)" of
+toponymie](https://web.archive.org/web/2019/http://education.ign.fr/sites/all/files/charte_toponymie_ign.pdf)" of
 IGN (French geographic name conventions)'''),
-            resource = 'http://education.ign.fr/sites/all/files/charte_toponymie_ign.pdf')
-
-        ## http://education.ign.fr/sites/all/files/charte_toponymie_ign.pdf
+            resource = 'https://web.archive.org/web/2019/http://education.ign.fr/sites/all/files/charte_toponymie_ign.pdf')
 
         # article 4.9 Majuscules et minuscules
         special  = [u""]


### PR DESCRIPTION
This commit fixes the two issues in #1322 and #1323 :

* The link in the “details” section now uses a correct absolute link.
* Both links point to the archived version at the Internet Archive.

Note : I have not updated the `*.po` files, I’m not sure what is the proper process. The only impacted language is Japanese, all other have no translation here, not even French (!?).