### PR TITLE
Disable analysers for non-existing speed limits in NL

### DIFF
--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -219,6 +219,7 @@
     "title": "max speed limit 35",
     "not_for": [
       "CA",
+      "NL",
       "US"
     ],
     "object": [
@@ -299,6 +300,7 @@
     "title": "max speed limit 45",
     "not_for": [
       "CA",
+      "NL",
       "US"
     ],
     "object": [
@@ -634,6 +636,7 @@
       "IM",
       "JE",
       "LR",
+      "NL",
       "US",
       "WS"
     ],


### PR DESCRIPTION
Speed limit signs of 35, 45 and 110 do not exist in The Netherlands, hence any detection must be a false positive. Therefore, I think disabling those is the easiest. 