### PR TITLE
Fixes the analyser_merge_power_branch_fr.py select filter with regexp

### DIFF
--- a/analysers/analyser_merge_power_branch_FR.py
+++ b/analysers/analyser_merge_power_branch_FR.py
@@ -48,8 +48,7 @@ class Analyser_Merge_Power_Branch_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes"],
                     tags = [
-                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": False},
-                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE"}]),
+                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":"(^|\(|\|)branch(\||\)|$)"}}]),
                 osmRef = "ref:FR:RTE",
                 conflationDistance = 200,
                 mapping = Mapping(

--- a/analysers/analyser_merge_power_branch_FR.py
+++ b/analysers/analyser_merge_power_branch_FR.py
@@ -48,7 +48,7 @@ class Analyser_Merge_Power_Branch_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes"],
                     tags = [
-                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":"(^|\\(|\\|)branch(\\||\\)|$)"}}]),
+                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":r"(^|\(|\|)branch(\||\)|$)"}}]),
                 osmRef = "ref:FR:RTE",
                 conflationDistance = 200,
                 mapping = Mapping(

--- a/analysers/analyser_merge_power_branch_FR.py
+++ b/analysers/analyser_merge_power_branch_FR.py
@@ -48,7 +48,7 @@ class Analyser_Merge_Power_Branch_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes"],
                     tags = [
-                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":r"(^|\(|\|)branch(\||\)|$)"}}]),
+                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management": {"regex": r"(^|\(|\|)branch(\||\)|$)"}}]),
                 osmRef = "ref:FR:RTE",
                 conflationDistance = 200,
                 mapping = Mapping(

--- a/analysers/analyser_merge_power_branch_FR.py
+++ b/analysers/analyser_merge_power_branch_FR.py
@@ -48,7 +48,7 @@ class Analyser_Merge_Power_Branch_FR(Analyser_Merge):
                 select = Select(
                     types = ["nodes"],
                     tags = [
-                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":"(^|\(|\|)branch(\||\)|$)"}}]),
+                        {"power": ["tower", "pole", "portal", "insulator", "connection"], "operator": "RTE", "line_management":{"regex":"(^|\\(|\\|)branch(\\||\\)|$)"}}]),
                 osmRef = "ref:FR:RTE",
                 conflationDistance = 200,
                 mapping = Mapping(


### PR DESCRIPTION
Following bogus filter in #1416, in propose this new improvement.

It should only select power supports with operator=RTE and line_management ~branch.
It sounds I'm the first to use regex filter, no other analyser uses it, right?

* https://www.openstreetmap.org/node/1759546819 should not match
* https://www.openstreetmap.org/node/1773389169 should raise no error
* https://www.openstreetmap.org/node/1933361368 should raise update with ref:FR:RTE=...
* https://www.openstreetmap.org/node/1195472674 should raise missing official feature in OSM.