### PR TITLE
Warn about missing parentheses in conditional restrictions

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -40,7 +40,7 @@ Combined restrictions should follow `value @ (condition1 AND condition2)`.
 Parentheses `()` must be used around the condition if the condition itself contains semicolons `;`, i.e. `value @ (date;date)`.'''),
         resource="https://wiki.openstreetmap.org/wiki/Conditional_restrictions")
     self.errors[33502] = self.def_class(item = 3350, level = 3, tags = ['highway', 'fix:chair'],
-        title = T_('Suboptimal conditional restriction'),
+        title = T_('Improve style of conditional'),
         detail = T_('''Although valid, it is recommended to format conditional restrictions with:
 - spaces around the `@`;
 - uppercase `AND` (in combined restrictions);
@@ -210,6 +210,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "delivery @ (Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00;yes@wet"},
                   {"highway": "residential", "access:conditional": "delivery @ (Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00));yes@wet"},
                   {"highway": "residential", "bicycle:conditional": "designated @ (Fr-Mo 22:00-00:00); (Fr-Mo 22:00-24:00)"},
+                  {"highway": "residential", "access:conditional": "no @ (Mo-Fr 22:00-00:00);"},
                   {"highway": "residential", "access:conditional": "yes @ ()"},
                   {"highway": "residential", "access:conditional": "yes @"},
                   {"highway": "residential", "access:conditional": "@ wet"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -209,6 +209,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "delivery @ Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00);yes@wet"},
                   {"highway": "residential", "access:conditional": "delivery @ (Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00;yes@wet"},
                   {"highway": "residential", "access:conditional": "delivery @ (Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00));yes@wet"},
+                  {"highway": "residential", "bicycle:conditional": "designated @ (Fr-Mo 22:00-00:00); (Fr-Mo 22:00-24:00)"},
                   {"highway": "residential", "access:conditional": "yes @ ()"},
                   {"highway": "residential", "access:conditional": "yes @"},
                   {"highway": "residential", "access:conditional": "@ wet"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -44,7 +44,7 @@ Parentheses `()` must be used around the condition if the condition itself conta
         detail = T_('''Although valid, it is recommended to format conditional restrictions with:
 - spaces around the `@`;
 - uppercase `AND` (in combined restrictions);
-- parentheses around all-but-the-simplest conditions. 
+- parentheses around all-but-the-simplest conditions.
 This helps to prevent errors and improves readability.
 For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'''),
         resource="https://wiki.openstreetmap.org/wiki/Conditional_restrictions")

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -218,17 +218,17 @@ class Test(TestPluginCommon):
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 
-          # Optimizable, yet valid conditions
-          for t in [{"highway": "residential", "access:conditional": "no @ 2099 May 22-2099 Oct 7"},
+        # Optimizable, yet valid conditions
+        for t in [{"highway": "residential", "access:conditional": "no @ 2099 May 22-2099 Oct 7"},
                     {"highway": "residential", "access:conditional": "no @ wet; no @ snow"},
                     {"highway": "residential", "access:conditional": "no @ wet; no @ (20:00-22:00)"},
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 
-          # Nodes
-          assert not a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ wet"})
-          assert a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00"})
+        # Nodes
+        assert not a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ wet"})
+        assert a.node(None, {"barrier": "lift_gate", "access:conditional": "no @ Mo-Fr 06:00-11:00,17:00-19:00;Sa 03:30-19:00"})
 
-          # Relations
-          assert not a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ (06:00-22:00)"}, None)
-          assert a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ 06:00-22:00)"}, None)
+        # Relations
+        assert not a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ (06:00-22:00)"}, None)
+        assert a.relation(None, {"type": "restriction", "restriction:conditional": "no_u_turn @ 06:00-22:00)"}, None)


### PR DESCRIPTION
**Warn about missing non-required parentheses in conditional restrictions**:
- if there are multiple conditions (`a@b;c@d`) and it is not the final condition
- if the last condition is not a simple (composed of a-z, A-Z, 0-9 and _) condition (i.e. `yes @ wet` is OK, but `yes @ 06:00-20:00` would request for parentheses)

i.e. 
`yes @ wet` will not warn
`yes @ 06:00-18:00` will warn until it is converted into `yes @ (06:00-18:00)`
`yes @ wet; yes @ snow` will warn until it is converted into `yes @ (wet); yes @ snow` or `yes @ (wet); yes @ (snow)`
`yes @ snow; yes @ 06:00-18:00` will warn until it is converted into `yes @ (snow); yes @ (06:00-18:00)`
`yes @ snow; yes @ (06:00-18:00)` will warn until it is converted into `yes @ (snow); yes @ (06:00-18:00)`
`yes @ (06:00-18:00); yes @ snow` will not warn


Additionally, warning about these will help people to resolve cases like `no @ Fr 16:00-24:00; Sa,Su 00:00-24:00; yes @ wet` which is currently interpret as `no @ Fr 16:00-24:00` + `Sa,Su 00:00-24:00; yes @ wet` and considered valid (as we do not interpret the value to be an valid value)

Involves #1380