### PR TITLE
Validate conditional restrictions and report outdated conditions

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -33,17 +33,17 @@ class ConditionalRestrictions(Plugin):
     self.currentYear = date.today().year
 
     self.errors[33501] = self.def_class(item = 3350, level = 2, tags = ['highway', 'fix:chair'],
-            title = T_('Bad conditional restriction'),
-            detail = T_('''Conditional restrictions should follow `value @ condition; value2 @ condition2` syntax.
+        title = T_('Bad conditional restriction'),
+        detail = T_('''Conditional restrictions should follow `value @ condition; value2 @ condition2` syntax.
 Combined restrictions should follow `value @ (condition1 AND condition2)
 Parentheses `()` should be used if the condition itself contains semicolons `;` too'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-            title = T_('Use uppercase `and` to combine conditions'),
-            detail = T_('''For readability, `AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
+        title = T_('Use uppercase `and` to combine conditions'),
+        detail = T_('''For readability, `AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-            title = T_('Expired conditional'),
-            detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),
-            trap = T_('''Other tags might need to be updated too to reflect the new situation'''))
+        title = T_('Expired conditional'),
+        detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),
+        trap = T_('''Other tags might need to be updated too to reflect the new situation'''))
 
 
 

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -133,7 +133,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
       if bad_tag:
         continue
 
-
       # Find outdated conditional restrictions, i.e. temporary road closures
       for condition in conditions:
         years_str = re.findall(self.ReYear, condition)

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -56,7 +56,7 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
     # Get the relevant tags with *:conditional
     tags_conditional = {}
     for tag in tags:
-      if tags[tag][-12:] == ":conditional":
+      if tag[-12:] == ":conditional":
         tags_conditional[tag] = tags[tag]
     if len(tags_conditional) == 0:
       return
@@ -69,7 +69,7 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
       bad_tag = False
 
       if not "@" in tag_value:
-        err.append({"class": 33501, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Missing `@`")})
+        err.append({"class": 33501, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Missing `@` in \"{0}\"", tag)})
         continue
 
       # Conditionals are split by semicolons, i.e. value @ condition; value @ condition
@@ -83,7 +83,7 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
       for c in tag_value:
         if c == "@":
           if len(tmp_str.strip()) == 0:
-            err.append({"class": 33501, "subclass": 1 + stablehash64(tag + '|' + tag_value), "text": T_("Missing value for the condition")})
+            err.append({"class": 33501, "subclass": 1 + stablehash64(tag + '|' + tag_value), "text": T_("Missing value for the condition in \"{0}\"", tag)})
             bad_tag = True
             break
           tmp_str = ""
@@ -93,13 +93,13 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
         elif c == ")":
           parentheses -= 1
           if parentheses == -1:
-            err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses")})
+            err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses in \"{0}\"", tag)})
             bad_tag = True
             break
         elif c == ";" and parentheses == 0:
           tmp_str = tmp_str.strip()
           if len(tmp_str) == 0:
-            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition")})
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition in \"{0}\"", tag)})
             bad_tag = True
             break
           conditions.append(tmp_str)
@@ -112,11 +112,11 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
           # Last condition wouldn't be added in the loop
           tmp_str = tmp_str.strip()
           if len(tmp_str) == 0:
-            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition")})
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition in \"{0}\"", tag)})
             continue
           conditions.append(tmp_str)
         else:
-          err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses")})
+          err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses in \"{0}\"", tag)})
           continue
 
       # Check the position of AND is ok
@@ -126,12 +126,12 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
           tmp_ANDsplitted = tmp_cond.upper().split(" AND ")
           for splittedANDpart in tmp_ANDsplitted:
             if len(splittedANDpart.strip()) == 0:
-              err.append({"class": 33501, "subclass": 4 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition before or after AND combinator")})
+              err.append({"class": 33501, "subclass": 4 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition before or after AND combinator in \"{0}\"", tag)})
               bad_tag = True
               break
 
           if not bad_tag and tmp_cond.count(" AND ") != tmp_cond.upper().count(" AND "):
-            err.append({"class": 33502, "subclass": 0 + stablehash64(tag + '|' + tag_value)}) # Recommendation to use uppercase "AND". Not a true error
+            err.append({"class": 33502, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Lowercase version of `AND` in \"{0}\"", tag)}) # Recommendation to use uppercase "AND". Not a true error
 
       if bad_tag:
         continue
@@ -145,7 +145,7 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
 
         maxYear = int(max(years_str))
         if maxYear < self.currentYear:
-          err.append({"class": 33503, "subclass": 0 + stablehash64(tag + '|' + tag_value + '|' + condition), "text": T_("Condition \"{0}\" was only valid until {1}", condition, maxYear)})
+          err.append({"class": 33503, "subclass": 0 + stablehash64(tag + '|' + tag_value + '|' + condition), "text": T_("Condition \"{0}\" in \"{1}\" was only valid until {2}", condition, tag, maxYear)})
 
     if err != []:
       return err

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -107,16 +107,17 @@ Parentheses `()` should be used if the condition itself contains semicolons `;` 
         else:
           tmp_str += c
 
-      if parentheses == 0 and not bad_tag:
-        # Last condition wouldn't be added in the loop
-        tmp_str = tmp_str.strip()
-        if len(tmp_str) == 0:
-          err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition")})
+      if not bad_tag:
+        if parentheses == 0:
+          # Last condition wouldn't be added in the loop
+          tmp_str = tmp_str.strip()
+          if len(tmp_str) == 0:
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition")})
+            continue
+          conditions.append(tmp_str)
+        else:
+          err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses")})
           continue
-        conditions.append(tmp_str)
-      else:
-        err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses")})
-        continue
 
       # Check the position of AND is ok
       if not bad_tag:

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -45,9 +45,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
         detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),
         trap = T_('''Other tags might need to be updated too to reflect the new situation'''))
 
-
-
-
   def way(self, data, tags, nds):
     # Get the relevant tags with *:conditional
     tags_conditional = {}

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -198,7 +198,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "yes@"},
                   {"highway": "residential", "access:conditional": "@wet"},
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22 AND AND 2020 Oct 7)"},
-                  {"highway": "residential", "access:conditional": "no @ (2018 May 22 AND 2020 Oct 7 AND)"; delivery @ wet},
+                  {"highway": "residential", "access:conditional": "no @ (2018 May 22 AND 2020 Oct 7 AND); delivery @ wet"},
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22 and 2020 Oct 7); delivery @ wet"},
                  ]:
           assert not a.way(None, t, None), a.way(None, t, None)

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -148,8 +148,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
     if err != []:
       return err
 
-
-
   def node(self, data, tags):
     return self.way(data, tags, None)
 

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -1,0 +1,40 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights osmose project 2021                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from plugins.Plugin import 
+
+class ConditionalRestrictions(Plugin):
+  def init(self, logger):
+    #......
+    
+  def way(self, data, tags, nds):
+    #.....
+  
+###########################################################################
+from plugins.Plugin import TestPluginCommon
+
+class Test(TestPluginCommon):
+    def test(self):
+        a = ConditionalRestrictions(None)
+        a.init(None)
+        
+        #.....

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -169,7 +169,6 @@ class Test(TestPluginCommon):
 
         # Valid conditionals
         for t in [{"highway": "residential"},
-                  {"highway": "residential", "access": "no"},
                   {"highway": "residential", "access:conditional": "no @ wet", "source:access:conditional": "survey"},
                   {"highway": "residential", "maxspeed:conditional": "20 @ (06:00-19:00)"},
                   {"highway": "residential", "maxspeed:conditional": "20 @ (06:00-20:00); 100 @ (22:00-06:00)"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -39,7 +39,7 @@ Combined restrictions should follow `value @ (condition1 AND condition2)`.
 Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`.'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Use uppercase `AND` to combine conditions'),
-        detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
+        detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions.'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Expired conditional'),
         detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -49,10 +49,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
 
 
   def way(self, data, tags, nds):
-    # Currently only checking highways with conditionals
-    if not "highway" in tags:
-      return
-
     # Get the relevant tags with *:conditional
     tags_conditional = {}
     for tag in tags:
@@ -155,6 +151,12 @@ Parentheses `()` must be used around the condition if the condition itself conta
 
 
 
+  def node(self, data, tags):
+    return self.way(data, tags, None)
+
+  def relation(self, data, tags, members):
+    return self.way(data, tags, None)
+
 ###########################################################################
 from plugins.Plugin import TestPluginCommon
 
@@ -204,3 +206,11 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 and 2099 Oct 7); delivery @ wet"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
+
+          # Nodes
+          assert not a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ wet"})
+          assert a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00"})
+
+          # Relations
+          assert not a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ (06:00-22:00)"}, None)
+          assert a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ 06:00-22:00)"}, None)

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -24,10 +24,100 @@ from plugins.Plugin import
 
 class ConditionalRestrictions(Plugin):
   def init(self, logger):
-    #......
+    Plugin.init(self, logger)
+    # TODO define errors
     
   def way(self, data, tags, nds):
-    #.....
+    # Currently only checking highways with conditionals
+    if not "highway" in tags:
+      return
+    
+    # Get the relevant tags with *:conditional
+    tags_conditional = {}
+    for tag in tags:
+      if tags[tag][-12:] == ":conditional":
+        tags_conditional[tag] = tags[tag]
+    if len(tags_conditional) == 0:
+      return
+    
+    err = []
+    for tag in tags_conditional:
+      tag_value = tags_conditional[tag]
+      conditions = []
+      parentheses = 0
+      bad_tag = False
+
+      if not "@" in tag_value:
+        err.append({}) # TODO - not a conditional
+        continue
+
+      # Conditionals are split by semicolons, i.e. value @ condition; value @ condition
+      # Herein, condition can also contain semicolons, e.g. no @ (Mo 06:00-24:00; Tu-Fr 00:00-24:00)
+      # In this case, the condition is wrapped in parentheses ( )
+      # Additionally, there's the magic keyword 'AND' to combine conditions
+      
+      # Get the parts after the @ excluding parentheses and put them in the list conditions
+      # Also validate the syntax of value @ (condition); value @ condition is obeyed
+      tmp_str = ""
+      for c in tag_value:
+        if c == "@":
+          if len(tmp_str.strip()) == 0:
+            err.append({}) # TODO - no value before @
+            bad_tag = True
+            break
+          tmp_str = ""
+        elif c == "(":
+          parentheses += 1
+          continue
+        elif c == ")":
+          parentheses -= 1
+          if parentheses == -1:
+            err.append({}) # TODO - mismatch in ( and ) count
+            bad_tag = True
+            break
+        elif c == ";" and parentheses == 0:
+          tmp_str = tmp_str.strip()
+          if len(tmp_str) == 0:
+            err.append({}) # TODO - no value after @
+            bad_tag = True
+            break
+          conditions.append(tmp_str)
+          tmp_str = ""
+        else:
+          tmp_str += c
+      
+      if parentheses == 0 and not bad_tag:
+        # Last condition wouldn't be added in the loop
+        tmp_str = tmp_str.strip()
+        if len(tmp_str) == 0:
+          err.append({}) # TODO - no value after @
+          continue
+        conditions.append(tmp_str)
+      else:
+        err.append({}) # TODO - mismatch in ( and ) count
+        continue
+      
+      # Check the position of AND is ok
+      if not bad_tag:
+        for condition in conditions:
+          tmp_cond = " " + condition + " "
+          tmp_ANDsplitted = tmp_cond.upper().split(" AND ")
+          for splittedANDpart in tmp_ANDsplitted:
+            if len(splittedANDpart.strip()) == 0:
+              err.append({}) # TODO - AND without condition before or after
+              bad_tag = True
+              break
+
+          if not bad_tag and tmp_cond.count(" AND ") != tmp_cond.upper().count(" AND "):
+            err.append({}) # TODO - recommendation: use uppercase "AND". Not an error though
+
+      if bad_tag:
+        continue
+      
+      ## TODO continue: find and validate years
+      
+      
+      
   
 ###########################################################################
 from plugins.Plugin import TestPluginCommon
@@ -37,4 +127,4 @@ class Test(TestPluginCommon):
         a = ConditionalRestrictions(None)
         a.init(None)
         
-        #.....
+        # TODO write tests

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -53,6 +53,8 @@ Parentheses `()` must be used around the condition if the condition itself conta
     tags_conditional = {}
     for tag in tags:
       if tag[-12:] == ":conditional":
+        if "source:" in tag or "note:" in tag or "fixme:" in tag.lower():
+          continue
         tags_conditional[tag] = tags[tag]
     if len(tags_conditional) == 0:
       return
@@ -168,7 +170,7 @@ class Test(TestPluginCommon):
         # Valid conditionals
         for t in [{"highway": "residential"},
                   {"highway": "residential", "access": "no"},
-                  {"highway": "residential", "access:conditional": "no @ wet"},
+                  {"highway": "residential", "access:conditional": "no @ wet", "source:access:conditional": "survey"},
                   {"highway": "residential", "maxspeed:conditional": "20 @ (06:00-19:00)"},
                   {"highway": "residential", "maxspeed:conditional": "20 @ (06:00-20:00); 100 @ (22:00-06:00)"},
                   {"highway": "residential", "access:forward:conditional": "delivery @ (Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00)"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -42,8 +42,8 @@ Parentheses `()` must be used around the condition if the condition itself conta
         detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions.'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Expired conditional'),
-        detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),
-        trap = T_('''Other tags might need to be updated too to reflect the new situation'''))
+        detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed.'''),
+        trap = T_('''Other tags might need to be updated too to reflect the new situation.'''))
 
   def way(self, data, tags, nds):
     # Get the relevant tags with *:conditional

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -20,11 +20,16 @@
 ###########################################################################
 
 from modules.OsmoseTranslation import T_
-from plugins.Plugin import 
+from plugins.Plugin import Plugin
+import re
+from datetime import date
 
 class ConditionalRestrictions(Plugin):
   def init(self, logger):
     Plugin.init(self, logger)
+    
+    self.ReYear = re.compile(r'20\d\d') # Update in 2099
+    self.currentYear = date.today().year
     # TODO define errors
     
   def way(self, data, tags, nds):
@@ -55,7 +60,7 @@ class ConditionalRestrictions(Plugin):
       # Herein, condition can also contain semicolons, e.g. no @ (Mo 06:00-24:00; Tu-Fr 00:00-24:00)
       # In this case, the condition is wrapped in parentheses ( )
       # Additionally, there's the magic keyword 'AND' to combine conditions
-      
+
       # Get the parts after the @ excluding parentheses and put them in the list conditions
       # Also validate the syntax of value @ (condition); value @ condition is obeyed
       tmp_str = ""
@@ -85,7 +90,7 @@ class ConditionalRestrictions(Plugin):
           tmp_str = ""
         else:
           tmp_str += c
-      
+
       if parentheses == 0 and not bad_tag:
         # Last condition wouldn't be added in the loop
         tmp_str = tmp_str.strip()
@@ -96,7 +101,7 @@ class ConditionalRestrictions(Plugin):
       else:
         err.append({}) # TODO - mismatch in ( and ) count
         continue
-      
+
       # Check the position of AND is ok
       if not bad_tag:
         for condition in conditions:
@@ -113,12 +118,22 @@ class ConditionalRestrictions(Plugin):
 
       if bad_tag:
         continue
-      
-      ## TODO continue: find and validate years
-      
-      
-      
-  
+
+
+      # Find outdated conditional restrictions, i.e. temporary road closures
+      for condition in conditions:
+        years_str = re.findall(self.ReYear, condition)
+        if len(years_str) == 0:
+          continue
+
+        maxYear = int(max(years_str))
+        if maxYear < self.currentYear:
+          err.append({}) # TODO - outdated condition
+
+
+
+
+
 ###########################################################################
 from plugins.Plugin import TestPluginCommon
 

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -181,7 +181,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7); destination @ length < 4"},
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7 AND weight > 5)"},
                  ]:
