### PR TITLE
Treat extract-border-crossing ways as connected

### DIFF
--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -124,8 +124,6 @@ class Analyser_Osmosis_Highway_Floating_Islands(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        if not "proj" in self.config.options:
-          return
         self.classs[4] = self.def_class(item = 1210, level = 1, tags = ['highway'],
             title = T_('Small highway group apart from the main network or with insufficient access upstream'),
             detail = T_(

--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -137,11 +137,11 @@ class Analyser_Osmosis_Highway_Floating_Islands(Analyser_Osmosis):
         self.callback10 = lambda res: {"class":4, "subclass":1, "data":[self.way_full, self.positionAsText]}
 
     def analyser_osmosis_common(self):
-        boundary_relation = self.config.polygon_id
+        boundary_relation = self.config.polygon_id # Either a number, None or (number, number, ...)
         if isinstance(boundary_relation, int):
-          boundary_relation = "('{0}')".format(boundary_relation)
-        else:
-          boundary_relation = str(set(map(str, boundary_relation)))
+          boundary_relation = "({0})".format(boundary_relation)
+        elif not boundary_relation:
+          boundary_relation = "(0)"
 
         self.run(sql10.format(boundary_ids=boundary_relation))
         self.run(sql11)

--- a/analysers/analyser_osmosis_highway_floating_islands.py
+++ b/analysers/analyser_osmosis_highway_floating_islands.py
@@ -44,6 +44,20 @@ WHERE
     (tags?'railway' AND tags->'railway' = 'platform') OR
     (tags?'highway' AND tags->'highway' IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link'))
   )
+UNION
+SELECT
+  -- highways crossing borders of extracts without reaching a main road within the extract
+  borderways.linestring,
+  borderways.id
+FROM
+  relation_members AS boundary_members
+  JOIN ways AS boundary_ways ON
+    boundary_members.member_id = boundary_ways.id
+  JOIN highways AS borderways ON
+    ST_Intersects(boundary_ways.linestring, borderways.linestring)
+WHERE
+  boundary_members.member_type = 'W' AND
+  boundary_members.relation_id IN {boundary_ids}
 """
 
 sql11 = """
@@ -110,6 +124,8 @@ class Analyser_Osmosis_Highway_Floating_Islands(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+          return
         self.classs[4] = self.def_class(item = 1210, level = 1, tags = ['highway'],
             title = T_('Small highway group apart from the main network or with insufficient access upstream'),
             detail = T_(
@@ -121,7 +137,13 @@ class Analyser_Osmosis_Highway_Floating_Islands(Analyser_Osmosis):
         self.callback10 = lambda res: {"class":4, "subclass":1, "data":[self.way_full, self.positionAsText]}
 
     def analyser_osmosis_common(self):
-        self.run(sql10)
+        boundary_relation = self.config.polygon_id
+        if isinstance(boundary_relation, int):
+          boundary_relation = "('{0}')".format(boundary_relation)
+        else:
+          boundary_relation = str(set(map(str, boundary_relation)))
+
+        self.run(sql10.format(boundary_ids=boundary_relation))
         self.run(sql11)
         self.run(sqlb13)
         self.run(sqlb14)


### PR DESCRIPTION
See #1679

If a road crosses an extract border, consider it connected (i.e. not a floating island)
For the case of #1679 (switzerland_appenzell_innerrhoden), only three ways remain (instead of the many false positives) :
way 378042935
way 418198089
way 753588065