### PR TITLE
Fixes for item 3360: Conflicting tags for sides of the way

### DIFF
--- a/plugins/Highway_Sides.py
+++ b/plugins/Highway_Sides.py
@@ -54,6 +54,8 @@ class Highway_Sides(Plugin):
             if tag_default in tags:
                 tt = tags[tag].replace("none", "no").replace("opposite_", "")
                 ttd = tags[tag_default].replace("none", "no").replace("opposite_", "")
+                if tag[0:5] == "name:" and tt in ttd:
+                    continue # 'name' probably equals "name:left" + "/" + name:right, handled by Name_Multiple
                 if tt != ttd and not ttd in allowedAlternativeValues:
                     err.append({"class": 33601, "subclass": 1 + stablehash64(tag), "text": T_("Conflicting values of \"{0}\" and \"{1}\"", tag_default, tag)})
 
@@ -79,6 +81,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "sidewalk": "yes", "sidewalk:left": "yes", "sidewalk:right": "yes", "sidewalk:both": "yes"}, # redundant, not conflicting
                   {"highway": "residential", "sidewalk": "right", "sidewalk:left": "no"}, # redundant, not conflicting
                   {"highway": "residential", "sidewalk": "none", "sidewalk:left": "no"}, # redundant, not conflicting
+                  {"highway": "residential", "name": "StreetA / StreetB", "name:left": "StreetA", "name:right": "StreetB"},
                   {"highway": "residential", "cycleway": "opposite_lane", "cycleway:left": "lane"}, # dubious whether equal
                  ]:
             assert not a.way(None, t, None), a.way(None, t, None)

--- a/plugins/Highway_Sides.py
+++ b/plugins/Highway_Sides.py
@@ -47,8 +47,8 @@ class Highway_Sides(Plugin):
                 continue # tag does not contain :both/:left/:right
             allowedAlternativeValues = []
             if tag_default in tags:
-                # Some tags allow left/right/both as values, e.g. sidewalk=both equals sidewalk:both=yes
-                allowedAlternativeValues = ["left", "right", "both", "yes"]
+                # Some tags allow i.e. left/right/both as values, e.g. sidewalk=both equals sidewalk:both=yes
+                allowedAlternativeValues = ["left", "right", "both", "yes", "opposite"]
             else:
                 tag_default = tag.replace(":left", ":both").replace(":right", ":both")
             if tag_default in tags:
@@ -83,6 +83,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "sidewalk": "none", "sidewalk:left": "no"}, # redundant, not conflicting
                   {"highway": "residential", "name": "StreetA / StreetB", "name:left": "StreetA", "name:right": "StreetB"},
                   {"highway": "residential", "cycleway": "opposite_lane", "cycleway:left": "lane"}, # dubious whether equal
+                  {"highway": "residential", "cycleway": "opposite", "cycleway:left": "no"}, # dubious whether equal
                  ]:
             assert not a.way(None, t, None), a.way(None, t, None)
 

--- a/plugins/Highway_Sides.py
+++ b/plugins/Highway_Sides.py
@@ -48,7 +48,7 @@ class Highway_Sides(Plugin):
             allowedAlternativeValues = []
             if tag_default in tags:
                 # Some tags allow left/right/both as values, e.g. sidewalk=both equals sidewalk:both=yes
-                if simplifyValue(tags[tag]) == "no":
+                if self.simplifyValue(tags[tag]) == "no":
                     allowedAlternativeValues = ["yes", "left", "right", "separate", "opposite"]
                 else:
                     allowedAlternativeValues = ["yes", "left", "right", "both"]
@@ -56,8 +56,8 @@ class Highway_Sides(Plugin):
                 tag_default = tag.replace(":left", ":both").replace(":right", ":both")
 
             if tag_default in tags:
-                tt = simplifyValue(tags[tag])
-                ttd = simplifyValue(tags[tag_default])
+                tt = self.simplifyValue(tags[tag])
+                ttd = self.simplifyValue(tags[tag_default])
                 if tag[0:5] == "name:" and tt in ttd:
                     continue # 'name' probably equals "name:left" + "/" + name:right, handled by Name_Multiple
                 if tt != ttd and not ttd in allowedAlternativeValues:
@@ -66,7 +66,7 @@ class Highway_Sides(Plugin):
         if err != []:
             return err
 
-    def simplifyValue(val):
+    def simplifyValue(self, val):
         if val in ["none"]:
             return "no"
         return val.replace("opposite_", "")


### PR DESCRIPTION
https://osmose.openstreetmap.fr/en/issues/open?source=&class=&useDevItem=all&username=&bbox=&item=3360

The new item implemented in #1405, currently under the useDevItem flag
~I'll add fixes to this PR when encountering them. Currently:~

- [x] Disable warning for `name=A/B` + `name:right=A` + `name:left=B`, that's handled by Name_Multiple (ex: [way](https://www.openstreetmap.org/way/34723456), [issue](https://osmose.openstreetmap.fr/en/issue/4f5cca51-0a6a-6295-3f27-65e139e0b3d4))
- [x] Disable warning for `cycleway=opposite` + `cycleway:[side]=no` (ex: [way](https://www.openstreetmap.org/way/4845489), [issue](https://osmose.openstreetmap.fr/en/issue/6a81d93d-d41e-6e60-72fa-3b002d08161d))
- [x] Disable warning for `sidewalk=separate` + `sidewalk:right=separate` + `sidewalk:left=no` (Quebec style, makes some sense. Ex: [way](https://www.openstreetmap.org/way/909293109), [issue](https://osmose.openstreetmap.fr/en/issue/3b5f224c-0615-f0d1-3095-0efd50099cf4))
- [x] Disallow the combination of `xxx=both` + `xxx:side=no` (limitation in previous implementation)

This should fix the majority of the false positives / duplicate warnings / dubious issues. After deployment of this PR (still under useDevItem) I'll re-check if there are no more false positives remaining.