### PR TITLE
Don't remove oneway from roundabout if oneway=no

### DIFF
--- a/plugins/TagRemove_Roundabout.py
+++ b/plugins/TagRemove_Roundabout.py
@@ -35,7 +35,7 @@ The tag `name=*` must be present if this is the name of the roundabout
 and not a road connected, same thing for `ref=*`.'''))
 
     def way(self, data, tags, nds):
-        if tags.get("junction") == "roundabout" and u"oneway" in tags:
+        if tags.get("junction") == "roundabout" and u"oneway" in tags and tags.get("oneway") != "no":
             return {"class": 101, "subclass": 0, "text": T_(u"Unnecessary tag oneway"), "fix": {"-": ["oneway"]}}
 
 
@@ -47,5 +47,6 @@ class Test(TestPluginCommon):
         a = TagRemove_Roundabout(None)
         a.init(None)
         assert not a.way(None, {"junction": "roundabout"}, None)
+        assert not a.way(None, {"junction": "roundabout", "oneway": "no"}, None)
         assert not a.way(None, {"junction": "yes", "oneway": "true"}, None)
         self.check_err(a.way(None, {"junction": "roundabout", "oneway": "true"}, None))


### PR DESCRIPTION
Prevent proposing to remove `oneway` from a roundabout if `oneway=no`. 

The proper fix would be to tag `junction=circular` instead of `junction=roundabout` and keep the `oneway` tag, however, I believe a check for this case belongs in JOSM ( filed: https://josm.openstreetmap.de/ticket/22343 ), hence I'm just adding the exception to Osmose.
Example issue: https://osmose.openstreetmap.fr/nl/issue/38388bc5-48a0-8cdb-7891-81cbb7f3fc4b
815 cases worldwide

(p.s.: theoretically this entire plugin could be in mapcss, but I find it too debatable if having oneway=yes is bad to propose it to JOSM myself. In fact, I always disable this check when I'm looking at Osmose issues)