### PR TITLE
Accept name=A / B with name:left and name:right

### DIFF
--- a/plugins/Name_Multiple.py
+++ b/plugins/Name_Multiple.py
@@ -124,6 +124,11 @@ class Test(TestPluginCommon):
             assert not p.way(None, {"name": u"บ้านแพะแม่คือ ซอย 5/10"}, None)
             assert not p.way(None, {"name": u"บ้านแพะแม่คือ ซอย 5/๓๔๕"}, None)
             assert not p.way(None, {"name": "streetA/streetB", "public_transport": "platform"}, None)
+            assert not p.way(None, {"name": u"Gas station no. 21/2356"}, None)
+            assert not p.way(None, {"name": "Foobar P+R"}, None)
+            assert not p.way(None, {"name": "StreetA / StreetB", "name:left": "StreetA", "name:right": "StreetB"}, None)
+            assert not p.way(None, {"name": "StreetB/StreetA", "name:left": "StreetA", "name:right": "StreetB"}, None)
+            self.check_err(p.way(None, {"name": "StreetC/StreetA", "name:left": "StreetA", "name:right": "StreetB"}, None))
 
         with with_options(p, {'country': 'US-TX'}):
             p.init(None)
@@ -142,9 +147,3 @@ class Test(TestPluginCommon):
         with with_options(p, {'country': 'DJ'}):
             p.init(None)
             assert not p.way(None, {"name": u"Avenue 17 / جادة 17"}, None)
-
-        assert not p.way(None, {"name": u"Gas station no. 21/2356"}, None)
-        assert not p.way(None, {"name": "Foobar P+R"}, None)
-        assert not p.way(None, {"name": "StreetA / StreetB", "name:left": "StreetA", "name:right": "StreetB"}, None)
-        assert not p.way(None, {"name": "StreetB/StreetA", "name:left": "StreetA", "name:right": "StreetB"}, None)
-        self.check_err(p.way(None, {"name": "StreetC/StreetA", "name:left": "StreetA", "name:right": "StreetB"}, None))

--- a/plugins/Name_Multiple.py
+++ b/plugins/Name_Multiple.py
@@ -95,7 +95,7 @@ The tag `name` should have the value `name:right / name:left` or `name:left / na
                     return
                 else:
                     return {"class": 50301, "subclass": 1,
-                            "fix": {"+": {"name": tags["name:right"] + " / " + tags["name:left"]}}}
+                            "fix": {"~": {"name": tags["name:right"] + " / " + tags["name:left"]}}}
 
             if not self.streetSubNumberRe.match(tags["name"]):
                 return {"class": 705, "subclass": 1, "text": {"en": "name={0}".format(tags["name"])}}


### PR DESCRIPTION
Fixes the first half of 1480

- Accepts `/` in `name` if `name` consists of `name:left / name:right` or the other way around
- Add a dedicated warning (not "multiple names", which is confusing for a typo) if the names don't match