### PR TITLE
Add more keys to TagFix_BadValue

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -45,7 +45,7 @@ However, this should probably still conform to the typical format used for value
         self.check_list_open = set((
             'abutters', 'access', 'admin_level', 'aerialway', 'aeroway', 'amenity',
             'barrier', 'bench', 'bicycle', 'bicycle_parking', 'bin', 'boat', 'border_type', 'boundary', 'bridge', 'building', 'bus', 'bus_bay',
-            'cemetery', 'club', 'construction', 'covered', 'craft', 'crossing', 'crossing_ref', 'cuisine', 'cutting', 'cycleway',
+            'cemetery', 'club', 'construction', 'covered', 'craft', 'crossing_ref', 'cuisine', 'cutting', 'cycleway',
             'disused', 'drive_in', 'drive_through',
             'electrified', 'embankment', 'emergency', 'entrance',
             'fenced', 'foot', 'footway', 'ford',
@@ -54,7 +54,7 @@ However, this should probably still conform to the typical format used for value
             'information', 'intermittent', 'internet_access',
             'junction',
             'kerb',
-            'landuse', 'lanes', 'leaf_type', 'leaf_cycle', 'leisure', 'location',
+            'landuse', 'leaf_type', 'leaf_cycle', 'leisure', 'location',
             'material', 'man_made', 'meadow', 'military', 'mooring', 'motor_vehicle', 'motorboat', 'motorcar', 'motorcycle', 'mountain_pass',
             'natural', 'noexit',
             'office',

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -44,27 +44,27 @@ However, this should probably still conform to the typical format used for value
         self.Values_open = re.compile("^[a-z0-9_]+( *; *[a-z0-9_]+)*$")
         self.check_list_open = set((
             'abutters', 'access', 'admin_level', 'aerialway', 'aeroway', 'amenity',
-            'barrier', 'bicycle', 'bicycle_parking', 'boat', 'border_type', 'boundary', 'bridge', 'building', 'bus_bay',
-            'construction', 'covered', 'craft', 'crossing', 'cutting', 'cycleway',
+            'barrier', 'bench', 'bicycle', 'bicycle_parking', 'bin', 'boat', 'border_type', 'boundary', 'bridge', 'building', 'bus', 'bus_bay',
+            'cemetery', 'club', 'construction', 'covered', 'craft', 'crossing', 'crossing_ref', 'cuisine', 'cutting', 'cycleway',
             'disused', 'drive_in', 'drive_through',
-            'electrified', 'embankment', 'emergency',
+            'electrified', 'embankment', 'emergency', 'entrance',
             'fenced', 'foot', 'footway', 'ford',
-            'geological', 'goods',
-            'handrail', 'hgv', 'highway', 'historic',
-            'intermittent', 'internet_access',
+            'geological', 'golf', 'goods',
+            'handrail', 'hazard', 'healthcare', 'hgv', 'highway', 'historic', 'horse',
+            'information', 'intermittent', 'internet_access',
             'junction',
-            'landuse', 'lanes', 'leisure',
-            'man_made', 'military', 'mooring', 'motorboat', 'mountain_pass',
+            'kerb',
+            'landuse', 'lanes', 'leaf_type', 'leaf_cycle', 'leisure', 'location',
+            'material', 'man_made', 'meadow', 'military', 'mooring', 'motor_vehicle', 'motorboat', 'motorcar', 'motorcycle', 'mountain_pass',
             'natural', 'noexit',
             'office',
-            'parking', 'power', 'public_transport',
-            'railway', 'ramp', 'route',
-            'sac_scale', 'service', 'shelter', 'shop', 'shoulder', 'sidewalk', 'smoothness', 'sport', 'surface',
-            'tactile_paving', 'toll', 'tourism', 'tracktype', 'traffic_calming', 'trail_visibility',
-            'traffic_signals', 'tunnel',
-            'usage',
+            'parking', 'place', 'power', 'public_transport',
+            'railway', 'ramp', 'religion', 'route', 'route_master',
+            'sac_scale', 'seasonal', 'service', 'shelter', 'shop', 'shoulder', 'sidewalk', 'smoothness', 'sport', 'surface',
+            'tactile_paving', 'toll', 'tourism', 'tracktype', 'traffic_calming', 'trail_visibility', 'train', 'traffic_signals', 'tunnel',
+            'usage', 'utility',
             'vehicle',
-            'wall', 'water', 'waterway', 'wheelchair', 'wood'
+            'wall', 'water', 'waterway', 'wetland', 'wheelchair', 'wood'
         ))
         self.check_list_open_node = self.check_list_open
         self.check_list_open_way = self.check_list_open
@@ -85,16 +85,20 @@ However, this should probably still conform to the typical format used for value
                                  "barrier": ( "full-height_turnstile" ),
                                  "parking": ( "multi-storey" ),
                                  "bicycle_parking": ( "two-tier" ),
+                                 "electrified": ( "ground-level_power_supply" ),
+                                 "religion": ( "self-realization_fellowship" ),
                                  "man_made": ( "MDF", "piste:halfpipe" ),
                                 }
 
         self.allow_closed = { "area": ( "yes", "no", ),
+                            "backrest": ( "yes", "no", ),
                             "conveying": ( "yes", "forward", "backward", "no", "reversible", ),
                             "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", ),
                             "lane_markings": ( "yes", "no", ),
                             "narrow": ( "yes", "no", ),
                             "oneway": ( "yes", "no", "1", "-1", "reversible", "alternating"),
                             "segregated": ( "yes", "no", ),
+                            "trolley_wire": ( "yes", "no", ),
                           }
         self.check_list_closed = set(self.allow_closed.keys())
 

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -44,25 +44,27 @@ However, this should probably still conform to the typical format used for value
         self.Values_open = re.compile("^[a-z0-9_]+( *; *[a-z0-9_]+)*$")
         self.check_list_open = set((
             'abutters', 'access', 'admin_level', 'aerialway', 'aeroway', 'amenity',
-            'barrier', 'bicycle', 'boat', 'border_type', 'boundary', 'bridge', 'building', 'construction',
-            'covered', 'craft', 'crossing', 'cutting',
+            'barrier', 'bicycle', 'bicycle_parking', 'boat', 'border_type', 'boundary', 'bridge', 'building', 'bus_bay',
+            'construction', 'covered', 'craft', 'crossing', 'cutting', 'cycleway',
             'disused', 'drive_in', 'drive_through',
             'electrified', 'embankment', 'emergency',
-            'fenced', 'foot', 'ford',
+            'fenced', 'foot', 'footway', 'ford',
             'geological', 'goods',
-            'hgv', 'highway', 'historic',
-            'internet_access',
+            'handrail', 'hgv', 'highway', 'historic',
+            'intermittent', 'internet_access',
+            'junction',
             'landuse', 'lanes', 'leisure',
-            'man_made', 'military', 'mooring', 'motorboat', 'mountain_pass', 'natural', 'noexit',
+            'man_made', 'military', 'mooring', 'motorboat', 'mountain_pass',
+            'natural', 'noexit',
             'office',
-            'power', 'public_transport',
-            'railway', 'route',
-            'sac_scale', 'service', 'shop', 'smoothness', 'sport', 'surface',
+            'parking', 'power', 'public_transport',
+            'railway', 'ramp', 'route',
+            'sac_scale', 'service', 'shelter', 'shop', 'shoulder', 'sidewalk', 'smoothness', 'sport', 'surface',
             'tactile_paving', 'toll', 'tourism', 'tracktype', 'traffic_calming', 'trail_visibility',
-            'tunnel',
+            'traffic_signals', 'tunnel',
             'usage',
             'vehicle',
-            'wall', 'waterway', 'wheelchair', 'wood'
+            'wall', 'water', 'waterway', 'wheelchair', 'wood'
         ))
         self.check_list_open_node = self.check_list_open
         self.check_list_open_way = self.check_list_open
