### PR TITLE
Populate UpperCase validator whitelist with NSI data

### DIFF
--- a/plugins/Name_UpperCase.py
+++ b/plugins/Name_UpperCase.py
@@ -28,7 +28,6 @@ import json
 # Whitelist of allowed capitals by country code
 UpperCase_WhiteList = {
     "FR": ["CNFPT", "COSEC", "EHPAD", "MEDEF", "URSSAF"],
-    "ES": ["FREMAP"],
 }
 
 class Name_UpperCase(Plugin):


### PR DESCRIPTION
This adds support for NSI data also to the UpperCase plugin. The whitelist from NSI data and the whitelist as defined in the plugin are merged and used in the validator.

Follow up to #1607 

Fixes #1428 