### PR TITLE
Fix linz vs line false positive

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -55,6 +55,7 @@ FROM
             'diet', -- vs dirt, dist
             'dist', -- vs dirt, list, diet
             'lines', -- vs line, lanes
+            'linz', -- vs line (New Zealand)
             'wine', -- vs line
             'levels', -- vs level
             'maxweight', -- vs maxheight

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -59,7 +59,7 @@ FROM
             'wine', -- vs line
             'levels', -- vs level
             'maxweight', -- vs maxheight
-            'stop', -- vs shop, stop
+            'stop', -- vs shop
             'ship', -- vs shop
             'stars', -- vs start, stairs
             'right', -- vs light


### PR DESCRIPTION
`linz` (Land Information New Zealand) is a NZ governmental organisation, used in many keys in that country (causing 855 false positives that want to convert `line` to `linz`)

Let's hope this is the last one. Most of the UK, Texas, Florida and North-Carolina still have to update since the merge of #1484