@@ -81,16 +83,26 @@ However, this should probably still conform to the typical format used for value
                                  "shop": ( "e-cigarette" ),
                                  "sport": ( "five-a-side", "jiu-jitsu", "pesäpallo", "shot-put" ),
                                  "barrier": ( "full-height_turnstile" ),
+                                 "parking": ( "multi-storey" ),
+                                 "bicycle_parking": ( "two-tier" ),
                                  "man_made": ( "MDF", "piste:halfpipe" ),
                                 }
         self.check_list_closed = set((
             'area',
+            'conveying',
+            'crossing',
+            'lane_markings',
             'narrow',
             'oneway',
+            'segregated',
         ))
         self.allow_closed = { "area": ( "yes", "no", ),
+                            "conveying": ( "yes", "forward", "backward", "no", "reversible", ),
+                            "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", ),
+                            "lane_markings": ( "yes", "no", ),
                             "narrow": ( "yes", "no", ),
                             "oneway": ( "yes", "no", "1", "-1", "reversible", "alternating"),
+                            "segregated": ( "yes", "no", ),
                           }
 
     def check(self, data, tags, check_list_open):

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -87,15 +87,7 @@ However, this should probably still conform to the typical format used for value
                                  "bicycle_parking": ( "two-tier" ),
                                  "man_made": ( "MDF", "piste:halfpipe" ),
                                 }
