### PR TITLE
Avoid duplicate warning for 1-member multipolygon

### DIFF
--- a/plugins/Structural_Multipolygon.py
+++ b/plugins/Structural_Multipolygon.py
@@ -66,14 +66,15 @@ class Structural_Multipolygon(Plugin):
                 err_members.append(u"{0} - {1}".format(member['type'], member['role']))
 
         err = []
-        if len(err_members) > 0:
-            err.append({"class": 11702, "subclass": 1, "text": {"en": ', '.join(err_members)}})
         if len(err_roles) > 0:
             err.append({"class": 11701, "subclass": 1, "text": {"en": ', '.join(err_roles)}})
-        elif outer == 1 and inner == 0:
-            err.append({"class": 11704, "subclass": 1})
+        if len(err_members) > 0:
+            err.append({"class": 11702, "subclass": 1, "text": {"en": ', '.join(err_members)}})
+
         if outer == 0:
             err.append({"class": 11703, "subclass": 1})
+        elif outer == 1 and inner == 0 and len(err_roles) == 0:
+            err.append({"class": 11704, "subclass": 1})
 
 
         return err

--- a/plugins/Structural_Multipolygon.py
+++ b/plugins/Structural_Multipolygon.py
@@ -76,7 +76,6 @@ class Structural_Multipolygon(Plugin):
         elif outer == 1 and inner == 0 and len(err_roles) == 0:
             err.append({"class": 11704, "subclass": 1})
 
-
         return err
 
 ###########################################################################

--- a/plugins/Structural_Multipolygon.py
+++ b/plugins/Structural_Multipolygon.py
@@ -66,15 +66,15 @@ class Structural_Multipolygon(Plugin):
                 err_members.append(u"{0} - {1}".format(member['type'], member['role']))
 
         err = []
-        if len(err_roles) > 0:
-            err.append({"class": 11701, "subclass": 1, "text": {"en": ', '.join(err_roles)}})
         if len(err_members) > 0:
             err.append({"class": 11702, "subclass": 1, "text": {"en": ', '.join(err_members)}})
-
-        if outer == 0:
-            err.append({"class": 11703, "subclass": 1})
+        if len(err_roles) > 0:
+            err.append({"class": 11701, "subclass": 1, "text": {"en": ', '.join(err_roles)}})
         elif outer == 1 and inner == 0:
             err.append({"class": 11704, "subclass": 1})
+        if outer == 0:
+            err.append({"class": 11703, "subclass": 1})
+
 
         return err
 

--- a/plugins/Structural_Multipolygon.py
+++ b/plugins/Structural_Multipolygon.py
@@ -41,7 +41,7 @@ class Structural_Multipolygon(Plugin):
 '''At least one outer ring must be present.'''),
             fix = T_(
 '''Find the way outside, it may be deleted, check the history.'''))
-        self.errors[11704] = self.def_class(item = 1170, level = 3, tags = ['relation', 'multipolygon', 'fix:chair'],
+        self.errors[11704] = self.def_class(item = 1170, level = 2, tags = ['relation', 'multipolygon', 'fix:chair'],
             title = T_('This multipolygon is a simple polygon'),
             detail = T_(
 '''Multipolygon relation actually defines a simple polygon.'''))

--- a/plugins/Structural_Useless_Relation.py
+++ b/plugins/Structural_Useless_Relation.py
@@ -43,6 +43,10 @@ sometimes be justified.'''),
             if tags.get("site") == "geodesic":
                 return
             if tags.get("type") in ("defaults", "route", "route_master", "associatedStreet"):
+                # 1 member allowed
+                return
+            if tags.get("type") == "multipolygon":
+                # Tested by Structural_Multipolygon plugin
                 return
             return {"class": 12001, "subclass": 1}
 


### PR DESCRIPTION
A single member multipolygon relation will always trigger both error [11704 ](https://github.com/osm-fr/osmose-backend/blob/2b171ea2f84dd84ed2508fae5b061bfdf75d4b3c/plugins/Structural_Multipolygon.py#L44)(`This multipolygon is a simple polygon`) as well as error [12001 ](https://github.com/Famlam/osmose-backend/blob/4e25c0b8927a6c8c55020ee5300894d8bbd21622/plugins/Structural_Useless_Relation.py#L30) (`1-member relation`)

This disables the less specific duplicate "1 member relation" warning.