### PR TITLE
Accept airport terminals as endpoint

### DIFF
--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -35,13 +35,12 @@ WHERE
   tags != ''::hstore AND
   (
     -- Cycle only
-    (tags?'railway' AND tags->'railway' = 'platform') OR
     (tags?'public_transport' AND tags->'public_transport' = 'platform') OR
     (tags?'highway' AND tags->'highway' = 'pedestrian') OR
     -- Commons
     (tags?'route' AND tags->'route' = 'ferry') OR
     (tags?'man_made' AND tags->'man_made' = 'pier') OR
-    (tags?'aeroway' AND tags->'aeroway' IN ('taxiway', 'runway', 'apron')) OR
+    (tags?'aeroway' AND tags->'aeroway' IN ('taxiway', 'runway', 'apron', 'terminal')) OR
     (tags?'railway' AND tags->'railway' = 'platform') OR
     (tags?'highway' AND tags->'highway' IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link'))
   )


### PR DESCRIPTION
Typically airports don't allow direct access to the airplanes, so I would propose to accept terminal too as the end node. https://github.com/osm-fr/osmose-backend/issues/1678#issuecomment-1342788906

Also remove duplicate railway=platform