### PR TITLE
Do not warn about lane if condition implies no lane

### DIFF
--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -73,9 +73,9 @@ be tagged on that object instead.'''))
 
         err = []
 
-        if (("parking:condition:right" in tags and not "parking:lane:right" in tags and not "parking:lane:both" in tags) or
-            ("parking:condition:left" in tags and not "parking:lane:left" in tags and not "parking:lane:both" in tags) or
-            ("parking:condition:both" in tags and not "parking:lane:both" in tags and not ("parking:lane:left" in tags and "parking:lane:right" in tags))):
+        if (("parking:condition:right" in tags and tags["parking:condition:right"][0:2] != "no" and not "parking:lane:right" in tags and not "parking:lane:both" in tags) or
+            ("parking:condition:left" in tags and tags["parking:condition:left"][0:2] != "no" and not "parking:lane:left" in tags and not "parking:lane:both" in tags) or
+            ("parking:condition:both" in tags and tags["parking:condition:both"][0:2] != "no" and not "parking:lane:both" in tags and not ("parking:lane:left" in tags and "parking:lane:right" in tags))):
             err.append({"class": 31616})
 
         sides = list(map(lambda tag: tag[len("parking:lane:"):].split(":")[0], filter(lambda tag: tag.startswith("parking:lane:"), tags)))
@@ -132,7 +132,7 @@ class Test(TestPluginCommon):
                   {"highway": "r", "parking:lane:right": "free"},
                   {"highway": "r", "parking:lane:right": "bus_stop"},
                   {"highway": "r", "parking:condition:right": "parallel"},
-                  {"highway": "r", "parking:lane:left": "no", "parking:condition:both": "no"},
+                  {"highway": "r", "parking:lane:left": "perpendicular", "parking:condition:both": "free"},
                   {"highway": "r", "parking:lane:both": "no", "parking:condition:both": "free"},
                   {"highway": "r", "parking:lane:left": "no", "parking:lane:right": "parallel", "parking:condition:both": "free"},
                   {"highway": "r", "parking:lane:both": "separate", "parking:condition:both": "free"},
@@ -153,5 +153,6 @@ class Test(TestPluginCommon):
                   {"highway": "r", "parking:lane:left": "parallel", "parking:condition:left": "free", "parking:lane:right": "separate"},
                   {"highway": "r", "parking:lane:both": "no", "parking:condition:both": "no_stopping"},
                   {"highway": "r", "parking:condition:both": "private", "parking:lane:left": "parallel", "parking:lane:right": "perpendicular"},
+                  {"highway": "r", "parking:condition:both": "no_parking"},
                  ]:
             assert not a.way(None, t, None), t


### PR DESCRIPTION
Fixes #1580, also relates to https://github.com/osm-fr/osmose-backend/issues/1506#issuecomment-1215119751  In case the `parking:condition:side` implies there won't be a lane (e.g. `no_parking`, `no_stopping`, ...), don't force redundant tagging of `parking:lane:side=no`.

Not the most beautiful if-blocks, given their length, but couldn't think of something more simple. Also updated the test case to still have a case for `parking:condition:both` without `parking:lane:both` or (`parking:lane:left + parking:lane:right`)

(How many PR's per week until I'm considered a stalker 🤐)