### PR TITLE
Update kOpeningHours

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium >= 3.1.3
-git+https://invent.kde.org/libraries/kopeninghours.git@v21.12.3
+git+https://invent.kde.org/libraries/kopeninghours.git@v22.11.70
 git+https://github.com/jocelynj/PyEasyArchive.git
 protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geojson
 vt2geojson


### PR DESCRIPTION
Contains a little fix for the Dutch weekdays.

Hmm, according to https://invent.kde.org/libraries/kopeninghours/-/commit/79db379496ebf15bfb7761553eed7a591dae4ed8 v22.11.70 has been released, I don't understand why it doesn't update...