### PR TITLE
Check if country exists

### DIFF
--- a/osmose_run.py
+++ b/osmose_run.py
@@ -474,7 +474,12 @@ def main(options):
     # analyser
 
     for country in options.country:
-        country_conf = config.config[country]
+        if country in config.config:
+            country_conf = config.config[country]
+        else:
+            logger.log("Failed to load country {0}".format(country))
+            continue
+
         if os.getenv('SENTRY_DSN'):
             sentry_sdk.set_tag('country', country)
 

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -478,7 +478,7 @@ def main(options):
             country_conf = config.config[country]
         else:
             logger.log("Failed to load country {0}".format(country))
-            return 2
+            return 8
 
         if os.getenv('SENTRY_DSN'):
             sentry_sdk.set_tag('country', country)

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -478,7 +478,7 @@ def main(options):
             country_conf = config.config[country]
         else:
             logger.log("Failed to load country {0}".format(country))
-            continue
+            return 2
 
         if os.getenv('SENTRY_DSN'):
             sentry_sdk.set_tag('country', country)


### PR DESCRIPTION
And provide a human readable error if not (and skip the country)

I accidentally ran Osmose with `--country=aruba` rather than `--country=netherlands_aruba` and got
```
Traceback (most recent call last):
  File "/opt/osmose-backend/./osmose_run.py", line 589, in <module>
    sys.exit(main(options))
  File "/opt/osmose-backend/./osmose_run.py", line 477, in main
    country_conf = config.config[country]
KeyError: 'aruba'
```

I prefer a human readable error instead :)