### PR TITLE
Add tex-mex to list of cuisine exceptions for TagFix_BadValue

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -88,6 +88,7 @@ However, this should probably still conform to the typical format used for value
                                  "electrified": ( "ground-level_power_supply" ),
                                  "religion": ( "self-realization_fellowship" ),
                                  "man_made": ( "MDF", "piste:halfpipe" ),
+                                 "cuisine": ( "tex-mex" ),
                                 }
 
         self.allow_closed = { "area": ( "yes", "no", ),


### PR DESCRIPTION
`cuisine` was added in https://github.com/osm-fr/osmose-backend/commit/50ee5f88952a0f7f15bfb11f231c4382bfba67ee, however `tex-mex` is a valid value that's specified in the NSI for Taco Bell, Chili's, etc. The PR adds an exception so they are skipped in the check.