### PR TITLE
Exclude highway=raceway from highway_deadend

### DIFF
--- a/tests/osmosis_highway_deadend.osm
+++ b/tests/osmosis_highway_deadend.osm
@@ -259,7 +259,7 @@
     <nd ref='62' />
     <nd ref='56' />
     <tag k='highway' v='motorway' />
-		<tag k='name' v='Class 3 good, class 2 bad' />
+    <tag k='name' v='Class 3 good, class 2 bad' />
   </way>
   <way id='1025' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='57' />
@@ -273,7 +273,7 @@
     <nd ref='61' />
     <nd ref='60' />
     <tag k='highway' v='primary' />
-		<tag k='name' v='Class 3 good, class 2 bad' />
+    <tag k='name' v='Class 3 good, class 2 bad' />
   </way>
   <way id='1027' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='61' />
@@ -330,14 +330,14 @@
     <tag k='name' v='Class 5 good' />
     <tag k='service' v='drive-through' />
   </way>
-	<way id='1034' timestamp='2014-03-31T22:00:00Z' version='1'>
+  <way id='1034' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='21' />
     <nd ref='22' />
     <nd ref='23' />
     <tag k='highway' v='residential' />
     <tag k='junction' v='roundabout' />
   </way>
-	<way id='1035' timestamp='2014-03-31T22:00:00Z' version='1'>
+  <way id='1035' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='56' />
     <nd ref='60' />
     <tag k='highway' v='tertiary' />

