### PR TITLE
Exclude only one key of each pair in analyser_osmosis_tag_typo

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -73,6 +73,7 @@ FROM
             'room', -- vs roof, rooms
             'house', -- vs horse
             'addr2', 'addr3',
+            'kern', -- vs kerb
             'lock_name', -- vs loc_name
             'camp_type', -- vs lamp_type
             'lock_ref', -- vs loc_ref

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -49,43 +49,44 @@ FROM
     WHERE
         length(key) > 3 AND
         key NOT IN (
-            'tower', 'power',
-            'food', 'foot',
-            'diet', 'dist',
-            'line', 'lines',
-            'level', 'levels',
-            'color', 'colour',
-            'maxweight', 'maxheight',
-            'stop', 'shop',
-            'stars', 'start',
-            'right', 'light',
+            'tower', -- vs power
+            'food', -- vs foot, ford
+            'diet', -- vs dirt, dist
+            'dist', -- vs dirt, list, diet
+            'lines', -- vs line, lanes
+            'levels', -- vs level
+            'maxweight', -- vs maxheight
+            'stop', -- vs shop, stop
+            'ship', -- vs shop
+            'stars', -- vs start, stairs
+            'right', -- vs light
             'truck',
-            'tracks',
-            'size', 'site',
-            'weight', 'height',
-            'lawyer',
-            'hall', 'well',
-            'clock',
-            'plane',
-            'services', 'service',
-            'room', 'rooms',
-            'house', 'horse',
+            'tracks', -- vs traces
+            'size', -- vs site, side
+            'weight', -- vs height
+            'lawyer', -- vs layer
+            'hall', -- vs wall
+            'well', -- vs wall
+            'clock', -- vs lock
+            'plane', -- vs place, plant, lane
+            'services', -- vs service
+            'room', -- vs roof, rooms
+            'house', -- vs horse
             'addr2', 'addr3',
-            'kerb', 'kern',
-            'lock_name', 'loc_name',
-            'camp_type', 'lamp_type',
-            'static_caravans', 'static_caravan',
-            'loc_ref', 'lock_ref',
-            'charge', 'change',
-            'mail', 'email',
-            'lock', 'rock',
-            'reg_name', 'ref_name',
-            'massage', 'message',
-            'bath',
-            'port',
-            'cave',
-            'produce',
-            'side',
+            'lock_name', -- vs loc_name
+            'camp_type', -- vs lamp_type
+            'lock_ref', -- vs loc_ref
+            'change', -- vs charge
+            'mail', -- vs email
+            'lock', -- vs rock, dock
+            'rock', -- vs lock, dock, rack
+            'reg_name', -- vs ref_name
+            'massage', -- vs message
+            'bath', -- vs path
+            'port', -- vs sport, post
+            'cave', -- vs cafe
+            'produce', -- vs product
+            'side', -- vs site, sides, hide
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:


### PR DESCRIPTION
- Exclude only one of each pair if possible, allowing typos to be found with the other key (as described & requested to be done with existing items in https://github.com/osm-fr/osmose-backend/pull/1470 :
> Interesting. Maybe can do it for other keys to un-blacklist some.

- Added `ship`, so that the (much more common key) shop could be used for matching
- Remove `static_caravan(s)` combination as almost all `static_caravan` have been converted to `static_caravans`
- Remove `colo(u)r` as all `color` have been converted to `colour` in a bulk edit early this year