### PR TITLE
Power plant analyzer : fix dataset URL and osm ref

### DIFF
--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -41,7 +41,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                     url="https://opendata.reseaux-energies.fr/explore/dataset/registre-national-installation-production-stockage-electricite-agrege"),
                 columns='commune', citycode='codeINSEEcommune', logger=logger)),
             Load_XY("longitude", "latitude",
-                where = lambda res: res.get('puisMaxRac') and float(res["puisMaxRac"]) >= 250 and res.get('nomInstallation') != 'Agrégation des installations de moins de 36KW',
+                where = lambda res: res["puisMaxRac"] and float(res["puisMaxRac"]) >= 250 and res["nomInstallation"] != "Agrégation des installations de moins de 36KW",
                 map = lambda res: dict(res, **{"_geom": [
                     float(res["_geom"][0]) + (Stablehash.stablehash(str(res)) % 200 - 100) * 0.00001,
                     float(res["_geom"][1]) + (Stablehash.stablehash(str(res)) % 212 - 106) * 0.00001] }),

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -43,7 +43,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
             Load_XY("longitude", "latitude",
                 where = lambda res: res.get('puisMaxRac') and float(res["puisMaxRac"]) > 250,
                 map = lambda res: dict(res, **{"_x": float(res["_x"]) + (Stablehash.stablehash(str(res)) % 200 - 100) * 0.00001, "_y": float(res["_y"]) + (Stablehash.stablehash(str(res)) % 212 - 106) * 0.00001}),
-                unique = ("codeeicresourceobject",)),
+                unique = ("codeEICResourceObject",)),
             Conflate(
                 select = Select(
                     types = ["ways", "relations"],
@@ -56,7 +56,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                         "power": "plant"},
                     static2 = {"source": self.source},
                     mapping1 = {
-                        "ref:EU:ENTSOE_EIC": lambda fields: fields["codeeicresourceobject"],
+                        "ref:EU:ENTSOE_EIC": lambda fields: fields["codeEICResourceObject"],
                         # No voltage tga on power=plant
                         #"voltage": lambda fields: (int(fields["Tension raccordement"].split(' ')[0]) * 1000) if fields.get("Tension raccordement") and fields["Tension raccordement"] not in ["< 45 kV", "BT", "HTA"] else None,
                         "plant:source": lambda fields: self.filiere[fields["filiere"]][fields["combustible"]],

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -64,9 +64,8 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                         "plant:source": lambda fields: self.filiere[fields["filiere"]][fields["combustible"]],
                         "plant:output:electricity": lambda fields: None if not fields["puisMaxRac"] else str(float(fields["puisMaxRac"]) / 1000).rstrip(".0") + " MW"},
                     mapping2 = {
-                        "start_date": lambda fields: None if not fields.get("dateMiseEnService") else fields["dateMiseEnService"][0:4] if fields["dateMiseEnService"].endswith('-01-01') or fields["dateMiseEnService"].endswith('-12-31') else fields["dateMiseEnService"],
-                        "name": lambda fields: None if not fields.get("nomInstallation") or fields.get("nomInstallation") == 'Confidentiel' else fields.get("nomInstallation")},
-                    text = lambda tags, fields: T_("Power plant {0}", ', '.join(filter(lambda res: res and res != 'None', [fields["nomInstallation"], fields["commune"]]))) )))
+                        "start_date": lambda fields: None if not fields["dateMiseEnService"] else fields["dateMiseEnService"][0:4] if fields["dateMiseEnService"].endswith('-01-01') or fields["dateMiseEnService"].endswith('-12-31') else fields["dateMiseEnService"] },
+                    text = lambda tags, fields: T_("Power plant {0}", ', '.join(filter(lambda res: res and res != 'None', [fields["nomInstallation"] if fields["nomInstallation"] != 'Confidentiel' else None, fields["commune"]]))) )))
 
     filiere = {
         "Autre": {

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -44,7 +44,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                 where = lambda res: res.get('puisMaxRac') and float(res["puisMaxRac"]) >= 250 and res.get('nomInstallation') != 'Agrégation des installations de moins de 36KW',
                 map = lambda res: dict(res, **{"_geom": [
                     float(res["_geom"][0]) + (Stablehash.stablehash(str(res)) % 200 - 100) * 0.00001,
-                    float(res["_geom"][1]) + (Stablehash.stablehash(str(res)) % 212 - 106) * 0.00001] })),
+                    float(res["_geom"][1]) + (Stablehash.stablehash(str(res)) % 212 - 106) * 0.00001] }),
                 unique = ("codeEICResourceObject",)),
             Conflate(
                 select = Select(

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -33,17 +33,17 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
             title = T_('Power plant not integrated, geocoded at municipality level'))
 
         self.init(
-            "https://odre.opendatasoft.com/explore/dataset/registre-national-installation-production-stockage-electricite-agrege",
+            "https://opendata.reseaux-energies.fr/explore/dataset/registre-national-installation-production-stockage-electricite-agrege",
             "Registre national des installations de production d'électricité et de stockage",
             CSV(Geocode_Addok_CSV(
                 SourceOpenDataSoft(
                     attribution="data.gouv.fr:RTE",
-                    url="https://odre.opendatasoft.com/explore/dataset/registre-national-installation-production-stockage-electricite-agrege"),
+                    url="https://opendata.reseaux-energies.fr/explore/dataset/registre-national-installation-production-stockage-electricite-agrege"),
                 columns='commune', citycode='codeINSEEcommune', logger=logger)),
             Load_XY("longitude", "latitude",
                 where = lambda res: res.get('puisMaxRac') and float(res["puisMaxRac"]) > 250,
                 map = lambda res: dict(res, **{"_x": float(res["_x"]) + (Stablehash.stablehash(str(res)) % 200 - 100) * 0.00001, "_y": float(res["_y"]) + (Stablehash.stablehash(str(res)) % 212 - 106) * 0.00001}),
-                unique = ("codeeicresourceobject",))
+                unique = ("codeeicresourceobject",)),
             Conflate(
                 select = Select(
                     types = ["ways", "relations"],

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -62,7 +62,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                         # No voltage, frequency, phases tags on power=plant
                         #"voltage": lambda fields: (int(fields["Tension raccordement"].split(' ')[0]) * 1000) if fields["Tension raccordement"] and fields["Tension raccordement"] not in ["< 45 kV", "BT", "HTA"] else None,
                         "plant:source": lambda fields: self.filiere[fields["filiere"]][fields["combustible"]],
-                        "plant:output:electricity": lambda fields: None if not fields.get("puisMaxRac") else str(float(fields["puisMaxRac"]) / 1000).rstrip(".0") + " MW"},
+                        "plant:output:electricity": lambda fields: None if not fields["puisMaxRac"] else str(float(fields["puisMaxRac"]) / 1000).rstrip(".0") + " MW"},
                     mapping2 = {
                         "start_date": lambda fields: None if not fields.get("dateMiseEnService") else fields["dateMiseEnService"][0:4] if fields["dateMiseEnService"].endswith('-01-01') or fields["dateMiseEnService"].endswith('-12-31') else fields["dateMiseEnService"],
                         "name": lambda fields: None if not fields.get("nomInstallation") or fields.get("nomInstallation") == 'Confidentiel' else fields.get("nomInstallation")},

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -60,7 +60,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                         # No voltage tga on power=plant
                         #"voltage": lambda fields: (int(fields["Tension raccordement"].split(' ')[0]) * 1000) if fields.get("Tension raccordement") and fields["Tension raccordement"] not in ["< 45 kV", "BT", "HTA"] else None,
                         "plant:source": lambda fields: self.filiere[fields["filiere"]][fields["combustible"]],
