### PR TITLE
Conditional restrictions: fix false positives with ; in the value

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -38,10 +38,6 @@ class ConditionalRestrictions(Plugin):
 Combined restrictions should follow `value @ (condition1 AND condition2)`.
 Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`.'''),
         resource="https://wiki.openstreetmap.org/wiki/Conditional_restrictions")
-    self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-        title = T_('Combine conditions using `AND`'),
-        detail = T_('''`AND` (uppercase) is to be preferred over lowercase variants when combining restrictions.'''),
-        resource="https://wiki.openstreetmap.org/wiki/Conditional_restrictions")
     self.errors[33503] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
         title = T_('Expired conditional'),
         detail = T_('''This conditional was only valid up to a date in the past. It can likely be removed.'''),
@@ -98,9 +94,7 @@ Parentheses `()` must be used around the condition if the condition itself conta
             err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses in \"{0}\"", tag)})
             bad_tag = True
             break
-        elif c == ";" and parentheses == 0:
-          if not condition_started:
-            continue # value contains semicolon, example turn:lanes:conditional = left;right @ ...
+        elif c == ";" and parentheses == 0 and condition_started:
           tmp_str = tmp_str.strip()
           if len(tmp_str) == 0:
             err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition, `@` or parentheses in \"{0}\"", tag)})
@@ -134,9 +128,6 @@ Parentheses `()` must be used around the condition if the condition itself conta
               err.append({"class": 33501, "subclass": 4 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition before or after AND combinator in \"{0}\"", tag)})
               bad_tag = True
               break
-
-          if not bad_tag and tmp_cond.count(" AND ") != tmp_cond.upper().count(" AND "):
-            err.append({"class": 33502, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Lowercase version of `AND` in \"{0}\"", tag)}) # Recommendation to use uppercase "AND". Not a true error
 
       if bad_tag:
         continue
@@ -207,7 +198,6 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "@ wet"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND AND 2099 Oct 7)"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND 2099 Oct 7 AND); delivery @ wet"},
-                  {"highway": "residential", "access:conditional": "no @ (2099 May 22 and 2099 Oct 7); delivery @ wet"},
                   {"highway": "residential", "maxweight:conditional": "27000 lbs (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles>=4)"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -88,6 +88,10 @@ Parentheses `()` must be used around the condition if the condition itself conta
           condition_started = True
         elif c == "(":
           parentheses += 1
+          if not condition_started:
+            err.append({"class": 33501, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Missing `@` in \"{0}\"", tag)})
+            bad_tag = True
+            break
         elif c == ")":
           parentheses -= 1
           if parentheses == -1:
@@ -95,9 +99,11 @@ Parentheses `()` must be used around the condition if the condition itself conta
             bad_tag = True
             break
         elif c == ";" and parentheses == 0:
+          if not condition_started:
+            continue # value contains semicolon, example turn:lanes:conditional = left;right @ ...
           tmp_str = tmp_str.strip()
-          if not condition_started or len(tmp_str) == 0:
-            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition or parentheses in \"{0}\"", tag)})
+          if len(tmp_str) == 0:
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition, `@` or parentheses in \"{0}\"", tag)})
             bad_tag = True
             break
           conditions.append(tmp_str)
@@ -111,7 +117,7 @@ Parentheses `()` must be used around the condition if the condition itself conta
           # Last condition wouldn't be added in the loop
           tmp_str = tmp_str.strip()
           if not condition_started or len(tmp_str) == 0:
-            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition or parentheses in \"{0}\"", tag)})
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition, `@` or parentheses in \"{0}\"", tag)})
             continue
           conditions.append(tmp_str)
         else:
@@ -173,6 +179,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ 2099"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22-2099 Oct 7)"},
                   {"highway": "residential", "access:conditional": "no @ (2010 May 22-2099 Oct 7)"},
+                  {"highway": "residential", "turn:lanes:forward:conditional": "left|through|through;right @ (Mo-Fr 06:00-09:00)"},
                  ]:
           assert not a.way(None, t, None), a.way(None, t, None)
 
@@ -201,6 +208,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND AND 2099 Oct 7)"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND 2099 Oct 7 AND); delivery @ wet"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 and 2099 Oct 7); delivery @ wet"},
+                  {"highway": "residential", "maxweight:conditional": "27000 lbs (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles>=4)"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 


### PR DESCRIPTION
### The false positive
Spotted this on https://www.openstreetmap.org/way/303019393 : a conditional `turn:lanes` with a semicolon in the value:
`turn:lanes:forward:conditional = left|through|through;right @ (Mo-Fr 06:00-09:00)`
This triggered the warning: `Missing condition or parentheses`

Fixing this by only calling `continue` would prevent a warning from appearing in cases like:
`maxweight:hgv:conditional = 27000 lbs (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles=4); 55800 lbs @ (axles=5); 62550 lbs @ (axles=6); 69750 @ (axles>=7)`, which should have been:
`maxweight:hgv:conditional = 27000 lbs @ (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles=4); 55800 lbs @ (axles=5); 62550 lbs @ (axles=6); 69750 @ (axles>=7)`
Hence, I added an additional (previously unneeded) check that there are no `(` allowed in the conditional-value of any `*:conditional`. (_This is an assumption, please correct me if I'm wrong here! If you prefer to use no assumptions, no problem, I will then just delete those lines of code_)

The following case - however - will no longer trigger and thus become a false negative:
`motor_vehicle:conditional = no @ Fr 16:00-24:00; Sa,Su 00:00-24:00; no @ wet` (which should be:
`motor_vehicle:conditional = no @ (Fr 16:00-24:00; Sa,Su 00:00-24:00); no @ wet`.
However, I would only be able to distinguish this from valid values by actually interpreting which values are valid (i.e. programming that `Sa,Su 00:00-24:00; no` is not a valid value for `motor_vehicle`). All I could possibly do without that is adding a recommendation to use `(` and `)` for readability (see #1380)




### Warning message improvement
I improved / clarified the warning message about a missing condition or parentheses as it also triggers on some cases where an `@` is missing, for example:
`vehicle:conditional = no @ (Apr 29-Sep 29); delivery (Apr 29-Sep 29 7:00-10:00)` instead of
`vehicle:conditional = no @ (Apr 29-Sep 29); delivery @ (Apr 29-Sep 29 7:00-10:00)`

### For discussion
Additionally ~~(not yet programmed, first for discussion only)~~, I'm considering whether the `and`-check should be removed, as only 1 out of 7 cases so far it finds is actually correct, the other 6 are just invalid conditions (for which a separate warning would be nice - and extremely challenging - but this one is just confusing)
https://osmose.openstreetmap.fr/nl/issues/open?source=&class=33502&useDevItem=all&username=&bbox=&limit=500