### PR TITLE
Check for proj in analysers using highway; add test for analyser_osmosis_roundabout

### DIFF
--- a/analysers/analyser_osmosis_cycleway_track.py
+++ b/analysers/analyser_osmosis_cycleway_track.py
@@ -61,6 +61,8 @@ class Analyser_Osmosis_Cycleway_track(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1180, level = 2, tags = ['geom', 'highway', 'cycleway', 'fix:chair'],
             title = T_('Duplicated cycle tracks, `highway=*`+`cycleway=track` and `highway=cycleway`'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_almost_junction.py
+++ b/analysers/analyser_osmosis_highway_almost_junction.py
@@ -98,6 +98,8 @@ class Analyser_Osmosis_Highway_Almost_Junction(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1270, level = 1, tags = ['highway', 'fix:chair'],
             title = T_('Almost junction, join or use noexit tag'))
 

--- a/analysers/analyser_osmosis_highway_area_access.py
+++ b/analysers/analyser_osmosis_highway_area_access.py
@@ -59,6 +59,8 @@ class Analyser_Osmosis_HighwayAreaAccess(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs_change[1] = self.def_class(item = 2130, level = 3, tags = ['highway', 'routing'],
             title = T_('Inconsistent Access'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_bad_intersection.py
+++ b/analysers/analyser_osmosis_highway_bad_intersection.py
@@ -90,6 +90,8 @@ class Analyser_Osmosis_Highway_Bad_Intersection(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs_change[1] = self.def_class(item = 1250, level = 3, tags = ['highway', 'power', 'fix:chair'],
             title = T_('Intersection of unrelated highway and power objects'))
         self.classs_change[2] = self.def_class(item = 1250, level = 3, tags = ['highway', 'waterway', 'fix:chair'],

--- a/analysers/analyser_osmosis_highway_broken_level_continuity.py
+++ b/analysers/analyser_osmosis_highway_broken_level_continuity.py
@@ -106,6 +106,8 @@ class Analyser_Osmosis_Highway_Broken_Level_Continuity(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         doc = dict(
             title = T_('Broken highway level continuity'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_cul-de-sac_level.py
+++ b/analysers/analyser_osmosis_highway_cul-de-sac_level.py
@@ -60,6 +60,8 @@ class Analyser_Osmosis_Highway_CulDeSac_Level(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         doc = dict(
             detail = T_(
 '''A way connects directly to the street classification much

--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -244,6 +244,8 @@ class Analyser_Osmosis_Highway_DeadEnd(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         detail = T_(
 '''The end of the way is not connected to another way.''')
         self.classs_change[1] = self.def_class(item = 1210, level = 1, tags = ['highway', 'cycleway', 'fix:chair'],

--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -111,6 +111,8 @@ class Analyser_Osmosis_Highway_Floating_Islands(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[4] = self.def_class(item = 1210, level = 1, tags = ['highway'],
             title = T_('Small highway group apart from the main network or with insufficient access upstream'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_link.py
+++ b/analysers/analyser_osmosis_highway_link.py
@@ -128,6 +128,8 @@ class Analyser_Osmosis_Highway_Link(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1110, level = 1, tags = ['highway', 'fix:chair'],
             title = T_('Bad *_link highway'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_motorway.py
+++ b/analysers/analyser_osmosis_highway_motorway.py
@@ -49,6 +49,8 @@ class Analyser_Osmosis_Highway_Motorway(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs_change[1] = self.def_class(item = 3220, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Direct or too permissive access to motorway'))
         self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText]}

--- a/analysers/analyser_osmosis_highway_name_close.py
+++ b/analysers/analyser_osmosis_highway_name_close.py
@@ -78,6 +78,8 @@ class Analyser_Osmosis_Highway_Name_Close(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
 
         # Check langues for country are writen with alphabets
         self.alphabet = 'language' in config.options and languages.languages_are_alphabets(config.options['language'])

--- a/analysers/analyser_osmosis_highway_noexit.py
+++ b/analysers/analyser_osmosis_highway_noexit.py
@@ -86,6 +86,8 @@ class Analyser_Osmosis_Highway_Noexit(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs_change[1] = self.def_class(item = 3210, level = 2, tags = ['highway', 'tag', 'fix:chair'],
             title = T_('Noexit on node with exit'))
         self.classs[2] = self.def_class(item = 3210, level = 2, tags = ['highway', 'tag', 'fix:chair'],

--- a/analysers/analyser_osmosis_highway_traffic_signals.py
+++ b/analysers/analyser_osmosis_highway_traffic_signals.py
@@ -159,6 +159,8 @@ class Analyser_Osmosis_Highway_Traffic_Signals(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         doc = dict(
             detail = T_(
 '''An other node very close have already a traffic signals.'''),

--- a/analysers/analyser_osmosis_highway_turn_lanes.py
+++ b/analysers/analyser_osmosis_highway_turn_lanes.py
@@ -137,6 +137,8 @@ class Analyser_Osmosis_Highway_Turn_Lanes(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 3160, level = 2, tags = ['highway', 'fix:chair'],
             title = T_('Bad lanes number or `turn:lanes` before and after this node'))
 

--- a/analysers/analyser_osmosis_highway_without_ref.py
+++ b/analysers/analyser_osmosis_highway_without_ref.py
@@ -48,6 +48,8 @@ class Analyser_Osmosis_Highway_Without_Ref(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[20804] = self.def_class(item = 2080, level = 2, tags = ['highway', 'ref', 'fix:chair'],
             title = T_('Motorway without ref, nat_ref, int_ref or noref tag'))
 

--- a/analysers/analyser_osmosis_highway_zone.py
+++ b/analysers/analyser_osmosis_highway_zone.py
@@ -109,6 +109,8 @@ class Analyser_Osmosis_Highway_Zone(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[20] = self.def_class(item = 2150, level = 1, tags = ['highway', 'fix:survey'],
             title = T_('Probably missing tag zone:maxspeed=XX:{0}, according to the neighborhood', 20))
         self.classs[30] = self.def_class(item = 2150, level = 1, tags = ['highway', 'fix:survey'],

--- a/analysers/analyser_osmosis_parking_highway.py
+++ b/analysers/analyser_osmosis_parking_highway.py
@@ -63,6 +63,8 @@ class Analyser_Osmosis_Parking_highway(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 3161, level = 1, tags = ['highway', 'fix:chair'],
             title = T_('Missing access way to parking'),
             detail = T_('There should be a `highway` feature leading to this parking facility to allow for correct routing.'))

--- a/analysers/analyser_osmosis_relation_associatedStreet.py
+++ b/analysers/analyser_osmosis_relation_associatedStreet.py
@@ -612,6 +612,8 @@ class Analyser_Osmosis_Relation_AssociatedStreet(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 2060, level = 3, tags = ['addr', 'relation', 'fix:chair'],
             title = T_('addr:housenumber or addr:housename without addr:street, addr:district, addr:neighbourhood, addr:quarter, addr:suburb, addr:place or addr:hamlet must be in a associatedStreet relation'),
             detail = T_(
@@ -666,14 +668,13 @@ provide a consistent address.'''))
         self.run(sql01.format(self.config.options.get("proj", 4326)))
         self.run(sql10, lambda res: {"class":1, "subclass":1, "data":[self.way_full, self.positionAsText]} )
         self.run(sql11, lambda res: {"class":1, "subclass":2, "data":[self.node_full, self.positionAsText]} )
-        if "proj" in self.config.options:
-            self.run(sql60.format(self.config.options.get("proj")))
-            self.run(sql61)
-            self.run(sql62)
-            self.run(sql63, lambda res: {"class":6, "subclass":1,
-                "data":[lambda t: self.typeMapping[res[1]](t), None, self.positionAsText],
-                "text": T_("Multiple numbers \"{numbers}\" in way \"{way}\"", numbers = ",  ".join(filter(lambda z: z, res[4:])), way = res[3]),
-            })
+        self.run(sql60.format(self.config.options.get("proj")))
+        self.run(sql61)
+        self.run(sql62)
+        self.run(sql63, lambda res: {"class":6, "subclass":1,
+            "data":[lambda t: self.typeMapping[res[1]](t), None, self.positionAsText],
+            "text": T_("Multiple numbers \"{numbers}\" in way \"{way}\"", numbers = ",  ".join(filter(lambda z: z, res[4:])), way = res[3]),
+        })
         self.run(sql70)
         self.run(sql80, lambda res: {"class":7, "subclass":1, "data":[self.relation_full, self.positionAsText], "text":{"en": res[2]}} )
         self.run(sql90)
@@ -684,9 +685,8 @@ provide a consistent address.'''))
             self.run(sqlC0)
             self.run(sqlC1.format( "','".join(self.config.options.get("addr:city-admin_level").split(','))))
             self.run(sqlC2, self.callbackC2)
-        if "proj" in self.config.options:
-            self.run(sqlD0)
-            self.run(sqlD1.format(self.config.options.get("addr:street_distance", 500)), self.callbackD1)
+        self.run(sqlD0)
+        self.run(sqlD1.format(self.config.options.get("addr:street_distance", 500)), self.callbackD1)
         self.run(sqlF0.format(self.config.options.get("proj")), self.callbackF0)
 
     def analyser_osmosis_full(self):

--- a/analysers/analyser_osmosis_relation_enforcement.py
+++ b/analysers/analyser_osmosis_relation_enforcement.py
@@ -55,6 +55,8 @@ class Analyser_Osmosis_Relation_Enforcement(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1280, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Disconnected speed camera'),
             fix = T_('Speed camera should be mapped as a node on the highway or use an enforcement relation.'))

--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -565,6 +565,8 @@ class Analyser_Osmosis_Relation_Public_Transport(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1260, level = 3, tags = ['public_transport'],
             title = T_('The track of this route contains gaps'))
         self.classs[2] = self.def_class(item = 1260, level = 3, tags = ['public_transport'],

--- a/analysers/analyser_osmosis_relation_restriction.py
+++ b/analysers/analyser_osmosis_relation_restriction.py
@@ -362,6 +362,8 @@ class Analyser_Osmosis_Relation_Restriction(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs_change[1] = self.def_class(item = 3180, level = 2, tags = ['relation', 'restriction', 'fix:survey'],
             title = T_('Restriction relation, wrong number of members'),
             detail = T_(

--- a/analysers/analyser_osmosis_roundabout.py
+++ b/analysers/analyser_osmosis_roundabout.py
@@ -86,49 +86,47 @@ class Analyser_Osmosis_Roundabout(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        if "proj" in self.config.options:
-            self.classs_change[1] = self.def_class(item = 2010, level = 1, tags = ['highway', 'roundabout', 'fix:imagery'],
-                title = T_('Missing `junction=roundabout`'),
-                detail = T_(
+        if not "proj" in self.config.options:
+            return
+        self.classs_change[1] = self.def_class(item = 2010, level = 1, tags = ['highway', 'roundabout', 'fix:imagery'],
+            title = T_('Missing `junction=roundabout`'),
+            detail = T_(
 '''This looks like a roundabout, but the tag `junction=roundabout` is not
 present. See [Roundabout](https://wiki.openstreetmap.org/wiki/Roundabout)
 for more info.'''),
-                fix = T_(
+            fix = T_(
 '''If it is really a roundabout, add the tag `junction=roundabout`,
 verify that the way direction is counter-clockwise when the driving side is
 on the right, and remove the tag `oneway=yes` if present.'''),
-                trap = T_(
+            trap = T_(
 '''Ensure that it is a roundabout, using satellite imagery or a local
 survey.
 
 Ensure the traffic on the roundabout has right of way. If not, use `junction=circular` instead.'''))
-            self.classs[2] = self.def_class(item = 2010, level = 2, tags = ['highway', 'roundabout', 'fix:imagery'],
-                title = T_('Roundabout without right of way'),
-                detail = T_(
+        self.classs[2] = self.def_class(item = 2010, level = 2, tags = ['highway', 'roundabout', 'fix:imagery'],
+            title = T_('Roundabout without right of way'),
+            detail = T_(
 '''A highway with `junction=roundabout` must by definition have the right of way.
 Circular highways without right of way should be tagged as `junction=circular`.'''),
-                fix = T_(
+            fix = T_(
 '''Replace `junction=roundabout` on the entire circular road with `junction=circular`.
 
 If the node with `highway=traffic_signals`, `give_way` or `stop` is actually for the road entering the roundabout, tag it on that way only.'''),
-                trap = T_(
+            trap = T_(
 '''Make sure to tag `oneway=*` when using `junction=circular`. Unlike `junction=roundabout`, `junction=circular` does not imply `oneway=yes`.'''),
-                resource = "https://wiki.openstreetmap.org/wiki/Tag:junction%3Dcircular")
+            resource = "https://wiki.openstreetmap.org/wiki/Tag:junction%3Dcircular")
 
-            self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText], "fix":{"+":{"junction":"roundabout"}} }
+        self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText], "fix":{"+":{"junction":"roundabout"}} }
 
     def analyser_osmosis_full(self):
-        if "proj" in self.config.options:
-            self.run(sql10.format(self.config.options.get("proj"), "", ""), self.callback10)
+        self.run(sql10.format(self.config.options.get("proj"), "", ""), self.callback10)
 
     def analyser_osmosis_diff(self):
-        if "proj" in self.config.options:
-            self.run(sql10.format(self.config.options.get("proj"), "touched_", ""), self.callback10)
-            self.run(sql10.format(self.config.options.get("proj"), "not_touched_", "touched_"), self.callback10)
+        self.run(sql10.format(self.config.options.get("proj"), "touched_", ""), self.callback10)
+        self.run(sql10.format(self.config.options.get("proj"), "not_touched_", "touched_"), self.callback10)
 
     def analyser_osmosis_common(self):
-        if "proj" in self.config.options:
-            self.run(sql20, lambda res: {"class":2, "data":[self.way_full, self.node_full, self.positionAsText]})
+        self.run(sql20, lambda res: {"class":2, "data":[self.way_full, self.node_full, self.positionAsText]})
 
 
 

--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -258,6 +258,8 @@ class Analyser_Osmosis_Roundabout_Level(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 3010, level = 2, tags = ['highway', 'roundabout', 'fix:chair'],
             title = T_('Wrong highway on roundabout'),
             detail = T_(

--- a/tests/osmosis_roundabout.test.osm
+++ b/tests/osmosis_roundabout.test.osm
@@ -1,0 +1,251 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09188231412' lon='17.01859123955' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09188155044' lon='17.01865463058' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09191203475' lon='17.0186103306' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0919026591' lon='17.01860702791' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0918951917' lon='17.01861663963' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09189525566' lon='17.01863192792' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09190280282' lon='17.0186413804' />
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09191215' lon='17.01863787915' />
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0919162586' lon='17.01862406069' />
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09193197658' lon='17.01867112308' />
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194132376' lon='17.01866762184' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0919412085' lon='17.01864007328' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194543235' lon='17.01865380338' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09193183286' lon='17.0186367706' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09192436547' lon='17.01864638231' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09192442943' lon='17.0186616706' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09193387805' lon='17.0185999775' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194322523' lon='17.01859647626' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194310998' lon='17.01856892771' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194733382' lon='17.0185826578' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09193373433' lon='17.01856562502' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09192626694' lon='17.01857523673' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0919263309' lon='17.01859052503' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09188190333' lon='17.01862507908' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0919570803' lon='17.01854978183' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09185481021' lon='17.01859852154' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09193245613' lon='17.01871516792' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.091918369' lon='17.01852319141' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09187797939' lon='17.01854244022' />
+  <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09185970263' lon='17.01866519428' />
+  <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09189036741' lon='17.01871126154' />
+  <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09196627501' lon='17.0186750856' />
+  <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09197599985' lon='17.01860976953' />
+  <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194842742' lon='17.01860311858' />
+  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09195360419' lon='17.01858304114' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194816194' lon='17.01856486577' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194763099' lon='17.01863249504' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09195161312' lon='17.01865384053' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09194723278' lon='17.01867286126' />
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09191988885' lon='17.01862418869' />
+  <node id='42' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09183990154' lon='17.01858893378' />
+  <node id='43' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09183721843' lon='17.01868088978' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09197285129' lon='17.01854478812' />
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09198692148' lon='17.01861157202' />
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09197789532' lon='17.01867328373' />
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09187515626' lon='17.01861326276' />
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09187568721' lon='17.01863608763' />
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09176527118' lon='17.01879382887' />
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09166586665' lon='17.01876504468' />
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09162350181' lon='17.01861900465' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09167418823' lon='17.0184798473' />
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09177484072' lon='17.01846586065' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09180123376' lon='17.01838656748' />
+  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09179383881' lon='17.018860739' />
+  <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09158846026' lon='17.01841760805' />
+  <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09157703164' lon='17.01879651712' />
+  <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09159451104' lon='17.01839245395' />
+  <node id='59' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09158173787' lon='17.01842991671' />
+  <node id='60' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09156627562' lon='17.01877671484' />
+  <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09157770424' lon='17.01881631833' />
+  <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.0918857713' lon='17.01859181016' />
+  <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09188072929' lon='17.01858779629' />
+  <node id='64' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09188526709' lon='17.01865656722' />
+  <node id='65' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.09187804022' lon='17.01865763758' />
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='2' />
+    <nd ref='48' />
+    <nd ref='47' />
+    <nd ref='1' />
+    <nd ref='24' />
+    <nd ref='2' />
+    <tag k='highway' v='residential' />
+    <tag k='note' v='Too flat for roundabout' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='7' />
+    <nd ref='8' />
+    <nd ref='9' />
+    <nd ref='3' />
+    <tag k='highway' v='residential' />
+    <tag k='note' v='Too few connections' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='12' />
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='16' />
+    <nd ref='10' />
+    <nd ref='11' />
+    <nd ref='13' />
+    <nd ref='12' />
+    <tag k='highway' v='residential' />
+    <tag k='junction' v='roundabout' />
+    <tag k='note' v='Is already roundabout' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='19' />
+    <nd ref='21' />
+    <nd ref='22' />
+    <nd ref='23' />
+    <nd ref='17' />
+    <nd ref='18' />
+    <nd ref='20' />
+    <nd ref='19' />
+    <tag k='highway' v='residential' />
+    <tag k='junction' v='circular' />
+    <tag k='note' v='Is already junction=circular' />
+  </way>
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='25' />
+    <nd ref='28' />
+    <nd ref='29' />
+    <nd ref='26' />
+    <nd ref='30' />
+    <nd ref='31' />
+    <nd ref='27' />
+    <nd ref='32' />
+    <nd ref='33' />
+    <nd ref='25' />
+    <tag k='highway' v='residential' />
+    <tag k='note' v='Not oneway' />
+  </way>
+  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='18' />
+    <nd ref='34' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='20' />
+    <nd ref='35' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='108' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='19' />
+    <nd ref='36' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='109' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='12' />
+    <nd ref='37' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='13' />
+    <nd ref='38' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='11' />
+    <nd ref='39' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='41' />
+    <nd ref='9' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='114' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='26' />
+    <nd ref='42' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='115' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='30' />
+    <nd ref='43' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='25' />
+    <nd ref='44' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='117' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='33' />
+    <nd ref='45' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='118' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='32' />
+    <nd ref='46' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='119' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='42' />
+    <nd ref='43' />
+    <nd ref='49' />
+    <nd ref='50' />
+    <nd ref='51' />
+    <nd ref='52' />
+    <nd ref='53' />
+    <nd ref='42' />
+    <tag k='highway' v='primary' />
+    <tag k='note' v='Likely roundabout' />
+    <tag k='oneway' v='-1' />
+  </way>
+  <way id='120' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='53' />
+    <nd ref='54' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='121' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='49' />
+    <nd ref='55' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='122' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='52' />
+    <nd ref='56' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='123' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='50' />
+    <nd ref='57' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='124' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='58' />
+    <nd ref='56' />
+    <nd ref='59' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='125' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='60' />
+    <nd ref='57' />
+    <nd ref='61' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='126' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='62' />
+    <nd ref='1' />
+    <nd ref='63' />
+    <tag k='highway' v='unclassified' />
+  </way>
+  <way id='127' timestamp='2014-03-31T22:00:00Z' version='1' >
+    <nd ref='64' />
+    <nd ref='2' />
+    <nd ref='65' />
+    <tag k='highway' v='unclassified' />
+  </way>
+</osm>


### PR DESCRIPTION
1. Add a test to ensure the same error as with junction before can't happen again (and yes, I did have some drawing fun while making the test case :) )
2. Protect the class-"2"-test against `proj` being unset. In line with the class-"1"-test, I also put the error description behind `proj`, although that's technically not needed I think
3. Use `is_oneway` rather than `NOT ways.tags->'oneway' = 'no'`