### PR TITLE
Add Luxembourgish

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -616,7 +616,7 @@ lithuania = default_country("europe", "lithuania", 72596, {"country": "LT", "lan
 del(lithuania.analyser["osmosis_highway_cul-de-sac_level"]) # follow official highway classification
 del(lithuania.analyser["osmosis_highway_broken_level_continuity"]) # follow official highway classification
 default_country("europe", "latvia", 72594, {"country": "LV","language": "lv", "proj": 32634}, download_repo=GEOFABRIK)
-luxembourg = default_country("europe", "luxembourg", 2171347, {"country": "LU", "language": "fr_LU", "proj": 2169, "boundary_detail_level": 6})
+luxembourg = default_country("europe", "luxembourg", 2171347, {"country": "LU", "language": ["fr_LU", "lb"], "proj": 2169, "boundary_detail_level": 6})
 luxembourg.analyser["merge_emergency_points_LU"] = "xxx"
 default_country("europe", "malta", 365307, {"country": "MT", "language": "en", "driving_side": "left", "proj": 32633})
 default_country("europe", "macedonia", 53293, {"country": "MK", "language": "sq", "proj": 32634})


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Luxembourgish -> ISO 639-1 = `lb`
Fixes "Default and local language name not the same" errors in Luxembourg (i.e. [error](http://osmose.openstreetmap.fr/en/issue/d6d9439c-4562-e51c-8d55-b03beae627af) - [way](https://www.openstreetmap.org/way/128541299) )

Does not fix issue 1415; that requires a change to [plugins/Name_PoorlyWrittenWayType*](https://github.com/osm-fr/osmose-backend/blob/master/plugins/Name_PoorlyWrittenWayType.py) as well