### PR TITLE
Add dedicated citycentre geocoding feature as to get rid of Addok

### DIFF
--- a/analysers/Analyser_Merge_Geocode_City_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_City_CSV.py
@@ -31,7 +31,7 @@ import json
 
 class Geocode_City_CSV(Source):
 
-    def __init__(self, source, logger, citycode = None, delimiter = ',', encoding = 'utf-8'):
+    def __init__(self, source, logger, citycode, delimiter = ',', encoding = 'utf-8'):
         self.source = source
         self.delimiter = delimiter
         self.citycode = citycode

--- a/analysers/Analyser_Merge_Geocode_City_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_City_CSV.py
@@ -51,7 +51,7 @@ class Geocode_City_CSV(Source):
         infile = self.source.open()
         header = None
         i = 0
-        
+
         for linestr in infile:
             outline = linestr.split(self.delimiter)
 
@@ -70,7 +70,7 @@ class Geocode_City_CSV(Source):
                 rData = json.loads(r.text)
 
                 outline.extend(rData["centre"]["coordinates"])
-            
+
             outfile.write(self.delimiter.join(outline))
             i += 1
 

--- a/analysers/Analyser_Merge_Geocode_City_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_City_CSV.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe 2022                                      ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+## This tool uses French administrative API to find center coordinates   ##
+## of cities                                                             ##
+## See https://geo.api.gouv.fr/decoupage-administratif                   ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge import Source
+from modules import downloader
+import json
+
+
+class Geocode_City_CSV(Source):
+
+    def __init__(self, source, logger, citycode = None, delimiter = ',', encoding = 'utf-8'):
+        self.source = source
+        self.delimiter = delimiter
+        self.citycode = citycode
+        self.encoding = encoding
+        self.logger = logger
+
+    def __getattr__(self, name):
+        return getattr(self.source, name)
+
+    def open(self):
+        return open(downloader.update_cache('citycoded://' + self.source.fileUrl, 60, fetch=self.fetch))
+
+    def fetch(self, url, tmp_file, date_string=None):
+        service = u'https://geo.api.gouv.fr/communes/'
+        outfile = open(tmp_file, 'w', encoding='utf-8')
+
+        infile = self.source.open()
+        header = None
+        i = 0
+        
+        for linestr in infile:
+            outline = linestr.split(self.delimiter)
+
+            if i == 0:
+                outline.extend(["longitude", "latitude"])
+                header = outline
+            else:
+                self.logger.log("Geocode line {0}".format(i))
+                r = downloader.requests_retry_session().get(url=service+outline[header[self.citycode]], params={
+                    'fields': 'centre',
+                    'format': 'json',
+                    'geometry': 'centre',
+                })
+
+                r.raise_for_status()
+                rData = json.loads(r.text)
+
+                outline.extend(rData["centre"]["coordinates"])
+            
+            outfile.write(self.delimiter.join(outline))
+            i += 1
+
+        return True

--- a/analysers/Analyser_Merge_Geocode_City_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_City_CSV.py
@@ -60,7 +60,7 @@ class Geocode_City_CSV(Source):
             else:
                 self.logger.log("Geocode line {0}".format(i))
                 geocode_url = "https://geo.api.gouv.fr/communes/"+outline[header[self.citycode]]+"?fields=centre&format=json&geometry=centre"
-                json_str = urlread(geocode_url, 60)
+                json_str = downloader.urlread(geocode_url, 60)
 
                 if json_str:
                     rData = json.loads(json_str)

--- a/analysers/Analyser_Merge_Geocode_City_CSV.py
+++ b/analysers/Analyser_Merge_Geocode_City_CSV.py
@@ -45,7 +45,6 @@ class Geocode_City_CSV(Source):
         return open(downloader.update_cache('citycoded://' + self.source.fileUrl, 60, fetch=self.fetch))
 
     def fetch(self, url, tmp_file, date_string=None):
-        service = u'https://geo.api.gouv.fr/communes/'
         outfile = open(tmp_file, 'w', encoding='utf-8')
 
         infile = self.source.open()
@@ -60,16 +59,14 @@ class Geocode_City_CSV(Source):
                 header = outline
             else:
                 self.logger.log("Geocode line {0}".format(i))
-                r = downloader.requests_retry_session().get(url=service+outline[header[self.citycode]], params={
-                    'fields': 'centre',
-                    'format': 'json',
-                    'geometry': 'centre',
-                })
+                geocode_url = "https://geo.api.gouv.fr/communes/"+outline[header[self.citycode]]+"?fields=centre&format=json&geometry=centre"
+                json_str = urlread(geocode_url, 60)
 
-                r.raise_for_status()
-                rData = json.loads(r.text)
-
-                outline.extend(rData["centre"]["coordinates"])
+                if json_str:
+                    rData = json.loads(json_str)
+                    outline.extend(rData["centre"]["coordinates"])
+                else:
+                    outline.extend(["",""])
 
             outfile.write(self.delimiter.join(outline))
             i += 1

--- a/analysers/analyser_merge_power_plant_FR.py
+++ b/analysers/analyser_merge_power_plant_FR.py
@@ -22,7 +22,7 @@
 
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge import Analyser_Merge_Point, SourceOpenDataSoft, CSV, Load_XY, Conflate, Select, Mapping
-from .Analyser_Merge_Geocode_Addok_CSV import Geocode_Addok_CSV
+from .Analyser_Merge_Geocode_City_CSV import Geocode_City_CSV
 from modules import Stablehash
 
 
@@ -35,7 +35,7 @@ class Analyser_Merge_Power_Plant_FR(Analyser_Merge_Point):
         self.init(
             "https://opendata.reseaux-energies.fr/explore/dataset/registre-national-installation-production-stockage-electricite-agrege",
             "Registre national des installations de production d'électricité et de stockage",
-            CSV(Geocode_Addok_CSV(
+            CSV(Geocode_City_CSV(
                 SourceOpenDataSoft(
                     attribution="data.gouv.fr:RTE",
                     url="https://opendata.reseaux-energies.fr/explore/dataset/registre-national-installation-production-stockage-electricite-agrege"),


### PR DESCRIPTION
i'd like to propose a new French city centre geocoding ability as to solve Addok problems when looking for centroïd or city hall point of a city.

Currently `analyser_merge_power_plant_FR.py` uses `Analyser_Merge_Geocode_Addok_CSV.py` which doesn't deliver appropriate results with city names/codes only.
As Addok client may be useful for further anlyzers, I've added `Analyser_Merge_Geocode_City_CSV.py` to use official https://api.gouv.fr/documentation/api-geo.
I can remove `Analyser_Merge_Geocode_Addok_CSV.py` if required by contribution guidelines.

Instead of Addok geocoder, official Geo API doesn't support csv data to make bulk geocoding, so the input file is read line by line. Is it ok?