### PR TITLE
log -> err

### DIFF
--- a/osmose_run.py
+++ b/osmose_run.py
@@ -430,7 +430,7 @@ def main(options):
         logger = OsmoseLog.logger(output, True)
 
     if options.change_init and not options.change:
-        logger.err(logger.log_av_b+"--change must be specified "+logger.log_ap)
+        logger.err("--change must be specified")
         return 1
 
     #=====================================
@@ -461,11 +461,11 @@ def main(options):
         count = 0
         for k in options.analyser:
             if k not in analysers:
-                logger.err(logger.log_av_b+"not found "+k+logger.log_ap)
+                logger.err("not found "+k)
                 count += 1
         # user is passing only non-existent analysers
         if len(options.analyser) == count:
-            logger.err(logger.log_av_b+"No valid analysers specified"+logger.log_ap)
+            logger.err("No valid analysers specified")
             return 1
 
     sys.path[:] = old_path # restore previous path

--- a/osmose_run.py
+++ b/osmose_run.py
@@ -430,7 +430,7 @@ def main(options):
         logger = OsmoseLog.logger(output, True)
 
     if options.change_init and not options.change:
-        logger.log(logger.log_av_b+"--change must be specified "+logger.log_ap)
+        logger.err(logger.log_av_b+"--change must be specified "+logger.log_ap)
         return 1
 
     #=====================================
@@ -456,16 +456,16 @@ def main(options):
                 analysers[fn[9:-3]] = importlib.import_module("analysers." + fn[:-3])
             except ImportError as e:
                 logger.log(e)
-                logger.log("Fails to load analysers {0}".format(fn[:-3]))
+                logger.err("Fails to load analysers {0}".format(fn[:-3]))
     if options.analyser:
         count = 0
         for k in options.analyser:
             if k not in analysers:
-                logger.log(logger.log_av_b+"not found "+k+logger.log_ap)
+                logger.err(logger.log_av_b+"not found "+k+logger.log_ap)
                 count += 1
         # user is passing only non-existent analysers
         if len(options.analyser) == count:
-            logger.log(logger.log_av_b+"No valid analysers specified"+logger.log_ap)
+            logger.err(logger.log_av_b+"No valid analysers specified"+logger.log_ap)
             return 1
 
     sys.path[:] = old_path # restore previous path
@@ -477,7 +477,7 @@ def main(options):
         if country in config.config:
             country_conf = config.config[country]
         else:
-            logger.log("Failed to load country {0}".format(country))
+            logger.err("Failed to load country {0}".format(country))
             return 8
 
         if os.getenv('SENTRY_DSN'):


### PR DESCRIPTION
As requested in https://github.com/osm-fr/osmose-backend/pull/1619#issuecomment-1296353313 by @jocelynj 

Now I replaced `logger.log` by `logger.err` for all errors. However, please let me know if you'd like me to either remove the blue color and/or restore `logger.log` for the ones with blue color. Using `logger.err` prefixes the word `error: ` to the output in red, so it looks kind-of funny at the moment when the text after it is blue.
Some examples in the picture below:
![image](https://user-images.githubusercontent.com/1315520/199093706-50b7ef55-ffa3-4979-bd5c-1eb2c811cb6e.png)

From a practical point of view, I find red easier to read than blue, but that's just a preference I guess.
