### PR TITLE
Add exceptions to analyser_osmosis_tag_typo

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -81,6 +81,8 @@ FROM
             'lock', 'rock',
             'reg_name', 'ref_name',
             'massage', 'message',
+            'bath',
+            'port',
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -83,6 +83,8 @@ FROM
             'massage', 'message',
             'bath',
             'port',
+            'cave',
+            'produce',
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -85,6 +85,7 @@ FROM
             'port',
             'cave',
             'produce',
+            'side',
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:


### PR DESCRIPTION
`port:type` -> `sport:type` (Fix #1469, http://osmose.openstreetmap.fr/nl/issue/7e8bb404-0a58-1f9d-4b85-ce7648aa4bba, https://www.openstreetmap.org/node/8610048660)
`bath:open_air` -> `path:open_air` (https://osmose.openstreetmap.fr/nl/issue/44546447-da21-06c0-a1dd-7a7ad80ab74e, https://www.openstreetmap.org/way/503722122; also for bath:type, i.e. https://osmose.openstreetmap.fr/nl/issue/a1d41915-377b-32bd-d07a-a53f721ab735)
`cafe` -> `cave` (https://osmose.openstreetmap.fr/nl/issue/b5fe2db0-1cad-287e-405a-6dfb7f27af3d, https://www.openstreetmap.org/node/4121332496)
`produce` -> `product` (https://osmose.openstreetmap.fr/nl/issue/c39054ee-1210-35d1-389c-2c35450a71a1, https://www.openstreetmap.org/way/827666026)
`sides` -> `side` (Fix #1476)

I only added the least-common key, so other typos with i.e. `sport` and `path` can still be found, unless there was no wiki for the alternative key