### PR TITLE
Improve power lines analyser about lines terminations 

### DIFF
--- a/analysers/analyser_osmosis_powerline.py
+++ b/analysers/analyser_osmosis_powerline.py
@@ -99,7 +99,7 @@ FROM
         line_ends.id = nodes.id AND
         NOT (tags?'location:transition' AND tags->'location:transition' = 'yes') AND
         NOT (tags?'transformer' AND tags->'transformer' in ('distribution', 'main')) AND
-        NOT (tags?'substation' AND tags->'substation' in ('minor_distribution')) AND
+        NOT (tags?'substation' AND tags->'substation' = 'minor_distribution') AND
         NOT (tags?'line_management' AND tags->'line_management' = 'termination') AND
         NOT (tags?'power' AND tags->'power' = 'terminal')
 """


### PR DESCRIPTION
Recent power proposals introduced line_management=* and transformer=main for substations supported by power poles.
Current roll out cause false positives on Osmose, like such https://osmose.openstreetmap.fr/fr/issue/f64f3096-a46e-eb8d-7931-38bc9cce76da

Furthermore, older false negatives have to be addressed with a lower threshold about terminators proximity. I propose to change 150m seek distance by 50m.
Such nodes should get line_management=termination to be valid
https://www.openstreetmap.org/node/1365158230

Lone power supports can also be portal, terminal or insulator.

It is expected to improve actual Osmose's alert count on 7040 classes 1, 6 and 7
Particularly in France, where recent surge is caused by transformer=main roll out.
https://osmose.openstreetmap.fr/fr/issues/graph.png?item=7040&class=6&country=france*