### PR TITLE
French minor distribution substations opendata extension

### DIFF
--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -59,6 +59,6 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                         "substation": "minor_distribution"},
                     mapping2 = {
                         "operator": "NOM_GRD",
-                        "source": lambda fields: self.source+"/"+fields["NOM_GRD"],
+                        "source": lambda fields: self.source + " - " + fields["NOM_GRD"],
                         "name": lambda fields: fields["NOM_POSTE"] if fields["NOM_POSTE"] not in ("") else None},
                 )))

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -48,7 +48,7 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                     types = ["nodes", "ways"],
                     tags = [
                         {"power": "substation", "substation": "minor_distribution"},
-                        {"power": None, "transformer": ["distribution", "main"},
+                        {"power": None, "transformer": ["distribution", "main"]},
                         {"power": "substation", "substation": "distribution"}]),
                 conflationDistance = 50,
                 mapping = Mapping(

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -28,10 +28,11 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
     def __init__(self, config, logger = None):
         Analyser_Merge.__init__(self, config, logger)
         self.def_class_missing_official(item = 8280, id = 11, level = 3, tags = ['merge', 'power', 'fix:survey', 'fix:picture'],
-            title = T_('Minor distribution power substation not integrated'),
-            detail = T ('A power substation that directly feeds consumers, known from operator, does not exist in OSM'))
+            title = T_('Minor distribution power substation missing in OSM'),
+            detail = T_('A power substation that directly feeds consumers, known from operator, does not exist in OSM.'))
         self.def_class_possible_merge(item = 8281, id = 13, level = 3, tags = ['merge', 'power', 'fix:chair'],
-            title = T_('Power minor_distribution substation, integration suggestion'))
+            title = T_('Power minor distribution substation, integration suggestion'),
+            detail = T_('This existing power substation can be integrated with official values.'))
 
         self.init(
             "https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/",

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -56,9 +56,9 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                         "power": "substation",
                         "voltage": "20000"},
                     static2 = {
-                        "substation": "minor_distribution",
-                        "source": self.source},
+                        "substation": "minor_distribution"},
                     mapping2 = {
                         "operator": "NOM_GRD",
+                        "source": self.source+"/"+fields["NOM_GRD"],
                         "name": lambda fields: fields["NOM_POSTE"] if fields["NOM_POSTE"] not in ("") else None},
                 )))

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -59,6 +59,6 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                         "substation": "minor_distribution"},
                     mapping2 = {
                         "operator": "NOM_GRD",
-                        "source": self.source+"/"+fields["NOM_GRD"],
+                        "source": lambda fields: self.source+"/"+fields["NOM_GRD"],
                         "name": lambda fields: fields["NOM_POSTE"] if fields["NOM_POSTE"] not in ("") else None},
                 )))

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -28,16 +28,17 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
     def __init__(self, config, logger = None):
         Analyser_Merge.__init__(self, config, logger)
         self.def_class_missing_official(item = 8280, id = 11, level = 3, tags = ['merge', 'power', 'fix:survey', 'fix:picture'],
-            title = T_('Power minor_distribution substation not integrated'))
+            title = T_('Minor distribution power substation not integrated'),
+            detail = T ('A power substation that directly feeds consumers, known from operator, does not exist in OSM'))
         self.def_class_possible_merge(item = 8281, id = 13, level = 3, tags = ['merge', 'power', 'fix:chair'],
             title = T_('Power minor_distribution substation, integration suggestion'))
 
         self.init(
-            "https://data.enedis.fr/explore/dataset/poste-electrique/",
+            "https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/",
             "Postes HTA/BT",
             CSV(SourceOpenDataSoft(
-                attribution="Enedis",
-                url="https://data.enedis.fr/explore/dataset/poste-electrique")),
+                attribution="Exploitants contributeurs de l'Agence ORE",
+                url="https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/")),
             Load("Geo Point", "Geo Point",
                 xFunction = lambda x: x and x.split(',')[1],
                 yFunction = lambda y: y and y.split(',')[0]),
@@ -45,16 +46,18 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes", "ways"],
                     tags = [
-                        {"power": "substation", "substation": "minor_distribution", "operator": [False, "EDF", "ERDF", "Enedis"]},
-                        {"power": None, "transformer": "distribution", "operator": [False, "EDF", "ERDF", "Enedis"]},
-                        {"power": "substation", "substation": "distribution", "operator": [False, "EDF", "ERDF", "Enedis"]}]),
+                        {"power": "substation", "substation": "minor_distribution"},
+                        {"power": None, "transformer": ["distribution", "main"},
+                        {"power": "substation", "substation": "distribution"}]),
                 conflationDistance = 50,
                 mapping = Mapping(
                     static1 = {
                         "power": "substation",
-                        "voltage": "20000",
-                        "operator": "Enedis"},
+                        "voltage": "20000"},
                     static2 = {
                         "substation": "minor_distribution",
                         "source": self.source},
+                    mapping2 = {
+                        "operator": "NOM_GRD",
+                        "name": lambda fields: fields["NOM_POSTE"] if fields["NOM_POSTE"] not in ("") else None},
                 )))


### PR DESCRIPTION
I propose this change regarding `analyser_merge_power_substation_minor_FR.py`.

It enlarge the scope of available opendata from Enedis only to all French distribution operators.
https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/

The new files contains some substations' names, when available.
The operator's name is got in `NOM_GRD` column. I will propose to add a supplementary column with proper operator OSM value in near future.