-        self.check_list_closed = set((
-            'area',
-            'conveying',
-            'crossing',
-            'lane_markings',
-            'narrow',
-            'oneway',
-            'segregated',
-        ))
+
         self.allow_closed = { "area": ( "yes", "no", ),
                             "conveying": ( "yes", "forward", "backward", "no", "reversible", ),
                             "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", ),
@@ -104,6 +96,7 @@ However, this should probably still conform to the typical format used for value
                             "oneway": ( "yes", "no", "1", "-1", "reversible", "alternating"),
                             "segregated": ( "yes", "no", ),
                           }
+        self.check_list_closed = set(self.allow_closed.keys())
 
     def check(self, data, tags, check_list_open):
         err = []

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -172,3 +172,6 @@ class Test(TestPluginCommon):
         for t in [{"type": "associatedStreet"},
                  ]:
             assert not a.relation(None, t, None), t
+
+            # Assure keys are not present in both sets
+            assert not a.check_list_open & a.check_list_closed

--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -109,6 +109,8 @@ class Test(TestPluginCommon):
         assert not a.way(None, {'highway': 'primary'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'source:maxspeed': 'FR:urban'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:type': 'FR:urban'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '30', 'source:maxspeed': 'FR:urban'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '30', 'maxspeed:type': 'FR:urban'}, None)
 
-        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '30', 'source:maxspeed': 'FR:urban'}, None))
-        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '30', 'maxspeed:type': 'FR:urban'}, None))
+        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '35', 'source:maxspeed': 'FR:urban'}, None))
+        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '35', 'maxspeed:type': 'FR:urban'}, None))


### PR DESCRIPTION
- Fix the tests (broken in #1448 )
- Add `bench, bicycle_parking, bin, bus, bus_bay, cemetery, club, crossing_ref, cuisine, cycleway, entrance, footway, golf, handrail, hazard, healthcare, horse, information, intermittent, junction, kerb, leaf_type, leaf_cycle, location, material, meadow, motor_vehicle, motorcar, motorcycle, parking, place, ramp, religion, route_master, seasonal, shelter, shoulder, sidewalk, train, traffic_signals, utility, water, wetland` as open entries (a-z, 0-9 or _)
- Add `backrest, conveying, crossing, lane_markings, segregated, trolley_wire` as closed entries (only known values allowed, see also issue 1449 (but this does not fix that issue)
- Add exception for `electrified=ground-level_power_supply`
- Reduce the need to declare "closed value set"-keys twice