### PR TITLE
Accept mi as unit

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -72,7 +72,7 @@ be used if the value is valid.''')
             self.tag_number.extend(list(map(lambda tag: tag + i, tag_number_directional)))
         self.tag_number.extend(self.tag_number_integer)
 
-        self.units = ["m", "cm", "mm", "km", "nmi", # distance excluding feet'inch"
+        self.units = ["m", "cm", "mm", "km", "mi", "nmi", # distance excluding feet'inch"
                       "km/h", "mph", "knots", # speed
                       "t", "kg", "st", "lbs", "lt", "cwt"] # weight
 


### PR DESCRIPTION
Eliminates the majority of issues of this plugin found in [usa_pennsylvania](https://osmose.openstreetmap.fr/en/issues/open?item=3091&source=12044 ) and a large amount in [usa_wisconsin](https://osmose.openstreetmap.fr/en/issues/open?country=usa_wisconsin&item=3091).
According to https://wiki.openstreetmap.org/wiki/Map_features/Units it's also an accepted (alternative, non-discouraged) unit

Previously they were in class 3091 ("invalid"), but in #1398 they were 'moved' to class 3094 ("Unknown unit"). Obviously they don't belong in either :). ~(Until we can convince the US to use the metric system)~

(Note that #1398 also added support for the key `distance` which uses 'mi'-units a lot, hence the numbers went up a lot)