### PR TITLE
Separate whitelists for similar and equal values

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -76,7 +76,6 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             'communication:mobile_phone',
             'cuisine',
             'operator',
-            'source',
         ))
         self.WhitelistSimilarEqualRegex = set(( # Regexes for keys that can have similar and even equal values
             re.compile('seamark:.+:colour'),

--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -37,7 +37,9 @@ similar.'''),
             fix = T_(
 '''Delete one value.'''),
             trap = T_(
-'''In some case all values maybe required.'''))
+'''In some cases all values may be required.
+
+Ensure the interpretation of the tag does not change when you delete one item.'''))
         self.errors[3060]  = self.def_class(item = 3060, level = 3, tags = ['value', 'fix:chair'],
             title = T_('Duplicated values'),
             **doc)

--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -66,12 +66,17 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             'is_in',
             'service_times', 'collection_times',
             'phone', 'contact:phone', 'fax', 'contact:fax',
+            'email',
             'url',
             'destination',
             'passenger',
             'healthcare:speciality',
-            'traffic_sign',
+            'traffic_sign', 'traffic_sign:forward', 'traffic_sign:backward',
             'sport',
+            'communication:mobile_phone',
+            'cuisine',
+            'operator',
+            'source',
         ))
         self.WhitelistSimilarEqualRegex = set(( # Regexes for keys that can have similar and even equal values
             re.compile('seamark:.+:colour'),
@@ -84,7 +89,9 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             re.compile('turn:lanes.*'),
         ))
         self.WhitelistSimilarRegex = set(( # Regexes for keys that can have similar, but not equal values
+            re.compile('.+_name'),
             re.compile('.+:conditional'),
+            re.compile('.+:date'),
             re.compile('opening_hours(:.+)?'),
             re.compile('(.+:)?wikidata'),
             re.compile('railway:signal:.+'),

--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -152,7 +152,7 @@ Ensure the interpretation of the tag does not change when you delete one item.''
                 for v1,v2 in itertools.combinations(vs_long, 2):
                     if abs(len(v1)-len(v2)) < 4 and self.levenshtein(v1, v2) < 4:
                         err.append({"class": 30601, "subclass": stablehash64(k),
-                                    "text": T_("Duplicated similar values {key}={val}", key = k, val = tags[k])})
+                                    "text": T_("Similar values {v1} and {v2} in {key}={val}", v1 = v1, v2 = v2, key = k, val = tags[k])})
                         break
 
         return err

--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -46,39 +46,47 @@ similar.'''),
             resource = 'https://en.wikipedia.org/wiki/Levenshtein_distance',
             **doc)
 
