### PR TITLE
Update KOpeningHours to v21.12.3

### DIFF
--- a/plugins/TagFix_Opening_Hours.py
+++ b/plugins/TagFix_Opening_Hours.py
@@ -80,7 +80,7 @@ class Test(TestPluginCommon):
 
         # These are OK, no suggestion
         assert not a.node(None, {'opening_hours': 'Mo-Fr 10:00-19:00'})
-        assert not a.node(None, {'opening_hours': 'Mo-Tu,Th-Fr 09:30-12:00; We 15:00-17:00; 2020 Dec 24,2020 Dec 31 off; Sa,Su off; PH off'})
+        assert not a.node(None, {'opening_hours': 'Mo-Tu,Th-Fr 09:30-12:00; We 15:00-17:00; 2020 Dec 24,31 off; Sa,Su off; PH off'})
         assert not a.node(None, {'opening_hours': 'Mo off, Tu-Th 09:00-18:00; Fr 09:00-19:00; Sa 08:00-18:00; Su off'})
 
         # Check 00:00 and 24:00 are both OK

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium >= 3.1.3
-git+https://invent.kde.org/libraries/kopeninghours.git@v21.08.3
+git+https://invent.kde.org/libraries/kopeninghours.git@v21.12.3
 git+https://github.com/jocelynj/PyEasyArchive.git
 
 # Tests


### PR DESCRIPTION
Relevant changes:
* b4cbddb - Turn nthMask into a vector of entries, to preserve intervals and ordering (https://bugs.kde.org/445963)
* 9818afb - Extended monthdays: remove ascending requirement
* e6bec2a - Extend the extended syntax for month day sets
* 405c78d - Simplify "Feb 1-29" to "Feb" (https://bugs.kde.org/446252)
* 9bb6be7 - Consider "through" as alternative range separator (https://bugs.kde.org/446136)
* 95f816e - Do not repeat months when unnecessary (https://bugs.kde.org/446224)
* 10dd6fd - Fix autocorrect for cases where the state differs (https://bugs.kde.org/445787)
* c491165 - Add more Spanish state values (https://bugs.kde.org/446134)
* 0248312 - Support 4 digit times to the extend possible (https://bugs.kde.org/446137)
* 33b00e2 - Merge adjacent single weekday and time range selectors (https://bugs.kde.org/445784)
* ca23f16 - Convert 24/7 rules to timespan selectors when used in a timespan context (https://bugs.kde.org/445962)
* 15a84ba - Add Russian language support for states and sun-based events (https://bugs.kde.org/445785)
* cd73585 - Parse Russian long-form time ranges
* e50c9ed - Add localized Russian month names
* 7142395 - Parse localized Russian day names
* 0d02b17 - Don't turn 20:00-26:00 into 20:00-02:00
