### PR TITLE
Improve numerical testing

### DIFF
--- a/plugins/Capacity.py
+++ b/plugins/Capacity.py
@@ -49,6 +49,9 @@ class Capacity(Plugin):
                 # Ignore errors that should be reported by generic analysers
                 or tags["capacity"] == ""):
             return []
+        # capacity (non-round number in cubic meters or liters) is also for volumes: storage_tank, reservoir_covered, water_tower
+        if "man_made" in tags:
+            return []
         try:
             total_capacity = int(tags["capacity"])
             if total_capacity < 0:
@@ -144,3 +147,5 @@ class Test(TestPluginCommon):
 
         assert not a.node(None, {"capacity": "1", "capacity:": "a"})
         assert not a.node(None, {"capacity:wheelchair": "1"})
+
+        assert not a.node(None, {"capacity": "123.45 m³", "man_made": "water_tower"}

--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -46,11 +46,27 @@ the specified tag.'''),
 '''Check that the value is accurate. Consider whether another tag should
 be used if the value is valid.''')
         )
+        self.errors[3093] = self.def_class(item = 3091, level = 2, tags = ['value', 'fix:chair'],
+            title = T_('Suspicious value'),
+            detail = T_(
+'''The tag expects a positive, round number without unit'''),
+            fix = T_(
+'''Check that the value is accurate. Consider whether another tag should
+be used if the value is valid.''')
+        )
 
-        self.tag_number = ["height", "maxheight", "maxheight:physical", "width", "maxwidth", "length", "maxlength", "maxweight", "maxspeed", "population", "admin_level", "ele"]
+        self.tag_number = ["height", "width", "length", "ele"]
+        self.tag_number_integer = ["population", "admin_level"] # Only positive integers (no units) allowed
+        tag_number_directional = ["maxheight", "maxheight:physical", "maxwidth", "maxlength", "maxweight", "maxspeed", "minspeed"]
+
+        # Add suffixes to the directional tags, add everything to tag_number
+        for i in ["", ":forward", ":backward"]:
+            self.tag_number.extend(list(map(lambda tag: tag + i, tag_number_directional)))
+        self.tag_number.extend(self.tag_number_integer)
+
         self.Number = re.compile(u"^((?:-?[0-9]+(?:[.][0-9]+)?)|(?:[.][0-9]+))(?: ?(?:m|cm|km|nmi|km/h|mph|knots|t|kg|st|lt|cwt)|'(?:[0-9]*(?:[.][0-9]+)?\")?|\")?$")
         self.MaxspeedExtraValue = ["none", "default", "signals", "national", "no", "unposted", "walk", "urban", "variable"]
-        self.MaxspeedClassValue = re.compile(u'^[A-Z]*:.*$')
+        self.MaxspeedClassValue = re.compile(u'^[A-Z]*:')
         self.MaxheightExtraValue = ["default", "below_default", "no_indications", "no_sign", "none", "unsigned"]
 
     def node(self, data, tags):
@@ -59,7 +75,7 @@ be used if the value is valid.''')
                 m = self.Number.match(tags[i])
                 if (not m and
                     not (i == "width" and tags[i] == "narrow") and
-                    not (i == "maxspeed" and (
+                    not (("maxspeed" in i or "minspeed" in i) and (
                         tags[i] in self.MaxspeedExtraValue or
                         self.MaxspeedClassValue.match(tags[i]) or
                         (tags[i] == "implicit" and ("traffic_sign" in tags) and "maxspeed" in tags["traffic_sign"].split(";"))
@@ -67,11 +83,20 @@ be used if the value is valid.''')
                     not (i == "maxheight" and tags[i] in self.MaxheightExtraValue)
                 ):
                     return {"class": 3091, "subclass": 1, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]])) }
-                elif m and i == "height" and float(m.group(1)) > 500:
+                if not m:
+                    continue
+
+                # Below here only tags containing numbers with/without unit remain
+                if i in self.tag_number_integer and str(int(abs(float(m.group(1))))) != tags[i]:
+                    # Expected: positive integer, found: decimal number or number with unit
+                    return {"class": 3093, "subclass": 4, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]])) }
+                elif i == "height" and float(m.group(1)) > 500:
                     return {"class": 3092, "subclass": 2, "text": T_("`height={0}` is really tall, consider changing to `ele=*`", m.group(1)),
                              "fix": {"-": ["height"], "+": {"ele": tags["height"]}} }
-                elif m and i == "maxspeed" and float(m.group(1)) < 5 and not "waterway" in tags:
+                elif "maxspeed" in i and float(m.group(1)) < 5 and not "waterway" in tags:
                     return {"class": 3092, "subclass": 3, "text": T_('`{0}` is really slow', 'maxspeed=' + m.group(1))}
+                elif i == "width" and float(m.group(1)) <= 0 and "highway" in tags: # seems to be an old iD bug
+                    return {"class": 3092, "subclass": 5, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]]))}
 
     def way(self, data, tags, nds):
         return self.node(data, tags)
@@ -97,14 +122,22 @@ class Test(TestPluginCommon):
 
         for d in ["foo", "18kph", "1", "30 c"]:
             self.check_err(a.node(None, {"maxspeed":d}), ("maxspeed='{0}'".format(d)))
+            self.check_err(a.node(None, {"minspeed:backward":d}), ("minspeed:backward='{0}'".format(d)))
 
-        for d in ["50", "FR:urban", "35 mph", "10 knots"]:
+        for d in ["50", "FR:urban", "35 mph", "10 knots", "default"]:
             assert not a.node(None, {"maxspeed":d}), ("maxspeed='{0}'".format(d))
+            assert not a.node(None, {"maxspeed:forward":d}), ("maxspeed:forward='{0}'".format(d))
 
         t = {"maxspeed":"1", "waterway": "river"}
         assert not a.node(None, {"maxspeed":"1", "waterway": "river"}), t
 
         assert not a.node(None, {"maxspeed": "implicit", "traffic_sign": "maxspeed"})
-        assert not a.node(None, {"maxspeed": "default"})
 
         assert not a.node(None, {"maxheight": "default"})
+        
+        assert not a.node(None, {"width": "4.5", "highway": "residential"})
+        assert a.node(None, {"width": "0", "highway": "residential"})
+
+        assert not a.node(None, {"population":"5000"})
+        for d in ["-50", "many", "20 km", "4.5", "4.0"]:
+            assert a.node(None, {"population": d})

--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -55,16 +55,16 @@ be used if the value is valid.''')
 be used if the value is valid.''')
         )
 
-        self.tag_number = ["height", "width", "length", "ele"]
-        self.tag_number_integer = ["population", "admin_level"] # Only positive integers (no units) allowed
-        tag_number_directional = ["maxheight", "maxheight:physical", "maxwidth", "maxlength", "maxweight", "maxspeed", "minspeed"]
+        self.tag_number = ["diameter", "distance", "ele", "height", "length", "width"]
+        self.tag_number_integer = ["admin_level", "capital", "heritage", "population", "step_count"] # Only positive integers (no units) allowed
+        tag_number_directional = ["maxaxleload", "maxheight", "maxheight:physical", "maxlength", "maxspeed", "maxspeed:advisory", "maxweight", "maxwidth", "minspeed"]
 
         # Add suffixes to the directional tags, add everything to tag_number
         for i in ["", ":forward", ":backward"]:
             self.tag_number.extend(list(map(lambda tag: tag + i, tag_number_directional)))
         self.tag_number.extend(self.tag_number_integer)
 
-        self.Number = re.compile(u"^((?:-?[0-9]+(?:[.][0-9]+)?)|(?:[.][0-9]+))(?: ?(?:m|cm|km|nmi|km/h|mph|knots|t|kg|st|lt|cwt)|'(?:[0-9]*(?:[.][0-9]+)?\")?|\")?$")
+        self.Number = re.compile(u"^((?:-?[0-9]+(?:[.][0-9]+)?)|(?:[.][0-9]+))(?: ?(?:m|cm|mm|km|nmi|km/h|mph|knots|t|kg|st|lbs|lt|cwt)|'(?:[0-9]*(?:[.][0-9]+)?\")?|\")?$")
         self.MaxspeedExtraValue = ["none", "default", "signals", "national", "no", "unposted", "walk", "urban", "variable"]
         self.MaxspeedClassValue = re.compile(u'^[A-Z]*:')
         self.MaxheightExtraValue = ["default", "below_default", "no_indications", "no_sign", "none", "unsigned"]
@@ -75,6 +75,8 @@ be used if the value is valid.''')
                 m = self.Number.match(tags[i])
                 if (not m and
                     not (i == "width" and tags[i] == "narrow") and
+                    not (i == "capital" and tags[i] == "yes") and
+                    not (i == "heritage" and tags[i] == "yes") and
                     not (("maxspeed" in i or "minspeed" in i) and (
                         tags[i] in self.MaxspeedExtraValue or
                         self.MaxspeedClassValue.match(tags[i]) or
@@ -134,7 +136,10 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"maxspeed": "implicit", "traffic_sign": "maxspeed"})
 
         assert not a.node(None, {"maxheight": "default"})
-        
+
+        assert not a.node(None, {"capital":"yes"})
+        assert not a.node(None, {"capital":"2"})
+
         assert not a.node(None, {"width": "4.5", "highway": "residential"})
         assert a.node(None, {"width": "0", "highway": "residential"})
 


### PR DESCRIPTION
- Add support for `max(speed/width/length/...):(forward/backward)`
- Check that integer-only keys are truly integers
- Add special check for `width=0` on highways (a former bug in iD as far as I could determine, about 8k worldwide)
- Added `diameter`, `distance`, `capital`, `heritage`, `step_count`, `maxaxleload`, `maxspeed:advisory`, `minspeed`
- Added `mm` and `lbs` as units
- fix `capacity` check on volumes (i.e. `man_made=storage_tank`)