### PR TITLE
Update TagFix_Maxspeed.py

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -53,6 +53,7 @@ class TagFix_Maxspeed(Plugin):
         'dk:rural': ['80'],
         'es:urban': ['20', '30', '50'],
         'fr:rural': ['80', '90'],
+        'fr:urban': ['30', '50'],
         'gb:nsl_single': ['60 mph'],
         'gb:nsl_dual': ['70 mph'],
         'gb:motorway': ['70 mph'],


### PR DESCRIPTION
A lot of cities like Paris have now a maximum speed of 30km/h wich brings a lot of errors in Osmose. "Discordant maxspeed and source:maxspeed or maxspeed:type. Discordance entre 30 et FR:urban"