### PR TITLE
Resolve duplicate warning: transformer on way

### DIFF
--- a/plugins/Power.py
+++ b/plugins/Power.py
@@ -55,27 +55,6 @@ class Power(PluginMapCSS):
 
         return err
 
-    def way(self, data, tags, nds):
-        capture_tags = {}
-        keys = tags.keys()
-        err = []
-
-
-        # way[power=transformer]
-        if ('power' in keys):
-            match = False
-            if not match:
-                capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'power') == mapcss._value_capture(capture_tags, 0, 'transformer')))
-                except mapcss.RuleAbort: pass
-            if match:
-                # -osmoseTags:list("geom")
-                # -osmoseItemClassLevel:"9100/91001/2"
-                # throwWarning:tr("Power Transformers should always be on a node")
-                err.append({'class': 91001, 'subclass': 0, 'text': mapcss.tr('Power Transformers should always be on a node')})
-
-        return err
-
     def relation(self, data, tags, members):
         capture_tags = {}
         keys = tags.keys()

--- a/plugins/Power.validator.mapcss
+++ b/plugins/Power.validator.mapcss
@@ -32,7 +32,6 @@ meta[lang=fr] {
     description: "Transformateurs électriques";
 }
 
-way[power=transformer],
 relation[power=transformer] {
     throwWarning: tr("Power Transformers should always be on a node");
     -osmoseItemClassLevel: "9100/91001/2";

--- a/plugins/Power.validator.mapcss
+++ b/plugins/Power.validator.mapcss
@@ -32,7 +32,7 @@ meta[lang=fr] {
     description: "Transformateurs électriques";
 }
 
-relation[power=transformer] {
+relation[power=transformer] { /* check for ways is in JOSM rules */
     throwWarning: tr("Power Transformers should always be on a node");
     -osmoseItemClassLevel: "9100/91001/2";
     -osmoseTags: list("geom");


### PR DESCRIPTION
https://osmose.openstreetmap.fr/nl/issue/7524de41-d16f-1f94-bd18-d83c8a6790c1 https://osmose.openstreetmap.fr/nl/issue/86f129a2-fe93-9263-080f-9ae6a895712f

First one is from power.validator.mapcss (which this PR removes). Second one is from [JOSM](https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/geometry.mapcss#L102). The rules are practically identical