### PR TITLE
Accept whitelisted values in ;-separated combinations

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -111,10 +111,10 @@ However, this should probably still conform to the typical format used for value
         keys = set(keyss) & check_list_open
         for k in keys:
             if (not self.Values_open.match(tags[k]) and ( # value has a non-standard character
-                   not k in self.exceptions_open or # no exceptions exist for the key
-                   any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) # Check each value in a multiple-value key for not being whitelisted (or normal)
+                not k in self.exceptions_open or # no exceptions exist for the key
+                any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) # Check each value in a multiple-value key for not being whitelisted (or normal)
             )):
-               err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
+                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         keys = set(keyss) & self.check_list_closed
         for k in keys:

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -111,8 +111,9 @@ However, this should probably still conform to the typical format used for value
         keys = set(keyss) & check_list_open
         for k in keys:
             if (not self.Values_open.match(tags[k]) and ( # value has a non-standard character
-               not k in self.exceptions_open or # no exceptions exist for the key
-               any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) )): # Check each value in a multiple-value key for not being whitelisted (or normal)
+                   not k in self.exceptions_open or # no exceptions exist for the key
+                   any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) # Check each value in a multiple-value key for not being whitelisted (or normal)
+            )):
                 err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         keys = set(keyss) & self.check_list_closed

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -111,26 +111,10 @@ However, this should probably still conform to the typical format used for value
         keys = set(keyss) & check_list_open
         for k in keys:
             if not self.Values_open.match(tags[k]):
-                if k in self.exceptions_open:
-                    isWhitelisted = tags[k] in self.exceptions_open[k]
-                    if not isWhitelisted and ";" in tags[k]:
-                        for val in tags[k].split(";"):
-                            if val in self.exceptions_open[k]:
-                                # Whitelisted value
-                                isWhitelisted = True
-                                continue
-                            elif self.Values_open.match(val):
-                                # Normal value
-                                continue
-                            else:
-                                # Bad value
-                                isWhitelisted = False
-                                break
-
-                    if isWhitelisted:
-                        # No error if in exception list
-                        continue
-                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
+                if (not k in self.exceptions_open or # no whitelists exist for the key
+                   (not ";" in tags[k] and not tags[k] in self.exceptions_open[k]) or # single-valued tag and not whitelisted
+                   (";" in tags[k] and any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))))): # multi-valued tag and one or more bad values
+                    err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         keys = set(keyss) & self.check_list_closed
         for k in keys:

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -114,7 +114,7 @@ However, this should probably still conform to the typical format used for value
                    not k in self.exceptions_open or # no exceptions exist for the key
                    any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) # Check each value in a multiple-value key for not being whitelisted (or normal)
             )):
-                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
+               err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         keys = set(keyss) & self.check_list_closed
         for k in keys:

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -110,11 +110,10 @@ However, this should probably still conform to the typical format used for value
 
         keys = set(keyss) & check_list_open
         for k in keys:
-            if not self.Values_open.match(tags[k]):
-                if (not k in self.exceptions_open or # no whitelists exist for the key
-                   (not ";" in tags[k] and not tags[k] in self.exceptions_open[k]) or # single-valued tag and not whitelisted
-                   (";" in tags[k] and any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))))): # multi-valued tag and one or more bad values
-                    err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
+            if (not self.Values_open.match(tags[k]) and ( # value has a non-standard character
+               not k in self.exceptions_open or # no exceptions exist for the key
+               any(map(lambda val: val not in self.exceptions_open[k] and not self.Values_open.match(val), tags[k].split(";"))) )): # Check each value in a multiple-value key for not being whitelisted (or normal)
+                err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         keys = set(keyss) & self.check_list_closed
         for k in keys:


### PR DESCRIPTION
Accept whitelisted values also if they occur in a `;`-separated list. (Only for "open" keys; not for "closed" keys with fixed values like `oneway`)

See #1564

Note, the easy way out would be:
`if any(x in tags[k].split(";") for x in self.exceptions_open[k]):`
but that would fail if a whitelisted and 'bad' entry are combined. Given that this part of the code is only ran in rare cases, I guess it doesn't harm performance to have the check as detailed as possible.