### PR TITLE
Allow bis and ter in housenumber in Switzerland

### DIFF
--- a/plugins/TagFix_Housenumber.py
+++ b/plugins/TagFix_Housenumber.py
@@ -53,7 +53,7 @@ and `potential`.'''))
         if country == 'CH':
             # From open data from cantons Zurich and Bern. See also https://github.com/ltog/osmi-addresses/issues/93
             # Plus allows commas with multiple numbers
-            ch_number = "[1-9][0-9]{0,3}( ?[a-zA-Z])?"
+            ch_number = "[1-9][0-9]{0,3}( ?[a-zA-Z]{0,3})?"
             self.housenumber = re.compile(r"^(:?{0})(:?,{0})?$".format(ch_number))
         elif country == 'CZ':
             # https://wiki.openstreetmap.org/wiki/Cs:WikiProject_Czech_Republic/Address_system
@@ -152,6 +152,7 @@ class Test(TestPluginCommon):
         a.init(None)
 
         assert not a.node(None, {"addr:housenumber": "313A"})
+        assert not a.node(None, {"addr:housenumber": "1bis"})
         assert not a.node(None, {"addr:housenumber": "1"})
         assert not a.node(None, {"addr:housenumber": "1,2"})
         assert a.node(None, {"addr:housenumber": "1;2"})

--- a/plugins/TagFix_Housenumber.py
+++ b/plugins/TagFix_Housenumber.py
@@ -53,7 +53,7 @@ and `potential`.'''))
         if country == 'CH':
             # From open data from cantons Zurich and Bern. See also https://github.com/ltog/osmi-addresses/issues/93
             # Plus allows commas with multiple numbers
-            ch_number = "[1-9][0-9]{0,3}( ?[a-zA-Z]{0,3})?"
+            ch_number = "[1-9][0-9]{0,3}( ?[a-zA-Z]{1,3})?"
             self.housenumber = re.compile(r"^(:?{0})(:?,{0})?$".format(ch_number))
         elif country == 'CZ':
             # https://wiki.openstreetmap.org/wiki/Cs:WikiProject_Czech_Republic/Address_system


### PR DESCRIPTION
Solve the related issue: https://github.com/osm-fr/osmose-backend/issues/1455

In the French part of Switzerland, keywords "bis and "ter" are used as suffix of housenumber like in France.