### PR TITLE
Add analyser to detect cyclic relations

### DIFF
--- a/analysers/analyser_osmosis_relation_cyclic.py
+++ b/analysers/analyser_osmosis_relation_cyclic.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose Project 2022                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Osmosis import Analyser_Osmosis
+
+sql10 = """
+WITH RECURSIVE rcte AS (
+  -- initial 'seed' relation
+  SELECT DISTINCT ON (relation_id)
+    relation_id AS start_id,
+    member_id,
+    1 as nloops,
+    CONCAT('r', relation_id) AS path
+  FROM
+    relation_members
+  WHERE
+    member_type = 'R' AND
+    relation_locate(relation_id) IS NOT NULL -- can't display relations without way/node members
+
+  UNION ALL
+
+  -- loop children until no 'relation'-type members or relation back to start
+  SELECT
+    rcte.start_id,
+    child.member_id,
+    nloops + 1 AS nloops,
+    CONCAT(rcte.path, ' > r', child.relation_id) AS path
+  FROM
+    rcte
+    JOIN relation_members AS child ON
+      child.relation_id = rcte.member_id
+    WHERE
+      child.member_type = 'R' AND
+      child.relation_id != rcte.start_id AND
+      nloops < {maxloops} -- avoid getting stuck in strange constructions
+)
+SELECT DISTINCT ON (start_id)
+  start_id,
+  ST_AsText(relation_locate(start_id)),
+  path
+FROM
+  rcte
+WHERE
+  start_id = member_id AND
+  nloops < {maxloops}
+ORDER BY
+  start_id,
+  LENGTH(path) -- to get the shortest path selected by the DISTINCT ON call
+"""
+
+class Analyser_Osmosis_Relation_Cyclic(Analyser_Osmosis):
+
+    def __init__(self, config, logger = None):
+        Analyser_Osmosis.__init__(self, config, logger)
+        self.classs[2] = self.def_class(item = 1160, level = 2, tags = ['relation', 'fix:chair'],
+            title = T_('Cyclic relation'),
+            detail = T_(
+'''A relation whose members (eventually) refer back to itself is rarely correct.'''))
+
+    def analyser_osmosis_common(self):
+        self.run(sql10.format(maxloops=10), lambda res: {
+            "class": 2,
+            "data": [self.relation, self.positionAsText],
+            "text": {"en": res[2] + " > r" + str(res[0])}
+        })
+
+
+
+###########################################################################
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_relation_cyclic.osm",
+                                         config.dir_tmp + "/tests/osmosis_relation_cyclic.test.xml", {})
+
+    def test_classes(self):
+        with Analyser_Osmosis_Relation_Cyclic(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="2", elems=[("relation", "10005")])
+        self.check_err(cl="2", elems=[("relation", "10006")])
+        self.check_err(cl="2", elems=[("relation", "10007")])
+        self.check_err(cl="2", elems=[("relation", "10008")])
+        self.check_err(cl="2", elems=[("relation", "10009")])
+        self.check_err(cl="2", elems=[("relation", "10010")])
+        self.check_err(cl="2", elems=[("relation", "10011")])
+        self.check_err(cl="2", elems=[("relation", "10012")])
+        self.check_num_err(8)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -147,6 +147,7 @@ class default_simple(template_config):
         self.analyser["osmosis_orphan_nodes_cluster"] = "xxx"
         self.analyser["osmosis_powerline"] = "xxx"
         self.analyser["osmosis_double_tagging"] = "xxx"
+        self.analyser["osmosis_relation_cyclic"] = "xxx"
         self.analyser["osmosis_relation_associatedStreet"] = "xxx"
         self.analyser["osmosis_highway_link"] = "xxx"
         self.analyser["osmosis_highway_broken_level_continuity"] = "xxx"

--- a/tests/osmosis_relation_cyclic.osm
+++ b/tests/osmosis_relation_cyclic.osm
@@ -1,0 +1,126 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83216791492' lon='5.84570362807' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83044698127' lon='5.84750025864' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83111315693' lon='5.84947655227' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83089964362' lon='5.8476057774' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83077473584' lon='5.84792018775' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83110782248' lon='5.84814476657' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83198216319' lon='5.84500066308'>
+    <tag k='highway' v='bus_stop' />
+  </node>
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83080249315' lon='5.85000877079'>
+    <tag k='highway' v='bus_stop' />
+  </node>
+  <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='2' />
+    <nd ref='3' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='4' />
+    <tag k='building' v='house' />
+  </way>
+  <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='from' />
+    <member type='node' ref='2' role='via' />
+    <member type='way' ref='101' role='to' />
+    <tag k='restriction' v='no_left_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+  <relation id='10001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='street' />
+    <member type='way' ref='101' role='street' />
+    <member type='way' ref='102' role='house' />
+    <tag k='name' v='Mystreet' />
+    <tag k='type' v='associatedStreet' />
+  </relation>
+  <relation id='10002' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='node' ref='7' role='platform' />
+    <member type='node' ref='8' role='platform' />
+    <member type='way' ref='100' role='' />
+    <member type='way' ref='101' role='' />
+    <tag k='name' v='Bus to destination' />
+    <tag k='public_transport:version' v='2' />
+    <tag k='route' v='bus' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='10003' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='relation' ref='10002' role='' />
+    <tag k='name' v='Bus to destination' />
+    <tag k='route_master' v='bus' />
+    <tag k='type' v='route_master' />
+  </relation>
+  <relation id='10004' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='relation' ref='10003' role='' />
+    <tag k='network' v='Bus network MyTown' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10005' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='way' ref='101' role='' />
+    <member type='relation' ref='10006' role='' />
+    <member type='relation' ref='10003' role='' />
+    <tag k='name' v='Bad relation simple 1' />
+    <tag k='public_transport:version' v='2' />
+    <tag k='route' v='monorail' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='10006' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='101' role='' />
+    <member type='way' ref='100' role='' />
+    <member type='relation' ref='10005' role='' />
+    <tag k='name' v='Bad relation simple 2' />
+    <tag k='public_transport:version' v='2' />
+    <tag k='route' v='monorail' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='10007' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='way' ref='101' role='' />
+		<member type='relation' ref='10008' role='' />
+		<member type='relation' ref='10009' role='' />
+    <tag k='name' v='Bad complicated 1' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10008' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='way' ref='101' role='' />
+    <member type='relation' ref='10007' role='' />
+    <tag k='name' v='Bad complicated 2' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10009' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='way' ref='101' role='' />
+    <member type='relation' ref='10007' role='' />
+    <tag k='name' v='Bad complicated 3' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10010' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='relation' ref='10011' role='' />
+    <tag k='name' v='Bad Triple 1' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10011' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+		<member type='relation' ref='10012' role='' />
+    <tag k='name' v='Bad Triple 2' />
+    <tag k='type' v='network' />
+  </relation>
+  <relation id='10012' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='100' role='' />
+    <member type='relation' ref='10010' role='' />
+    <tag k='name' v='Bad Triple 3' />
+    <tag k='type' v='network' />
+  </relation>
+</osm>


### PR DESCRIPTION
New analyser which detects self-referring relations, either directly (`r1 > r2 > r1`) or via other relations (`r1 > r2 > r3 > r1`).
Restricted to 10 referrals (but can be increased if needed) to avoid potential infinite loops, and limited to relations which have a location (otherwise you'll just get a NULL location).

It doesn't return many results (as self-referring relations are pretty rare; JOSM also doesn't allow adding them) but in nearly all cases it finishes within a second.
[Some test results attached](https://github.com/osm-fr/osmose-backend/files/10254834/cyclic.zip)

#1635