### PR TITLE
Whitelist `highway=slipway`+`leisure=slipway` conflict

### DIFF
--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -73,7 +73,7 @@ class TagRemove_Incompatibles(Plugin):
                 ['footway', 'railway', 'disused'],
                 ['path', 'railway', 'disused'],
                 ['service', 'amenity', 'weighbridge'],
-                ['slipway', 'leisure', 'slipway']
+                ['slipway', 'leisure', 'slipway'],
             ],
             'natural': [
                 ['water', 'leisure', 'marina'],

--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -73,6 +73,7 @@ class TagRemove_Incompatibles(Plugin):
                 ['footway', 'railway', 'disused'],
                 ['path', 'railway', 'disused'],
                 ['service', 'amenity', 'weighbridge'],
+                ['slipway', 'leisure', 'slipway']
             ],
             'natural': [
                 ['water', 'leisure', 'marina'],

--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -73,7 +73,7 @@ class TagRemove_Incompatibles(Plugin):
                 ['footway', 'railway', 'disused'],
                 ['path', 'railway', 'disused'],
                 ['service', 'amenity', 'weighbridge'],
-                ['slipway', 'leisure', 'slipway'],
+                ['service', 'leisure', 'slipway'],
             ],
             'natural': [
                 ['water', 'leisure', 'marina'],


### PR DESCRIPTION
According to https://wiki.openstreetmap.org/wiki/Tag:leisure=slipway this is a valid use case, and iD has it set as the preset for [Slipway (Drivable)](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/leisure/slipway_drivable.json) so I think it's worth whitelisting here. 