### PR TITLE
Add tag typo exceptions: drain/train, camra/camera

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -95,6 +95,7 @@ FROM
             'fridge', -- vs bridge
             'moved', -- vs moped
             'drain', -- vs train
+            'camra', -- vs camera
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:

--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -94,6 +94,7 @@ FROM
             'draft', -- vs craft
             'fridge', -- vs bridge
             'moved', -- vs moped
+            'drain', -- vs train
             'name_1', 'name_2', 'name_3', 'name_4', 'name_5', 'name_6', 'name_7', 'name_8', 'name_9', -- Tiger mess
 
             -- Regional hiking/cycling/etc. routes. Lesser used ones like 'rhn' for horse riding trigger false positives:


### PR DESCRIPTION
Added two exceptions:
`drain` is only documented in DE/ES/FR/RU wiki's, but that's enough for me. `train` is documented and very common. Fixes #1579
`camra` is rarely used, but still a documented key. `camera` is used and documented for many of it's `camera:*` keys. Fixes #1581


p.s.: I'm not adding the other proposed 'bad' tags of the other issues reported today as they each involve at least 1 non-documented tag and it's thus likely that it's a real typo.