### PR TITLE
Increase priority of guaranteed errors in Highway_Parking_Lane

### DIFF
--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -32,7 +32,7 @@ class Highway_Parking_Lane(Plugin):
         self.parkingConditionValues = ["free", "ticket", "disc", "residents", "customers", "private", "disabled", "loading", "no_parking", "no_standing", "no_stopping", "no"] # or custom
         self.parkingConditionReasonValues = ["bus_stop", "crossing", "driveway", "dual_carriage", "fire_lane", "junction", "loading_zone", "narrow", "passenger_loading_zone", "priority_road", "street_cleaning", "turnaround", "turn_lane"] # or custom
 
-        self.errors[31611] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:imagery'],
+        self.errors[31611] = self.def_class(item = 3161, level = 1, tags = ['highway', 'parking', 'fix:imagery'],
             title = T_('Bad parking:lane:[side]'),
             detail = T_(
 '''The side was not recognized, see

--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -32,7 +32,7 @@ class Highway_Parking_Lane(Plugin):
         self.parkingConditionValues = ["free", "ticket", "disc", "residents", "customers", "private", "disabled", "loading", "no_parking", "no_standing", "no_stopping", "no"] # or custom
         self.parkingConditionReasonValues = ["bus_stop", "crossing", "driveway", "dual_carriage", "fire_lane", "junction", "loading_zone", "narrow", "passenger_loading_zone", "priority_road", "street_cleaning", "turnaround", "turn_lane"] # or custom
 
-        self.errors[31611] = self.def_class(item = 3161, level = 1, tags = ['highway', 'parking', 'fix:imagery'],
+        self.errors[31611] = self.def_class(item = 3161, level = 2, tags = ['highway', 'parking', 'fix:imagery'],
             title = T_('Bad parking:lane:[side]'),
             detail = T_(
 '''The side was not recognized, see


### PR DESCRIPTION
I checked the results after the recent modification. All seemed fine.
However, I spotted that suggestions for optimization got the same priority as 100% certainly errors (like 31611)

I didn't touch the others as they are either suggestions (31614,31616 for example: not wrong, just suboptimal), error prone (31617 and above: they can have custom values added in the future) or currently very very common (31615, due to the `no_stopping`/`no_parking` move). However, 31611 is very unlikely to contain false positives: anything but `left`, `right` or `both` is unlikely to be added, ever.

`31611` (unknown [side]) has 508 occurances at the moment