-        self.BlackList = set((
-            'ref', 'created_by', 'is_in',
+        self.WhitelistSimilarEqual = set(( # Keys that can have similar and even equal values
             'CLC:id', 'GNS:id', 'tmc', 'tiger:cfcc', 'statscan:rbuid', 'nysgissam:nysaddresspointid',
-            'source:geometry:date', 'source:geometry:ref', # Belgium, Flanders
+            'ref',
             'source:date',
-            'service_times', 'collection_times',
-            'phone', 'contact:phone', 'fax', 'contact:fax',
-            'url',
-            'technology', 'cables', 'position', 'passenger', 'couplings:diameters',
-            'healthcare:speciality',
-            'traffic_sign',
-            'sport',
+            'source:geometry:date', # Belgium, Flanders
+            'technology',
+            'cables',
+            'position',
+            'couplings:diameters',
             'voltage',
             'addr:flats', 'addr:housenumber', 'addr:unit', 'addr:floor', 'addr:block', 'addr:door',
         ))
-        self.BlackListRegex = set((
+        self.WhitelistSimilar = set(( # Keys that can have similar, but not equal values
+            'source:geometry:ref', # Belgium, Flanders
+            'created_by',
+            'is_in',
+            'service_times', 'collection_times',
+            'phone', 'contact:phone', 'fax', 'contact:fax',
+            'url',
+            'destination',
+            'passenger',
+            'healthcare:speciality',
+            'traffic_sign',
+            'sport',
+        ))
+        self.WhitelistSimilarEqualRegex = set(( # Regexes for keys that can have similar and even equal values
             re.compile('seamark:.+:colour'),
             re.compile('.+_ref'), re.compile('ref:.+'),
             re.compile('destination:.+'),
-            re.compile('AND_.+'), re.compile('AND:.+'),
+            re.compile('AND_.+'), re.compile('AND:.+'), # Netherlands
             re.compile('[Nn][Hh][Dd]:.+'),
             re.compile('massgis:.+'),
-            re.compile('maxspeed(:.+)?'),
-            re.compile('maxheight(:.+)?'),
-            re.compile('maxwidth(:.+)?'),
-            re.compile('maxweight(:.+)?'),
             re.compile('lacounty:.+'),
-            re.compile('.+:conditional'),
-            re.compile('railway:signal:.+'),
             re.compile('turn:lanes.*'),
+        ))
+        self.WhitelistSimilarRegex = set(( # Regexes for keys that can have similar, but not equal values
+            re.compile('.+:conditional'),
             re.compile('opening_hours(:.+)?'),
             re.compile('(.+:)?wikidata'),
-       ))
+            re.compile('railway:signal:.+'),
+        ))
 
     # http://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Python
     def levenshtein(self, s1, s2):
@@ -99,37 +107,45 @@ similar.'''),
 
         return previous_row[-1]
 
+    def anyRegexMatch(self, set_of_regexes, key):
+        for r in set_of_regexes:
+            if r.match(key):
+                return True
+        return False
+
     def node(self, data, tags):
         err = []
         keys = tags.keys()
+
         for k in keys:
-            if k in self.BlackList:
-                continue
-
-            try:
-                for blr in self.BlackListRegex:
-                    if blr.match(k):
-                        raise Exception
-            except Exception:
-                continue
-
+            if k in self.WhitelistSimilarEqual:
+                continue # Key may have equal or similar values
             v = tags[k]
+            if not ';' in v:
+                continue
+            if self.anyRegexMatch(self.WhitelistSimilarEqualRegex, k):
+                continue # Key may have equal or similar values
             if k == 'source':
                 v = v.replace('Cadastre ; mise', 'Cadastre, mise') # France
                 v = v.replace('GSImaps/ort', 'GSImaps/std') # Japan
-            if ';' in v:
-                vs = list(filter(lambda w: len(w) > 0, map(lambda w: w.strip(), v.split(';'))))
-                if len(vs) != len(set(vs)):
-                    err.append({"class": 3060, "subclass": stablehash64(k),
-                                "text": T_("Duplicated values {key}={val}", key = k, val = tags[k]),
-                                "fix": {k: ";".join(set(vs))} })
-                else:
-                    vs_long = filter(lambda w: len(w) > 6, vs)
-                    for v1,v2 in itertools.combinations(vs_long, 2):
-                        if abs(len(v1)-len(v2)) < 4 and self.levenshtein(v1, v2) < 4:
-                            err.append({"class": 30601, "subclass": stablehash64(k),
-                                        "text": T_("Duplicated similar values {key}={val}", key = k, val = tags[k])})
-                            break
+            vs = list(filter(lambda w: len(w) > 0, map(lambda w: w.strip(), v.split(';'))))
+
+            if len(vs) != len(set(vs)):
+                err.append({"class": 3060, "subclass": stablehash64(k),
+                            "text": T_("Duplicated values {key}={val}", key = k, val = tags[k]),
+                            "fix": {k: ";".join(set(vs))} })
+            else:
+                if k in self.WhitelistSimilar:
+                    continue # Key may have similar values
+                if self.anyRegexMatch(self.WhitelistSimilarRegex, k):
+                    continue # Key may have similar values
+
+                vs_long = filter(lambda w: len(w) > 6, vs)
+                for v1,v2 in itertools.combinations(vs_long, 2):
+                    if abs(len(v1)-len(v2)) < 4 and self.levenshtein(v1, v2) < 4:
+                        err.append({"class": 30601, "subclass": stablehash64(k),
+                                    "text": T_("Duplicated similar values {key}={val}", key = k, val = tags[k])})
+                        break
 
         return err
 
@@ -151,6 +167,8 @@ class Test(TestPluginCommon):
         for t in [{"oneway":"yes;yes"},
                   {"oneway":"yes;yes;no"},
                   {"oneway":"yes;yes;yes;yes;-1;-1;no;no"},
+                  {"passenger":"national;national"},
+                  {"opening_hours": "Mo 14:00-19:00; Tu-Fr 10:00-14:00,15:00-19:00; Mo 14:00-19:00"},
                   {"source":u"cadastre-dgi-fr source : Direction Générale des Impôts - Cadastre ; mise à jour : 2013;cadastre-dgi-fr source : Direction Générale des Impôts - Cadastre ; mise à jour : 2013"},
                   {"source":u"cadastre-dgi-fr source : Direction Générale des Impôts - Cadastre ; mise à jour : 2010;cadastre-dgi-fr source : Direction Générale des Impôts - Cadastre ; mise à jour : 2013"},
                   {"source":"GSImaps/ort;GSImaps/std"},
@@ -164,6 +182,7 @@ class Test(TestPluginCommon):
                   {"ref:mhs":"IA00070520; IA00070492"},
                   {"opening_hours": "Mo 14:00-19:00; Tu-Fr 10:00-14:00,15:00-19:00; Sa 10:00-19:00"},
                   {"oneway":"yes;no"},
+                  {"passenger":"national;international;regional"},
                   {"AND_toto":"121;121;121"},
                   {"NHD:ComID":"141725410;141725411"},
                   {"massgis:OS_ID":"305-735;305-764"},


### PR DESCRIPTION
Currently, there is one whitelist list for both similar values and equal values. 
Therefore, if you want to whitelist a key that can have similar values (such as `opening_hours`), you also whitelist exact duplicates.

In this PR:
- Use separate whitelists for keys that can have equal+similar values, and keys that can only have similar, but not equal values
- Adds a couple new exceptions for keys that can be similar, yet not duplicates (`destination`, `email`, `traffic_sign:[direction]`, `communication:mobile_phone`, `cuisine`, `operator`, `*:date` (like: `survey:date`), `*_name` (like `old_name`, `artist_name`, ...))
- removes the exceptions for `max*` (as to my understanding, those were added for `max*:conditional`, which later got its generic whitelist)
- Gets rid of the 'interesting' try...raise...except approach :). (Note I didn't use `any(map(...))` because `map` would first execute all regexes; however I can use that if desired)
- fixes a typo in the doc

P.s. I kept `ref` in "equal AND similar are allowed", because there's a test case `{"ref":"E 05; E 70; E 05;E 70; E 05;E 70; E 05;E 70; E 05;E 70"},`. I'm however not sure if duplicate values are truly valid?