### PR TITLE
Ignore proposed roads

### DIFF
--- a/analysers/analyser_osmosis_highway_almost_junction.py
+++ b/analysers/analyser_osmosis_highway_almost_junction.py
@@ -45,7 +45,7 @@ FROM (
     FROM
       highways
     WHERE
-      highway NOT IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'service', 'footway', 'path', 'platform', 'steps') AND
+      highway NOT IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'service', 'footway', 'path', 'platform', 'steps', 'proposed') AND
       NOT is_polygon AND
       ST_Length(linestring_proj) > 10
     ) AS t


### PR DESCRIPTION
Example: http://osmose.openstreetmap.fr/nl/issue/f8eb8970-9b0a-3a9e-b836-fb34208c5846
Proposed roads do not reflect the current situation, but rather a future situation, hence it makes sense that they do not connect to the present road network exactly.