-                        "plant:output:electricity": lambda fields: int(float(fields["puisMaxRac"]) * 1000)},
+                        "plant:output:electricity": lambda fields: None if not fields.get("puisMaxRac") else str(float(fields["puisMaxRac"]) / 1000).rstrip(".0") + " MW"},
                     mapping2 = {
                         "start_date": lambda fields: None if not fields.get("dateMiseEnService") else fields["dateMiseEnService"][0:4] if fields["dateMiseEnService"].endswith('-01-01') or fields["dateMiseEnService"].endswith('-12-31') else fields["dateMiseEnService"]},
                     text = lambda tags, fields: T_("Power plant {0}", ', '.join(filter(lambda res: res and res != 'None', [fields["nomInstallation"], fields["commune"]]))) )))

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -60,7 +60,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
                     mapping1 = {
                         "ref:EU:ENTSOE_EIC": lambda fields: fields["codeEICResourceObject"],
                         # No voltage, frequency, phases tags on power=plant
-                        #"voltage": lambda fields: (int(fields["Tension raccordement"].split(' ')[0]) * 1000) if fields.get("Tension raccordement") and fields["Tension raccordement"] not in ["< 45 kV", "BT", "HTA"] else None,
+                        #"voltage": lambda fields: (int(fields["Tension raccordement"].split(' ')[0]) * 1000) if fields["Tension raccordement"] and fields["Tension raccordement"] not in ["< 45 kV", "BT", "HTA"] else None,
                         "plant:source": lambda fields: self.filiere[fields["filiere"]][fields["combustible"]],
                         "plant:output:electricity": lambda fields: None if not fields.get("puisMaxRac") else str(float(fields["puisMaxRac"]) / 1000).rstrip(".0") + " MW"},
                     mapping2 = {


### PR DESCRIPTION
I'd like to propose this improvement of `analyser_merge_power_plant_FR.py`

The analyzer originally use a 2017 stuck dataset.
Another one is available and continuously updated.

One thing still bothers me between both.
Osmose use case sensitive fields names like `codeINSEEcommune` while opendatasoft's data model use lower caps only => `codeinseecommune`.
Should I change `codeeicresourceobject` for `codeEICResourceObject`?

To me, EIC codes weren't enough used for conflation as every power=plant should now have one in France.

Let me know and I'll change my code if needed.

Best regards
