### PR TITLE
Only run analyser on real vehicle roads

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -66,7 +66,14 @@ SELECT
         WHEN 'track' THEN 5
         WHEN 'cycleway' THEN 5
         WHEN 'service' THEN 5
+        WHEN 'busway' THEN 5
+        WHEN 'bus_guideway' THEN 5
         WHEN 'road' THEN 5
+        WHEN 'pedestrian' THEN 6
+        WHEN 'footway' THEN 6
+        WHEN 'bridleway' THEN 6
+        WHEN 'steps' THEN 6
+        WHEN 'path' THEN 6
         ELSE NULL
     END AS level
 FROM

--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -97,6 +97,7 @@ FROM (
       highways
     WHERE
       NOT highways.is_construction AND
+      highways.level IS NOT NULL AND
       highway != 'motorway' AND -- Ignore motorway even with oneway tag
       (
         is_oneway OR

--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -101,7 +101,7 @@ FROM
 WHERE
   NOT highways.is_construction AND
   (NOT tags?'golf' OR tags->'golf' != 'cartpath') AND
-  highways.level IS NOT NULL AND
+  highways.level <= 5 AND
   islands.linestring IS NULL
 """
 


### PR DESCRIPTION
Suggestions for a more generic fix (rather than just blacklisting raceway) #1667

Add level tags for all common roads in highway table generation
- Adds missing busway/bus_guideway to level=5
- Add level=6 for paths and the like
- Modify floating_islands to require level<=5, so the behavior of the analyser doesn't change by the addition of level=6

Require the level tag to exist for the deadend analyser, i.e. only if it's a real road, the analyser will run (so no longer on raceway)

Still to be tested