### PR TITLE
Fixes for item 3040 - uncommon access values

### DIFF
--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -72,7 +72,7 @@ class TagFix_Access(Plugin):
       isConditional = ":conditional" in tag
       for accessVal in values:
         accessValue = accessVal
-        if isConditional: 
+        if isConditional:
           if "@" in accessVal:
             accessValue = accessValue.split("@")[0]
           else:


### PR DESCRIPTION
- An incorrect warning was given when the condition of a conditional restriction contained a `;` (which is common for time spans)
- Allow `dog=leashed`/`dog=unleashed` (in such a way that future exceptions are easy to add)
- Change `dismount` to only work for vehicles that actually allow movement after dismounting