### PR TITLE
Allow duplicate values of voltage

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -58,6 +58,7 @@ similar.'''),
             'healthcare:speciality',
             'traffic_sign',
             'sport',
+            'voltage',
             'addr:flats', 'addr:housenumber', 'addr:unit', 'addr:floor', 'addr:block', 'addr:door',
         ))
         self.BlackListRegex = set((


### PR DESCRIPTION
Fixes i.e. https://osmose.openstreetmap.fr/nl/issue/7d31b94c-b199-d15e-89b8-a3a070221d5c
[way 716680780](https://www.openstreetmap.org/way/716680780) `voltage=380000;380000;150000;150000`

According to the [wiki](https://wiki.openstreetmap.org/wiki/Key:voltage#Examples) this is allowed; the example given:
> A transmission line carrying two circuits at 110 kV and one at 66 kV:
> `voltage=110000;110000;66000`

Several hundreds of cases worldwide