### PR TITLE
Add requires_tables_common to analyser_osmosis_roundabout

### DIFF
--- a/analysers/analyser_osmosis_roundabout.py
+++ b/analysers/analyser_osmosis_roundabout.py
@@ -81,6 +81,7 @@ WHERE
 
 class Analyser_Osmosis_Roundabout(Analyser_Osmosis):
 
+    requires_tables_common = ['highways']
     requires_tables_full = ['highways']
     requires_tables_diff = ['highways', 'touched_highways', 'not_touched_highways']
 


### PR DESCRIPTION
In case it's preferred to have requires_tables_common, even though requires_tables_full and requires_tables_diff both already load `highways` (based on #1560)