### PR TITLE
Followup of 1424 - review comments of ConditionalRestrictions update

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -248,7 +248,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:forward:conditional": "no @ (10:00-18:00 AND length>5)"},
                   {"highway": "residential", "access:conditional": "no @ 2099"},
                   {"highway": "residential", "access:conditional": "no @ (weight >= 12020 AND length < 20200)"},
-                  #{"highway": "residential", "access:conditional": "no @ (2099 May 22-2099 Oct 07)"}, #https://bugs.kde.org/show_bug.cgi?id=452236
+                  #{"highway": "residential", "access:conditional": "no @ (2099 May 22-2099 Oct 07)"}, # https://bugs.kde.org/show_bug.cgi?id=452236
                   {"highway": "residential", "access:conditional": "no @ (2010 May 22-2099 Oct 07)"},
                   {"highway": "residential", "turn:lanes:forward:conditional": "left|through|through;right @ (Mo-Fr 06:00-09:00)"},
                  ]:
@@ -263,12 +263,12 @@ class Test(TestPluginCommon):
                  ]:
           assert a.way(None, t, None), a.way(None, t, None)
 
-        # Invalid or suboptimal conditions in conditionals
+        # Invalid conditions in conditionals
         for t in [{"highway": "residential", "access:conditional": "no @ (weight >)"},
                   {"highway": "residential", "access:conditional": "no @ (foggy AND weight <= AND wet); destination @ snow"},
                   {"highway": "residential", "access:conditional": "no @ (2098-05-22 - 2099-10-7)"},
                   {"highway": "residential", "access:conditional": "no @ (22 mei 2099 - 07 okt 2099)"},
-                  #{"highway": "residential", "access:conditional": "no @ (JUL 01-JAN 31)"}, #disabled as TagFix_Opening_Hours calls lower()
+                  {"highway": "residential", "access:conditional": "no @ (JUL 01-JAN 31)"},
                   {"highway": "residential", "access:conditional": "no @ (6h00-19h00)"},
                   {"highway": "residential", "access:conditional": "no @ (Ma-Vr 18:00-20:00); destination @ (length < 4)"},
                   {"highway": "residential", "access:conditional": "no @ (Mei 22 - Okt 7 AND weight > 5)"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -146,9 +146,9 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
           condition_ANDsplitted = list(map(str.strip, self.ReAND.split(condition)))
           # Check the position of AND is ok
           if "" in condition_ANDsplitted:
-            err.append({"class": 33501, "subclass": 4 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition before or after AND combinator in \"{0}\"", tag)})
+            err.append({"class": 33501, "subclass": 4 + stablehash64(tag + '|' + tag_value + '|' + condition), "text": T_("Missing condition before or after AND combinator in \"{0}\"", tag)})
             bad_tag = True
-            break
+            continue
 
           if len(condition_ANDsplitted) != condition.count("AND") + 1:
             # Likely lower/mixed case 'AND' used. Might also be a opening_hours fallback rule

--- a/plugins/TagFix_Opening_Hours.py
+++ b/plugins/TagFix_Opening_Hours.py
@@ -48,7 +48,7 @@ class TagFix_Opening_Hours(Plugin):
             return {"isValid": False}
         sanitized_field = parser.normalizedExpression()
         # Ignore trivial changes that can be fixed by bots rather than humans like spaces, case errors, etc
-        simplify = lambda s: s.replace(' ', '').replace('24:00', '00:00').replace('0', '').lower()
+        simplify = lambda s: s.replace(' ', '').replace('24:00', '00:00').replace('0', '')
         if simplify(sanitized_field) != simplify(openinghours_value):
             return {"isValid": False, 'fix': sanitized_field}
         return {"isValid": True}

--- a/plugins/TagFix_Opening_Hours.py
+++ b/plugins/TagFix_Opening_Hours.py
@@ -83,8 +83,8 @@ class Test(TestPluginCommon):
         self.check_err(a.node(None, {'opening_hours': 'Monday to Friday 8:00AM to 4:30PM'}), expected={"class": 32501, "subclass": 0, 'fix': {'opening_hours': 'Mo-Fr 08:00-16:30'}})
 
         # These return a parse error
-        self.check_err(a.node(None, {'opening_hours': 'mo-fr 10h - 19h00"'}), expected={"class": 32501, "subclass": 1, 'text': T_("The `opening_hours` value is invalid and could not be parsed")})
-        self.check_err(a.node(None, {'opening_hours': '09:00-21:00 TEL/072(360)3200'}), expected={"class": 32501, "subclass": 1, 'text': T_("The `opening_hours` value is invalid and could not be parsed")})
+        self.check_err(a.node(None, {'opening_hours': 'mo-fr 10h - 19h00"'}), expected={"class": 32501, "subclass": 1})
+        self.check_err(a.node(None, {'opening_hours': '09:00-21:00 TEL/072(360)3200'}), expected={"class": 32501, "subclass": 1})
 
         # These are OK, no suggestion
         assert not a.node(None, {'opening_hours': 'Mo-Fr 10:00-19:00'})


### PR DESCRIPTION
PR #1424 was accidentally merged to master, before all review comments were implemented
This should address the review comments:
- use continue rather than break
- remove `lower()` normalization
- remove `text: *` from tests