### PR TITLE
Exclude junction=circular in missing roundabout check

### DIFF
--- a/analysers/analyser_osmosis_roundabout.py
+++ b/analysers/analyser_osmosis_roundabout.py
@@ -45,6 +45,7 @@ WHERE
     NOT ways.is_construction AND
     (NOT ways.tags?'name' OR ways.tags->'name' LIKE 'Rond%' OR ways.tags->'name' LIKE 'Giratoire%') AND -- no name or start with 'Rond' or 'Giratoire' (French)
     NOT ways.tags->'oneway' = 'no' AND
+    NOT ways.tags->'junction' = 'circular' AND
     -- geometry
     ways.is_polygon AND -- It's a polygon
     ST_NPoints(ways.linestring) < 24 AND
@@ -68,6 +69,7 @@ FROM
   JOIN nodes ON
     roundabouts.linestring && nodes.geom AND
     nodes.id = ANY(roundabouts.nodes) AND
+    nodes.tags != ''::hstore AND
     nodes.tags?'highway' AND nodes.tags->'highway' IN ('traffic_signals', 'give_way', 'stop') AND -- "yield-nodes"
     (-- tolerate rarely-red traffic_signals such as emergency, blink_mode, continuous_green, ...
       NOT nodes.tags?'traffic_signals' OR


### PR DESCRIPTION
Fixes issue #1549.
Also add the `nodes.tags != ''::hstore` check to the new check as recommended by the docs

---------

@frodrigo I have some issues with debugging the 'diff'-supporting analysers locally.
When I run it the first time (i.e. via `./osmose_run.py --no-clean --country=sweden_gotland --skip-frontend-check --skip-upload --analyser=osmosis_roundabout`) all results (1) are present. When I re-run the analyser (using the same command) the results are empty, probably because it uses the diff mode (and the relevant ways haven't changed).
Is there some option to ensure you always get the full results for i.e. debugging purposes?
Example using the command above:
First time running, I got https://www.openstreetmap.org/way/5134430 as a result for class 1
Second time running, I got no results