### PR TITLE
Update KOpeningHours to v22.08.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium >= 3.1.3
-git+https://invent.kde.org/libraries/kopeninghours.git@v21.12.3
+git+https://invent.kde.org/libraries/kopeninghours.git@v22.08.3
 git+https://github.com/jocelynj/PyEasyArchive.git
 protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geojson
 vt2geojson


### PR DESCRIPTION
Fixes #1568
(https://bugs.kde.org/show_bug.cgi?id=445787)