--- a/tests/osmosis_highway_deadend.osm
+++ b/tests/osmosis_highway_deadend.osm
@@ -1,0 +1,345 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85303753624' lon='5.83317659938' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85303060034' lon='5.83387279372' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85267125081' lon='5.83316873145' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85266535486' lon='5.83384248673' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85238078584' lon='5.83383595991' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85265960937' lon='5.83449904934' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85237504031' lon='5.83449252252' />
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85238668182' lon='5.83316220462' />
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85194511875' lon='5.83309799679' />
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85193706375' lon='5.83383585474' />
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85214279626' lon='5.83385033584' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85182373739' lon='5.83382787796' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85201082689' lon='5.83384104678' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85200407009' lon='5.83423493549' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85142845598' lon='5.83365985887' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85161935502' lon='5.83365482122' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85119173072' lon='5.83367021559' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85140097166' lon='5.83332969006' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85141048813' lon='5.83402250383' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85086370949' lon='5.83337479614' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85065446605' lon='5.83371532167' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85087322606' lon='5.8340676099' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85108209545' lon='5.8336999273' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85252335404' lon='5.83778650268' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85238966285' lon='5.83751239555' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85222651766' lon='5.83772094838' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85236020934' lon='5.8379950555' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85262048277' lon='5.8377205388' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85246971615' lon='5.83767652879' />
+  <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85245305553' lon='5.83764236951' />
+  <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8522996348' lon='5.83762748089' />
+  <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85259013862' lon='5.83760604472' />
+  <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85263004378' lon='5.83775661424' />
+  <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85257629003' lon='5.83755379149' />
+  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85190412296' lon='5.83699448043' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85190987335' lon='5.83803868895' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85190708745' lon='5.8375327992' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85179543917' lon='5.83753441063' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85179259322' lon='5.83701761816' />
+  <node id='40' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85179827425' lon='5.83804922877' />
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8516948206' lon='5.83753586286' />
+  <node id='42' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85169197464' lon='5.83701907039' />
+  <node id='43' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85169765568' lon='5.838050681' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85190523597' lon='5.83719659092' />
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85202834802' lon='5.83720779483'>
+    <tag k='amenity' v='parking_entrance' />
+  </node>
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85199886804' lon='5.83779450981'>
+    <tag k='amenity' v='parking_entrance' />
+  </node>
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85190851309' lon='5.83779168031' />
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85140551839' lon='5.83723489134' />
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85124429748' lon='5.83750954664' />
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85135207753' lon='5.83709550542' />
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85147692823' lon='5.83742114471' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8512974308' lon='5.83752711217' />
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85123591854' lon='5.83757485072' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85128921157' lon='5.83759242703' />
+  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85103301305' lon='5.83692145683' />
+  <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85103301305' lon='5.838128568' />
+  <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85103301305' lon='5.8371572646' />
+  <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85087001185' lon='5.83737622895' />
+  <node id='59' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85087001185' lon='5.83695795089' />
+  <node id='60' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85087001185' lon='5.83813418247' />
+  <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85087001185' lon='5.83761765118' />
+  <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85103301305' lon='5.83784784447' />
+  <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85342247358' lon='5.83319906287' />
+  <node id='64' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85187279705' lon='5.83383133115' />
+  <node id='65' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85186194549' lon='5.83451380738' />
+  <node id='66' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85204140432' lon='5.83450929137' />
+  <node id='67' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85180219459' lon='5.83451531098' />
+  <node id='68' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85180370991' lon='5.83467313256' />
+  <node id='69' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85204291964' lon='5.83466711295' />
+  <node id='70' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8554997203' lon='5.8268996101' />
+  <node id='71' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85498648886' lon='5.8268996101' />
+  <node id='72' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85511478686' lon='5.8268996101' />
+  <node id='73' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85511478686' lon='5.82760705023' />
+  <node id='74' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85526487205' lon='5.82689962612' />
+  <node id='75' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85526279044' lon='5.8274690169' />
+  <node id='76' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85536163427' lon='5.82746996412' />
+  <node id='77' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85536371943' lon='5.82689960204' />
+  <node id='78' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8552634216' lon='5.82729637275' />
+  <node id='79' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85536226544' lon='5.82729731998' />
+  <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1002' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='4' />
+    <nd ref='6' />
+    <nd ref='7' />
+    <nd ref='5' />
+    <nd ref='8' />
+    <nd ref='3' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1003' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='9' />
+    <nd ref='10' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1004' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='11' />
+    <nd ref='13' />
+    <nd ref='10' />
+    <nd ref='64' />
+    <nd ref='12' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='1005' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='13' />
+    <nd ref='14' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='-1' />
+  </way>
+  <way id='1006' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='15' />
+    <nd ref='17' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1007' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='15' />
+    <nd ref='16' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1008' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='18' />
+    <nd ref='17' />
+    <nd ref='19' />
+    <nd ref='16' />
+    <nd ref='18' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='1009' action='modify' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='23' />
+    <nd ref='20' />
+    <nd ref='21' />
+    <tag k='highway' v='residential' />
+    <tag k='junction' v='roundabout' />
+  </way>
+  <way id='1010' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='24' />
+    <nd ref='29' />
+    <nd ref='30' />
+    <nd ref='25' />
+    <nd ref='31' />
+    <nd ref='26' />
+    <nd ref='27' />
+    <nd ref='24' />
+    <tag k='highway' v='raceway' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1011' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='24' />
+    <nd ref='28' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1012' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='30' />
+    <nd ref='31' />
+    <tag k='highway' v='raceway' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1013' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='32' />
+    <nd ref='29' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1014' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='33' />
+    <nd ref='28' />
+    <nd ref='32' />
+    <nd ref='34' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='no' />
+  </way>
+  <way id='1015' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='35' />
+    <nd ref='44' />
+    <nd ref='37' />
+    <nd ref='47' />
+    <nd ref='36' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='1016' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='37' />
+    <nd ref='38' />
+    <nd ref='41' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1017' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='39' />
+    <nd ref='38' />
+    <nd ref='40' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='1018' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='39' />
+    <nd ref='42' />
+    <nd ref='41' />
+    <nd ref='43' />
+    <nd ref='40' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1019' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='44' />
+    <nd ref='45' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1020' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='46' />
+    <nd ref='47' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1021' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='48' />
+    <nd ref='49' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1022' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='50' />
+    <nd ref='48' />
+    <nd ref='51' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='1023' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='52' />
+    <nd ref='49' />
+    <nd ref='53' />
+    <nd ref='54' />
+    <nd ref='52' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='1024' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='55' />
+    <nd ref='57' />
+    <nd ref='62' />
+    <nd ref='56' />
+    <tag k='highway' v='motorway' />
+		<tag k='name' v='Class 3 good, class 2 bad' />
+  </way>
+  <way id='1025' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='57' />
+    <nd ref='58' />
+    <tag k='highway' v='motorway_link' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1026' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='59' />
+    <nd ref='58' />
+    <nd ref='61' />
+    <nd ref='60' />
+    <tag k='highway' v='primary' />
+		<tag k='name' v='Class 3 good, class 2 bad' />
+  </way>
+  <way id='1027' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='61' />
+    <nd ref='62' />
+    <tag k='highway' v='motorway_link' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1028' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='65' />
+    <nd ref='64' />
+    <tag k='highway' v='service' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1029' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='66' />
+    <nd ref='65' />
+    <nd ref='67' />
+    <nd ref='68' />
+    <nd ref='69' />
+    <nd ref='66' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='1030' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='70' />
+    <nd ref='77' />
+    <nd ref='74' />
+    <nd ref='72' />
+    <nd ref='71' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='1031' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='72' />
+    <nd ref='73' />
+    <tag k='highway' v='service' />
+    <tag k='name' v='Class 5 bad' />
+    <tag k='service' v='drive-through' />
+  </way>
+  <way id='1032' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='74' />
+    <nd ref='78' />
+    <nd ref='75' />
+    <nd ref='76' />
+    <nd ref='79' />
+    <nd ref='77' />
+    <tag k='highway' v='service' />
+    <tag k='name' v='Class 5 good' />
+    <tag k='oneway' v='yes' />
+    <tag k='service' v='drive-through' />
+  </way>
+  <way id='1033' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='78' />
+    <nd ref='79' />
+    <tag k='highway' v='service' />
+    <tag k='name' v='Class 5 good' />
+    <tag k='service' v='drive-through' />
+  </way>
+	<way id='1034' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='21' />
+    <nd ref='22' />
+    <nd ref='23' />
+    <tag k='highway' v='residential' />
+    <tag k='junction' v='roundabout' />
+  </way>
+	<way id='1035' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='56' />
+    <nd ref='60' />
+    <tag k='highway' v='tertiary' />
+  </way>
+</osm>


### PR DESCRIPTION
- Exclude `highway=raceway` from the osmosis_highway_deadend analyser as it is usually a closed circuit highway area (with one-directional traffic)
- Adds test case for several common cases (to reduce the chance of regressions when 1670 is dealt with. Note that it obviously doesn't contain the test case of 1670 as otherwise the tests would fail continuously)

See #1667

p.s. the reason for adding line 145 is because there are some raceways connected with service roads. If I just exclude raceways altogether, those service roads are suddenly considered "floating" and pop up as error. (This is part of the test cases)