### PR TITLE
Allow connection to highway=steps

### DIFF
--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -280,7 +280,7 @@ WHERE
     nodes.tags != ''::hstore AND
     nodes.tags?'highway' AND nodes.tags->'highway' = 'bus_stop' AND
     nodes.tags->'public_transport' != 'stop_position' AND
-    highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform')
+    highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform', 'steps')
 """
 
 sql70 = """
@@ -318,7 +318,7 @@ FROM
 WHERE
   relations.tags->'type' = 'route' AND
   relations.tags->'route' IN ('bus', 'trolleybus', 'coach', 'share_taxi', 'school_bus', 'walking_bus') AND
-  highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform')
+  highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform', 'steps')
 """
 
 sql90 = """


### PR DESCRIPTION
Fixes the false positive of i.e. http://osmose.openstreetmap.fr/en/issue/c4d6b033-c145-57bb-214e-ff070ad857a0 , where a highway=steps directly connects to a platform (https://www.openstreetmap.org/node/3848754089)

Although technically it's better to adjust the map (by having an ~1m footway between the platform and the steps), the error incorrectly suggests to change the role to an invalid value. Hence I think it's better to disable it for highway=steps.
Also adjusted the class=8 warning comparably, although I don't have a real-life example for this