### PR TITLE
Make parking:*:[side] reflect current wiki

### DIFF
--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -65,7 +65,7 @@ be tagged on that object instead.'''))
         self.errors[31619] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:survey'],
             title = T_('Bad parking:condition:[side] value'),
             fix = T_('''Use any of the following values: `{0}`''', ", ".join(self.parkingConditionValues)),
-            resource = "https://wiki.openstreetmap.org/wiki/Key:parking:condition"))
+            resource = "https://wiki.openstreetmap.org/wiki/Key:parking:condition")
 
     def way(self, data, tags, nds):
         if not "highway" in tags:
@@ -103,7 +103,7 @@ be tagged on that object instead.'''))
                         err.append({"class": 31615, "subclass": stablehash64(side)})
                 condition = side.replace("lane", "condition")
                 if condition in tags:
-                    if tags[side] == "no":
+                    if tags[side] == "no" and tags[condition][0:2] != "no":
                         # parking:lane:[side] = no together with parking:condition:[side]
                         err.append({"class": 31617, "subclass": stablehash64(side)})
                     elif tags[side] == "separate":
@@ -147,5 +147,6 @@ class Test(TestPluginCommon):
                   {"highway": "r", "parking:lane:left": "parallel", "parking:lane:right": "separate"},
                   {"highway": "r", "parking:lane:both": "separate"},
                   {"highway": "r", "parking:lane:left": "parallel", "parking:condition:left": "free", "parking:lane:right": "separate"},
+                  {"highway": "r", "parking:lane:both": "no", "parking:condition:both": "no_stopping"},
                  ]:
             assert not a.way(None, t, None), t

--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -75,7 +75,7 @@ be tagged on that object instead.'''))
 
         if (("parking:condition:right" in tags and not "parking:lane:right" in tags and not "parking:lane:both" in tags) or
             ("parking:condition:left" in tags and not "parking:lane:left" in tags and not "parking:lane:both" in tags) or
-            ("parking:condition:both" in tags and not "parking:condition:both" in tags)):
+            ("parking:condition:both" in tags and not "parking:lane:both" in tags and not ("parking:lane:left" in tags and "parking:lane:right" in tags))):
             err.append({"class": 31616})
 
         sides = list(map(lambda tag: tag[len("parking:lane:"):].split(":")[0], filter(lambda tag: tag.startswith("parking:lane:"), tags)))
@@ -102,6 +102,8 @@ be tagged on that object instead.'''))
                     else:
                         err.append({"class": 31615, "subclass": stablehash64(side)})
                 condition = side.replace("lane", "condition")
+                if not condition in tags:
+                    condition = "parking:condition:both"
                 if condition in tags:
                     if tags[side] == "no" and tags[condition][0:2] != "no":
                         # parking:lane:[side] = no together with parking:condition:[side]
@@ -130,7 +132,9 @@ class Test(TestPluginCommon):
                   {"highway": "r", "parking:lane:right": "free"},
                   {"highway": "r", "parking:lane:right": "bus_stop"},
                   {"highway": "r", "parking:condition:right": "parallel"},
+                  {"highway": "r", "parking:lane:left": "no", "parking:condition:both": "no"},
                   {"highway": "r", "parking:lane:both": "no", "parking:condition:both": "free"},
+                  {"highway": "r", "parking:lane:left": "no", "parking:lane:right": "parallel", "parking:condition:both": "free"},
                   {"highway": "r", "parking:lane:both": "separate", "parking:condition:both": "free"},
                   {"highway": "r", "parking:lane:both": "yes", "parking:condition:both": "parallel"},
                  ]:
@@ -148,5 +152,6 @@ class Test(TestPluginCommon):
                   {"highway": "r", "parking:lane:both": "separate"},
                   {"highway": "r", "parking:lane:left": "parallel", "parking:condition:left": "free", "parking:lane:right": "separate"},
                   {"highway": "r", "parking:lane:both": "no", "parking:condition:both": "no_stopping"},
+                  {"highway": "r", "parking:condition:both": "private", "parking:lane:left": "parallel", "parking:lane:right": "perpendicular"},
                  ]:
             assert not a.way(None, t, None), t

--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -46,7 +46,7 @@ class Highway_Parking_Lane(Plugin):
 sides.'''))
         self.errors[31615] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:chair'],
             title = T_('Bad parking:lane:[side] value'),
-            fix = T_('''Use any of the following values: `{0}`''', "`, `".join(self.parkingLaneValues)),
+            fix = T_('''Use any of the following values: `{0}`.''', "`, `".join(self.parkingLaneValues)),
             resource = "https://wiki.openstreetmap.org/wiki/Key:parking:lane")
         self.errors[31616] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:survey'],
             title = T_('parking:condition:[side] without parking:lane:[side] value'),
@@ -64,7 +64,7 @@ that the parking area is mapped separately. Any parking conditions should
 be tagged on that object instead.'''))
         self.errors[31619] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:survey'],
             title = T_('Bad parking:condition:[side] value'),
-            fix = T_('''Use any of the following values: `{0}`''', ", ".join(self.parkingConditionValues)),
+            fix = T_('''Use any of the following values: `{0}`.''', ", ".join(self.parkingConditionValues)),
             resource = "https://wiki.openstreetmap.org/wiki/Key:parking:condition")
 
     def way(self, data, tags, nds):


### PR DESCRIPTION
Related to: #1506, #1479

- `no_stopping`, `no_parking` are now `parking:condition:[side]` values, `fire_lane` is a `parking:condition:[side]:reason` value
- warn if `parking:condition:[side]` is set to a value belonging to `parking:lane:[side]`
- make error 31615 more clear in case `parking:lane:[side]` is set to a `parking:condition:[side]` or `parking:condition:[side]:reason` value
- Check `parking:lane:[left/right]` + `parking:condition:both` mismatches (as it was very easy to implement)
- Fix part of the check for error 31616 which never returned true

Marked as ready for review, but it may be good to wait until the checks are fixed...