### PR TITLE
Implement drive-through check (attempt 2)

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -211,7 +211,7 @@ SELECT
   wid,
   nid,
   (SELECT ST_AsText(geom) FROM nodes WHERE id = nid)
-FROM 
+FROM
   (
   SELECT
     id AS wid,


### PR DESCRIPTION
New attempt based on feedback in #1521 (new PR as it's mostly a rewrite; keeps things clean :) )
Fixes #1499  -  Check for potential driveway/drive-through mix-ups.

1. Start from `highway=service` + `service=drive-through` (and not a oneway, which is just a shortcut as oneways are theoretically never dead-ended)
2. Get the end nodes of this way
3. Filter out (via `LEFT JOIN` + `WHERE ... IS NULL`) the end nodes that are connected to any other way
4. Filter out (the last `JOIN`) i.e. turning circles (which could make it a valid dead-end drivethrough) and entrances (if e.g. the indoor part isn't mapped)

Results of some countries [attached](https://github.com/osm-fr/osmose-backend/files/9437767/results.zip); no false positives so far; several "bad" drive-throughs found. (Note: in my local tests I disabled the class=1&2&3 analysers, hence their results are not listed)