### PR TITLE
Fix list_contains ( key~=val comparison)

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -210,7 +210,7 @@ def string_contains(subject, string):
 
 def list_contains(subject, string):
     if subject is not None and string is not None:
-        return string in subject
+        return string in subject and string in subject.split(";")
 
 def at(asset_lat, asset_lon, lat, lon):
     return asset_lat == lat and asset_lon == lon


### PR DESCRIPTION
The following rules:
```
way[highway][traffic_sign~="NL:C1"][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways][!access][!access:forward][!access:backward][!access:both_ways],
way[highway][traffic_sign~="NL:C01"][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways][!access][!access:forward][!access:backward][!access:both_ways],
way[highway][traffic_sign~="NL:C6"][!motor_vehicle][!motor_vehicle:forward][!motor_vehicle:backward][!motor_vehicle:both_ways][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways][!access][!access:forward][!access:backward][!access:both_ways],
way[highway][traffic_sign~="NL:C06"][!motor_vehicle][!motor_vehicle:forward][!motor_vehicle:backward][!motor_vehicle:both_ways][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways][!access][!access:forward][!access:backward][!access:both_ways],
way[highway][traffic_sign~="NL:C7"][!hgv][!hgv:forward][!hgv:backward][!hgv:both_ways],
way[highway][traffic_sign~="NL:C07"][!hgv][!hgv:forward][!hgv:backward][!hgv:both_ways],
way[highway][traffic_sign~="NL:C9"][!bicycle][!bicycle:forward][!bicycle:backward][!bicycle:both_ways],
way[highway][traffic_sign~="NL:C9"][!moped][!moped:forward][!moped:backward][!moped:both_ways],
way[highway][traffic_sign~="NL:C09"][!bicycle][!bicycle:forward][!bicycle:backward][!bicycle:both_ways],
way[highway][traffic_sign~="NL:C09"][!moped][!moped:forward][!moped:backward][!moped:both_ways],
way[highway][traffic_sign~="NL:C10"][!trailer][!trailer:forward][!trailer:backward][!trailer:both_ways],
way[highway][traffic_sign~="NL:C11"][!motorcycle][!motorcycle:forward][!motorcycle:backward][!motorcycle:both_ways],
way[highway][traffic_sign~="NL:C12"][!motor_vehicle][!motor_vehicle:forward][!motor_vehicle:backward][!motor_vehicle:both_ways][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways][!access][!access:forward][!access:backward][!access:both_ways],
way[highway][traffic_sign~="NL:C13"][!moped][!moped:forward][!moped:backward][!moped:both_ways],
way[highway][traffic_sign~="NL:C14"][!bicycle][!bicycle:forward][!bicycle:backward][!bicycle:both_ways],
way[highway][traffic_sign~="NL:C15"][!bicycle][!bicycle:forward][!bicycle:backward][!bicycle:both_ways],
way[highway][traffic_sign~="NL:C15"][!moped][!moped:forward][!moped:backward][!moped:both_ways],
way[highway][traffic_sign~="NL:C16"][!foot][!foot:forward][!foot:backward][!foot:both_ways][!access][!access:forward][!access:backward][!access:both_ways][!vehicle][!vehicle:forward][!vehicle:backward][!vehicle:both_ways] {
  group: tr("NL traffic signs");
  throwWarning: tr("{0} without {1}=no (or private or destination or ...)", "{1.tag}", "{2.key}");
  assertMatch: "way highway=service traffic_sign=\"NL:C01\"";
  assertMatch: "way highway=service traffic_sign=\"NL:C01;NL:OB58\"";
  assertNoMatch: "way highway=service traffic_sign=\"NL:C01;NL:C16\" access=no";
  assertNoMatch: "way highway=track traffic_sign=\"NL:C12\" motor_vehicle=no";
}
```
trigger `AssertionError: {'class': 1, 'subclass': 1346556208, 'text': {'en': 'traffic_sign=NL:C1 without vehicle=no (or private or destination or ...)'}} Found in the errors list`

This is because Osmose treats the `~=` comparison operator (note: not the same as the regex operator `=~`) as "value-in-string", thereby applying the "NL:C1" rule on "NL:C12" values. The actual interpretation should be "value in ;-separated list". See https://josm.openstreetmap.de/wiki/Help/Styles/MapCSSImplementation

