### PR TITLE
Add major german supermarket brands to UpperCase Validator whitelist

### DIFF
--- a/plugins/Name_UpperCase.py
+++ b/plugins/Name_UpperCase.py
@@ -27,6 +27,7 @@ import regex as re
 UpperCase_WhiteList = {
     "FR": ["CNFPT", "COSEC", "EHPAD", "MACIF", "MEDEF", "URSSAF"],
     "ES": ["FREMAP"],
+    "DE": ["ALDI", "EDEKA", "MARKTKAUF", "PENNY", "REWE"],
 }
 
 class Name_UpperCase(Plugin):


### PR DESCRIPTION
As listed at https://nsi.guide/index.html?t=brands&k=shop&v=supermarket&cc=de