### PR TITLE
Small fixes for multiple names, tag typos, and access value checks

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -92,6 +92,7 @@ FROM
             'side', -- vs site, sides, hide
             'draft', -- vs craft
             'fridge', -- vs bridge
+            'moved', -- vs moped
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -72,7 +72,7 @@ FROM
             'services', -- vs service
             'room', -- vs roof, rooms
             'house', -- vs horse
-            'addr2', 'addr3',
+            'addr2', 'addr3', 'addr4', 'addr5',
             'kern', -- vs kerb
             'lock_name', -- vs loc_name
             'camp_type', -- vs lamp_type

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -88,6 +88,8 @@ FROM
             'cave', -- vs cafe
             'produce', -- vs product
             'side', -- vs site, sides, hide
+            'draft', -- vs craft
+            'fridge', -- vs bridge
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -51,9 +51,11 @@ FROM
         key NOT IN (
             'tower', -- vs power
             'food', -- vs foot, ford
+            'fdot', -- vs foot (Florida)
             'diet', -- vs dirt, dist
             'dist', -- vs dirt, list, diet
             'lines', -- vs line, lanes
+            'wine', -- vs line
             'levels', -- vs level
             'maxweight', -- vs maxheight
             'stop', -- vs shop, stop

--- a/plugins/Name_Multiple.py
+++ b/plugins/Name_Multiple.py
@@ -51,7 +51,9 @@ the tag `name:left=*` and `name:right=*`.'''))
             detail = T_(
 '''This is a street with different names on each side of the way, given by the keys `name:left` and `name:right`.
 These names do not match with the value of `name`.
-The tag `name` should have the value `name:right / name:left` or `name:left / name:right`.'''))
+The tag `name` should have the value `name:right / name:left` or `name:left / name:right`.'''),
+            trap = T_(
+'''The warning also shows up if `name:left` or `name:right` is spelled incorrectly.'''))
 
         self.NoExtra = False
         self.HighwayOnly = False

--- a/plugins/Name_Multiple.py
+++ b/plugins/Name_Multiple.py
@@ -93,7 +93,7 @@ The tag `name` should have the value `name:right / name:left` or `name:left / na
                 nameparts = [n.strip() for n in tags["name"].split("/")]
                 if tags["name:left"] in nameparts and tags["name:right"] in nameparts and len(nameparts) == 2:
                     return
-                else:
+                elif tags["name:right"] != tags["name:left"]:
                     return {"class": 50301, "subclass": 1,
                             "fix": {"~": {"name": tags["name:right"] + " / " + tags["name:left"]}}}
 

--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -118,7 +118,7 @@ class Test(TestPluginCommon):
         # Valid nodes and ways
         for t in [{"amenity": "parking", "vehicle": "no"},
                   {"amenity": "parking", "vehicle:conditional": "no @ wet"},
-                  {"access": "agricultural", "agricultural": "designated"},
+                  {"access": "agricultural", "agricultural": "designated", "agricultural": "agricultural"},
                   {"highway": "residential", "hgv:conditional": "no @ (Mo-Fr 00:00-12:00;Sa 0:00-19:00); yes @ (Mo-Fr 12:00-24:00;Sa 19:00-24:00)"},
                   {"dog": "leashed", "bicycle": "dismount"},
                  ]:

--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -39,7 +39,7 @@ class TagFix_Access(Plugin):
                        "share_taxi", "ship", "ski:nordic", "ski", "small_electric_vehicle", "snowmobile", "speed_pedelec", "subway", "swimming", "tank", "taxi", "tourist_bus", "trailer", "train", "tram", "vehicle"]
     self.accessValuesGeneral = ["yes", "no", "private", "permissive", "permit", "destination", "delivery", "customers", "designated", "use_sidepath", "agricultural", "forestry", "discouraged"]
     self.accessValuesSpecial = {"bicycle": ["dismount"],
-                                "dog": ["leashed", "unleached"],
+                                "dog": ["leashed", "unleashed"],
                                 "horse": ["dismount"],
                                 "mofa": ["dismount"],
                                 "moped": ["dismount"],

--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -39,6 +39,7 @@ class TagFix_Access(Plugin):
                        "share_taxi", "ship", "ski:nordic", "ski", "small_electric_vehicle", "snowmobile", "speed_pedelec", "subway", "swimming", "tank", "taxi", "tourist_bus", "trailer", "train", "tram", "vehicle"]
     self.accessValuesGeneral = ["yes", "no", "private", "permissive", "permit", "destination", "delivery", "customers", "designated", "use_sidepath", "agricultural", "forestry", "discouraged"]
     self.accessValuesSpecial = {"bicycle": ["dismount"],
+                                "canoe": ["put_in", "portage"],
                                 "dog": ["leashed", "unleashed"],
                                 "horse": ["dismount"],
                                 "mofa": ["dismount"],

--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -118,7 +118,8 @@ class Test(TestPluginCommon):
         # Valid nodes and ways
         for t in [{"amenity": "parking", "vehicle": "no"},
                   {"amenity": "parking", "vehicle:conditional": "no @ wet"},
-                  {"access": "agricultural", "agricultural": "designated", "agricultural": "agricultural"},
+                  {"access": "agricultural", "agricultural": "designated"},
+                  {"agricultural": "agricultural"},
                   {"highway": "residential", "hgv:conditional": "no @ (Mo-Fr 00:00-12:00;Sa 0:00-19:00); yes @ (Mo-Fr 12:00-24:00;Sa 19:00-24:00)"},
                   {"dog": "leashed", "bicycle": "dismount"},
                  ]:

--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -82,7 +82,7 @@ class TagFix_Access(Plugin):
         if transportMode in self.accessValuesSpecial and accessValue in self.accessValuesSpecial[transportMode]:
           continue
         if not accessValue in self.accessValuesGeneral:
-          if accessValue in self.accessKeys or accessValue == "emergency":
+          if (accessValue in self.accessKeys or accessValue == "emergency") and accessValue != transportMode:
             propose = tag + " = ### + " + accessValue + accessTags[tag]["suffix"] + " = yes"
             if len(values) > 1 or isConditional:
               propose = propose.replace("###", "...") # i.e. access=bus;destination should become access=destination + bus=yes instead of access=no + bus=yes


### PR DESCRIPTION
Accidentally did everything in one branch, but since it's all simple things, I left it like this. Please let me know if I should split it up instead.

This fixes:
- Add `addr4`/`addr5` to exceptions (common in [Austria](https://osmose.openstreetmap.fr/nl/issues/open?source=13138&item=3150&class=1))
- Add `draft` and `fridge` to exceptions (false positives vs `craft` and `bridge`)
- Add `fdot` (Florida specific) and `wine` to exceptions (false positives vs `foot` and `line`)
- Fix a typo with `unleashed`
- Add a trap warning and prevent potential bogus messages for `name:left/name:right/name` if `name:left` equals `name:right`
- Fix the error when `tram=tram` is encountered (and similar x=x values, except when it's a valid value). ([Example](https://osmose.openstreetmap.fr/nl/issue/a36b97b9-9352-5cff-a17f-77b2e197d289))
- Add two dedicated `canoe` access values