### PR TITLE
Remove unneeded whitelists

### DIFF
--- a/analysers/analyser_osmosis_tag_typo.py
+++ b/analysers/analyser_osmosis_tag_typo.py
@@ -58,12 +58,7 @@ FROM
             'linz', -- vs line (New Zealand)
             'traces', -- vs tracks (Hungary)
             -- Documented keys without their own key:* wiki page. Between () where it's documented
-            'dist', -- vs dirt, list, diet (golf=hole)
-            'hide', -- vs site, sides, side (amenity=hunting_stand)
-            'levels', -- vs level (building:levels)
-            'linen', -- vs line, lines (shop=bed)
-            'path', -- vs bath (highway=path)
-            'lwn_ref', -- vs XYn_ref (Node_Networks)
+            'levels', -- vs level (listed as deprecated on building:levels)
             -- Undocumented keys, not found in Wiki
             'clock', -- vs lock
             'hall', -- vs wall


### PR DESCRIPTION
Credits to @Marc-marc-marc for creating the wiki pages of these 5 keys https://github.com/osm-fr/osmose-backend/pull/1616#issuecomment-1297305341

As the 30 day cache period is expiring today, it should now be safe to remove the whitelists, as they're in the TagInfo file
(Also clarified the `levels` comment)