-          assert not a.way(None, t, None), a.way(None, t, None)
+          assert a.way(None, t, None), a.way(None, t, None)
 
         # Invalid conditionals
         for t in [{"highway": "residential", "access:conditional": "no"},
@@ -200,4 +200,4 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22 AND 2020 Oct 7 AND); delivery @ wet"},
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22 and 2020 Oct 7); delivery @ wet"},
                  ]:
-          assert not a.way(None, t, None), a.way(None, t, None)
+          assert a.way(None, t, None), a.way(None, t, None)

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -53,7 +53,7 @@ Parentheses `()` must be used around the condition if the condition itself conta
     tags_conditional = {}
     for tag in tags:
       if tag[-12:] == ":conditional":
-        if "source:" in tag or "note:" in tag or "fixme:" in tag.lower():
+        if "source:" in tag or "note:" in tag or "fixme:" in tag:
           continue
         tags_conditional[tag] = tags[tag]
     if len(tags_conditional) == 0:

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -38,8 +38,8 @@ class ConditionalRestrictions(Plugin):
 Combined restrictions should follow `value @ (condition1 AND condition2)`
 Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-        title = T_('Use uppercase `and` to combine conditions'),
-        detail = T_('''For readability, `AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
+        title = T_('Use uppercase `AND` to combine conditions'),
+        detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Expired conditional'),
         detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -35,8 +35,8 @@ class ConditionalRestrictions(Plugin):
     self.errors[33501] = self.def_class(item = 3350, level = 2, tags = ['highway', 'fix:chair'],
         title = T_('Bad conditional restriction'),
         detail = T_('''Conditional restrictions should follow `value @ condition; value2 @ condition2` syntax.
-Combined restrictions should follow `value @ (condition1 AND condition2)`
-Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`'''))
+Combined restrictions should follow `value @ (condition1 AND condition2)`.
+Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`.'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Use uppercase `AND` to combine conditions'),
         detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -38,7 +38,7 @@ class ConditionalRestrictions(Plugin):
 Combined restrictions should follow `value @ (condition1 AND condition2)`.
 Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`.'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-        title = T_('Use uppercase `AND` to combine conditions'),
+        title = T_('Combine conditions using `AND`'),
         detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions.'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Expired conditional'),
@@ -86,7 +86,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
           condition_started = True
         elif c == "(":
           parentheses += 1
-          continue
         elif c == ")":
           parentheses -= 1
           if parentheses == -1:

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -28,24 +28,22 @@ from modules.Stablehash import stablehash64
 class ConditionalRestrictions(Plugin):
   def init(self, logger):
     Plugin.init(self, logger)
-    
+
     self.ReYear = re.compile(r'20\d\d') # Update in 2099
     self.currentYear = date.today().year
 
     self.errors[33501] = self.def_class(item = 3350, level = 2, tags = ['highway', 'fix:chair'],
             title = T_('Bad conditional restriction'),
-            detail = T_(
-'''Conditional restrictions should follow `value @ condition; value2 @ condition2 syntax.'''))
+            detail = T_('''Conditional restrictions should follow `value @ condition; value2 @ condition2` syntax.
+Combined restrictions should follow `value @ (condition1 AND condition2)
+Parentheses `()` should be used if the condition itself contains semicolons `;` too'''))
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Use uppercase `and` to combine conditions'),
-            detail = T_(
-'''For readability, `AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
+            detail = T_('''For readability, `AND` (uppercase) is to be preferred over lowercase variants when combining restrictions'''))
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Expired conditional'),
-            detail = T_(
-'''This conditional was only valid up to a date in the past. It can likely be removed'''),
-            trap = T_(
-'''Other tags might need to be updated too to reflect the new situation'''))
+            detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed'''),
+            trap = T_('''Other tags might need to be updated too to reflect the new situation'''))
 
 
 
@@ -54,7 +52,7 @@ class ConditionalRestrictions(Plugin):
     # Currently only checking highways with conditionals
     if not "highway" in tags:
       return
-    
+
     # Get the relevant tags with *:conditional
     tags_conditional = {}
     for tag in tags:
@@ -62,7 +60,7 @@ class ConditionalRestrictions(Plugin):
         tags_conditional[tag] = tags[tag]
     if len(tags_conditional) == 0:
       return
-    
+
     err = []
     for tag in tags_conditional:
       tag_value = tags_conditional[tag]
@@ -160,7 +158,7 @@ class Test(TestPluginCommon):
     def test(self):
         a = ConditionalRestrictions(None)
         a.init(None)
-        
+
         # Valid conditionals
         for t in [{"highway": "residential"},
                   {"highway": "residential", "access": "no"},
@@ -174,7 +172,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2010 May 22-2099 Oct 7)"},
                  ]:
           assert not a.way(None, t, None), a.way(None, t, None)
-            
+
         # Expired conditionals
         for t in [{"highway": "residential", "access:forward:conditional": "no @ 2020"},
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7)"},
@@ -183,7 +181,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2018 May 22-2020 Oct 7 AND weight > 5)"},
                  ]:
           assert not a.way(None, t, None), a.way(None, t, None)
-          
+
         # Invalid conditionals
         for t in [{"highway": "residential", "access:conditional": "no"},
                   {"highway": "residential", "access:forward:conditional": "no @ 2098;2099"},


### PR DESCRIPTION
1. Implement a **basic validation of conditional restrictions**:
- `@` must be present
- `(` and `)` count/sequence must match
- value and condition must be present in the sequence `value @ condition` or `value @ (condition)`
- parentheses required if the condition itself contains `;`
- `AND` in a combined condition must be followed and preceded by a condition

2. **Search for expired conditions**. Only using the current year at the moment

**Outdated, use the other PR instead**