### PR TITLE
Allow pole-mounted transformers

### DIFF
--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -221,12 +221,11 @@ FROM
     NATURAL JOIN power_line
     JOIN nodes ON
         power_line.nid = nodes.id AND
-        NOT (
-            nodes.tags?'power' AND
-            (
-                nodes.tags->'power' = 'transformer' OR
-                nodes.tags?'transformer' -- example: power=pole + transformer=*
-            )
+        (
+            NOT nodes.tags?'power' OR
+            nodes.tags->'power' != 'transformer'
+        ) AND
+        NOT nodes.tags?'transformer' -- example: power=pole + transformer=*
         )
 GROUP BY
     nid,

--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -221,9 +221,12 @@ FROM
     NATURAL JOIN power_line
     JOIN nodes ON
         power_line.nid = nodes.id AND
-        (
-            NOT nodes.tags?'power' OR
-            nodes.tags->'power' != 'transformer'
+        NOT (
+            nodes.tags?'power' AND
+            (
+                nodes.tags->'power' = 'transformer' OR
+                nodes.tags?'transformer' -- example: power=pole + transformer=*
+            )
         )
 GROUP BY
     nid,
@@ -367,7 +370,10 @@ or marked as transitioning into ground (`location:transition=yes`).'''),
 In which case make use of the `disused:` [lifecycle prefix](https://wiki.openstreetmap.org/wiki/Lifecycle_prefix).'''))
         self.classs[3] = self.def_class(item = 7040, level = 3, tags = ['power', 'fix:chair'],
             title = T_('Connection between different voltages'),
-            detail = T_('Two power lines meet at this point, but have inconsistent voltages (`voltage=*`).'))
+            detail = T_('Two power lines meet at this point, but have inconsistent voltages (`voltage=*`).'),
+            fix = T_(
+'''Check if the voltages are really different.
+Add a transformer using `power=transformer` (standalone transformers) or `power=pole + transformer=*` (pole mounted transformers).'''))
         self.classs[4] = self.def_class(item = 7040, level = 3, tags = ['power', 'fix:imagery'],
             title = T_('Non power node on power way'),
             detail = T_(

--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -417,3 +417,24 @@ there's likely an unmapped pole nearby.'''))
         self.run(sql50.format("touched_"))
         self.run(sql51)
         self.run(sql52, self.callback50)
+
+
+###########################################################################
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_powerline_voltage.test.osm",
+                                         config.dir_tmp + "/tests/osmosis_powerline_voltage.test.xml")
+
+    def test_class3(self):
+        with Analyser_Osmosis_Powerline(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="3", elems=[("node", "4")])
+        self.check_num_err(1)

--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -226,7 +226,6 @@ FROM
             nodes.tags->'power' != 'transformer'
         ) AND
         NOT nodes.tags?'transformer' -- example: power=pole + transformer=*
-        )
 GROUP BY
     nid,
     voltage,

--- a/tests/osmosis_powerline_voltage.test.osm
+++ b/tests/osmosis_powerline_voltage.test.osm
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84322985982' lon='5.87096297419'>
+    <tag k='power' v='transformer' />
+  </node>
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8467261794' lon='5.86359678886'>
+    <tag k='note' v='I am valid' />
+    <tag k='power' v='transformer' />
+  </node>
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84933436795' lon='5.87213078406'>
+    <tag k='note' v='I am valid' />
+    <tag k='power' v='pole' />
+    <tag k='transformer' v='yes' />
+  </node>
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85205338231' lon='5.86377645192'>
+    <tag k='note' v='I am missing a transformer' />
+    <tag k='power' v='pole' />
+  </node>
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85388446269' lon='5.8732087624'>
+    <tag k='power' v='generator' />
+  </node>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='10000' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='2' />
+    <nd ref='3' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='20000' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='3' />
+    <nd ref='4' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='30000' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='5' />
+    <nd ref='4' />
+    <tag k='power' v='line' />
+    <tag k='voltage' v='40000' />
+  </way>
+</osm>


### PR DESCRIPTION
Issue #1329 

Besides power=transformer for a standalone transformer, also power=pole + transformer=* is a valid transformer tagging. See https://wiki.openstreetmap.org/wiki/Tag:power=transformer and https://wiki.openstreetmap.org/wiki/Tag%3Atransformer%3Ddistribution

Fixes i.e. https://www.openstreetmap.org/node/1980809160, https://www.openstreetmap.org/node/3159270648, https://www.openstreetmap.org/node/3269583658 (examples for three different values of transformer=* on pole)

Verified all results on germany_schleswig_holstein, excludes 15 cases of the 74 detected errors. 
(Tested on the dev server, which is many times faster than my local pc, thanks!)