### PR TITLE
Require highway_ends in 'common' analysers

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -238,12 +238,14 @@ WHERE
 
 class Analyser_Osmosis_Highway_DeadEnd(Analyser_Osmosis):
 
-    requires_tables_common = ['highways']
+    requires_tables_common = ['highways', 'highway_ends']
     requires_tables_full = ['highway_ends']
     requires_tables_diff = ['touched_highway_ends']
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         detail = T_(
 '''The end of the way is not connected to another way.''')
         self.classs_change[1] = self.def_class(item = 1210, level = 1, tags = ['highway', 'cycleway', 'fix:chair'],


### PR DESCRIPTION
- Require highway_ends as common table for common analysers (fixes diff mode run)
- Also ensure `proj` is set


(I suspect it's not needed to remove highway_ends from `requires_tables_full`? I see the code checks if it already exists, and if so, doesn't build it twice, so it'd have little additional benefit)