### PR TITLE
Fix analyser_osmosis_roundabout

### DIFF
--- a/analysers/analyser_osmosis_roundabout.py
+++ b/analysers/analyser_osmosis_roundabout.py
@@ -45,7 +45,7 @@ WHERE
     NOT ways.is_construction AND
     (NOT ways.tags?'name' OR ways.tags->'name' LIKE 'Rond%' OR ways.tags->'name' LIKE 'Giratoire%') AND -- no name or start with 'Rond' or 'Giratoire' (French)
     NOT ways.tags->'oneway' = 'no' AND
-    NOT ways.tags->'junction' = 'circular' AND
+    NOT ways.tags?'junction' AND
     -- geometry
     ways.is_polygon AND -- It's a polygon
     ST_NPoints(ways.linestring) < 24 AND


### PR DESCRIPTION
See #1551 
`NOT ways.tags->'junction' = 'circular'` evaluates to false if junction is not present. However, as no other value of `junction` can work together with `junction=roundabout`, just check that `junction` is absent.

Alternative is:
`NOT (ways.tags?'junction' AND ways.tags->'junction' = 'circular')`


(This very likely means that the line above it also doesn't act as it's intended to, although the effect makes more sense there)

Will run over some more areas overnight to ensure the results are ok now. Apologies... when debugging locally this I was blaming this on my non-understanding of the diff mode. (I should've understood something was wrong when frodrigo told me that diff mode isn't run unless `--resume` is used)