### PR TITLE
Whitelist combinations with landuse=education

### DIFF
--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -42,8 +42,11 @@ class TagRemove_Incompatibles(Plugin):
         self.CONFLICT[4] = set(['information', 'place'])
         self.WHITE_LIST = {
             'landuse': [
-                ['school', 'amenity', 'school'],
-                ['school', 'landuse', 'education'],
+                ['school', 'amenity', 'school'], # deprecated
+                ['education', 'amenity', 'school'],
+                ['education', 'amenity', 'university'],
+                ['education', 'amenity', 'college'],
+                ['education', 'amenity', 'kindergarten'],
                 ['industrial', 'amenity', 'recycling'],
                 ['retail', 'amenity', 'marketplace'],
                 ['retail', 'amenity', 'fuel'],


### PR DESCRIPTION
Whitelist combinations of `landuse=education` together with `amenity=school|university|college|kindergarten`
Per the [wiki](https://wiki.openstreetmap.org/wiki/Tag:landuse%3Deducation#Use_cases): 
> For an area/ground that is only used by one facility. In this case it is not necessary to use landuse=education because the amenity=kindergarten;school;college;university already imply the landuse. However, it is optional that these areas are also marked with landuse=education.

Also added a note regarding the deprecated tag `landuse=school` and removed an impossible combination (typo I presume?) of `landuse=school` together with `landuse=education` (can't have two identical tags on a single object).

Fixes #1367 
Updates #1295 

