### PR TITLE
Allow similar wikidata values

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -48,7 +48,7 @@ similar.'''),
 
         self.BlackList = set((
             'ref', 'created_by', 'is_in',
-            'CLC:id', 'GNS:id', 'tmc', 'tiger:cfcc', 'statscan:rbuid',
+            'CLC:id', 'GNS:id', 'tmc', 'tiger:cfcc', 'statscan:rbuid', 'nysgissam:nysaddresspointid',
             'source:geometry:date', 'source:geometry:ref', # Belgium, Flanders
             'source:date',
             'service_times', 'collection_times',
@@ -77,6 +77,7 @@ similar.'''),
             re.compile('railway:signal:.+'),
             re.compile('turn:lanes.*'),
             re.compile('opening_hours(:.+)?'),
+            re.compile('(.+:)?wikidata'),
        ))
 
     # http://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Python


### PR DESCRIPTION
- Allow similar wikidata values, fixes #1504
- Disable check for `nysgissam:nysaddresspointid` (which overflows [New York](https://osmose.openstreetmap.fr/nl/issues/open?source=10268&item=3060&class=30601&limit=12500) )