### PR TITLE
ConditionalRestrictions: warn if there's something before '(' or after ')'

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -113,6 +113,10 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
             err.append({"class": 33501, "subclass": 0 + stablehash64(tag + '|' + tag_value), "text": T_("Missing `@` in \"{0}\"", tag)})
             bad_tag = True
             break
+          if parentheses == 1 and tmp_str.lstrip() != "":
+            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition, `@` or parentheses in \"{0}\"", tag)})
+            bad_tag = True
+            break
         elif c == ")":
           parentheses -= 1
           if parentheses == -1:
@@ -294,6 +298,7 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "yes @ ()"},
                   {"highway": "residential", "access:conditional": "yes @"},
                   {"highway": "residential", "access:conditional": "@ wet"},
+                  {"highway": "residential", "access:conditional": "no_@_(06:00-19:00)"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND AND 2099 Oct 07)"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND 2099 Oct 07 AND); delivery @ wet"},
                   {"highway": "residential", "maxweight:conditional": "27000 lbs (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles>=4)"},

--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -84,6 +84,7 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
       tag_value = tags_conditional[tag]
       conditions = []
       parentheses = 0
+      past_parentheses = False
       bad_tag = False
 
       if not "@" in tag_value:
@@ -100,7 +101,7 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
       tmp_str = ""
       condition_started = False
       for c in tag_value:
-        if c == "@":
+        if c == "@" and not past_parentheses:
           if len(tmp_str.strip()) == 0:
             err.append({"class": 33501, "subclass": 1 + stablehash64(tag + '|' + tag_value), "text": T_("Missing value for the condition in \"{0}\"", tag)})
             bad_tag = True
@@ -114,7 +115,7 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
             bad_tag = True
             break
           if parentheses == 1 and tmp_str.lstrip() != "":
-            err.append({"class": 33501, "subclass": 3 + stablehash64(tag + '|' + tag_value), "text": T_("Missing condition, `@` or parentheses in \"{0}\"", tag)})
+            err.append({"class": 33501, "subclass": 7 + stablehash64(tag + '|' + tag_value), "text": T_("Unexpected \"{0}\" before or after parentheses in \"{1}\"", tmp_str.strip(), tag)})
             bad_tag = True
             break
         elif c == ")":
@@ -123,6 +124,8 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
             err.append({"class": 33501, "subclass": 2 + stablehash64(tag + '|' + tag_value), "text": T_("Mismatch in the number of parentheses in \"{0}\"", tag)})
             bad_tag = True
             break
+          if parentheses == 0:
+            past_parentheses = True
         elif c == ";" and parentheses == 0 and condition_started:
           tmp_str = tmp_str.strip()
           if len(tmp_str) == 0:
@@ -131,9 +134,14 @@ For example, use `no @ (weight > 5 AND wet)` rather than `no@weight>5 and wet`.'
             break
           conditions.append(tmp_str)
           condition_started = False
+          past_parentheses = False
           tmp_str = ""
         else:
           tmp_str += c
+          if past_parentheses and c != " ": # tolerate spaces
+            err.append({"class": 33501, "subclass": 7 + stablehash64(tag + '|' + tag_value), "text": T_("Unexpected \"{0}\" before or after parentheses in \"{1}\"", c, tag)})
+            bad_tag = True
+            break
 
       if not bad_tag:
         if parentheses == 0:
@@ -299,6 +307,8 @@ class Test(TestPluginCommon):
                   {"highway": "residential", "access:conditional": "yes @"},
                   {"highway": "residential", "access:conditional": "@ wet"},
                   {"highway": "residential", "access:conditional": "no_@_(06:00-19:00)"},
+                  {"highway": "residential", "access:conditional": "no @ (abc)_; no @ (06:00-19:00)"},
+                  {"highway": "residential", "access:conditional": "no @ (abc); no @ (06:00-19:00)_"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND AND 2099 Oct 07)"},
                   {"highway": "residential", "access:conditional": "no @ (2099 May 22 AND 2099 Oct 07 AND); delivery @ wet"},
                   {"highway": "residential", "maxweight:conditional": "27000 lbs (axles=2); 41400 lbs @ (axles=3); 48600 lbs @ (axles>=4)"},


### PR DESCRIPTION
Example: https://www.openstreetmap.org/node/8365099879

Presently `a @ b(c)` (an invalid expression) is treated as `a @ bc`. If `bc` is an invalid condition (example: b=`_`, c=`2022 May 04`, giving `_2022 May 04`, which will trigger the invalid date warning) , the error will say the time is invalid. (Someone marked the above way as a false positive, hence I spotted this...)

Similar issue occurs if there's something after the closing `)`. This is especially common with `*:lanes:conditional`, when people use:
`tag:lanes:conditional = a @ (b)||; c @ (d)||` instead of
`tag:lanes:conditional = a|| @ (b); c|| @ (d)`
Example: https://www.openstreetmap.org/way/302595376

Instead, the current PR makes sure the entire condition is marked as invalid when there's something before or after parentheses. (So also `no @_(wet)_` will be found, currently that escapes detection)