### PR TITLE
Remove 32001 (Redundant area=yes tagging) in favor of JOSM mapcss rules

### DIFF
--- a/plugins/TagFix_Area.py
+++ b/plugins/TagFix_Area.py
@@ -45,6 +45,8 @@ class TagFix_Area(Plugin):
 
     def way(self, data, tags, nds):
         err = []
+        if not "area" in tags:
+            return err
         key_set = set(tags.keys())
         if tags.get("area") == "yes":
             if len(key_set & self.area_yes_default) == 0 and len(key_set & self.area_yes_good) == 0 and tags.get("railway") != "platform":


### PR DESCRIPTION
This patch removes the test in Osmose as part of #1533
~Prior to applying, the updated JOSM rules should be imported in Osmose (completed in https://github.com/osm-fr/osmose-backend/commit/6c5c1a414e639da144ff41dcc0b97b38510bd86a)~ and in the ideal case, the parsing issue should be fixed first too.