### PR TITLE
Add missing `

### DIFF
--- a/analysers/analyser_merge_milestone_FR_metropole.py
+++ b/analysers/analyser_merge_milestone_FR_metropole.py
@@ -30,7 +30,8 @@ class Analyser_Merge_Milestone_FR_metropole(Analyser_Merge_Point):
             detail = T_(
 '''The list of milestone comes from the CEREMA's database "RIU" in France.'''),
             trap = T_(
-'''Those milestones can't be on way * _link. The position of the marker may be a little different than what is visible on the road. Sometimes, a small white line perpendicular to the road on the emergency stop strip or the left flared strip can be seen on satellite images or Mapillary's photos.'''))
+'''Those milestones can't be on `*_link` ways. The position of the marker may be a little different than what is visible on the road.
+Sometimes, a small white line perpendicular to the road on the emergency stop strip or the left flared strip can be seen on satellite images or Mapillary's photos.'''))
 
         self.def_class_missing_official(item = 8430, id = 41, level = 3, tags = ['merge', 'highway', 'fix:picture', 'fix:survey'],
             title = T_('Milestone not integrated'), **doc)

--- a/analysers/analyser_osmosis_boundary_administrative.py
+++ b/analysers/analyser_osmosis_boundary_administrative.py
@@ -143,10 +143,10 @@ class Analyser_Osmosis_Boundary_Administrative(Analyser_Osmosis):
         self.classs_change[3] = self.def_class(item = 6060, level = 2, tags = ['boundary', 'geom', 'fix:chair'],
             title = T_('Lone boundary fragment'),
             detail = T_(
-'''Unconnected boundary fragment, a way with a boundary tag not part of a
-boundary relation.'''),
+'''Unconnected boundary fragment, a way with a `boundary` tag not part of a
+`boundary` relation.'''),
             fix = T_(
-'''Delete the way, remove boundary tag or add to a relation.'''))
+'''Delete the way, remove the `boundary` tag or add the way to a relation.'''))
 
         self.callback40 = lambda res: {"class":2, "subclass": stablehash64(res[2]), "data":[self.relation_full, self.relation_full, self.positionAsText]}
         self.callback50 = lambda res: {"class":3, "data":[self.way_full, self.positionAsText]}

--- a/analysers/analyser_osmosis_indoor.py
+++ b/analysers/analyser_osmosis_indoor.py
@@ -192,11 +192,11 @@ class Analyser_Osmosis_Indoor(Analyser_Osmosis):
         self.classs[1] = self.def_class(item = 1300, level = 3, tags = ['indoor', 'geom', 'fix:survey'],
             title = T_('This indoor room should have a door'),
             fix = T_(
-'''Find out where are the entrances of the room and add them (with a door=* tag) so we can actually enter this indoor room.'''))
+'''Find out where the entrances of the room are and add them (with a `door=*` tag) so we can actually enter this indoor room.'''))
         self.classs[2] = self.def_class(item = 1300, level = 3, tags = ['indoor', 'geom', 'fix:survey'],
             title = T_('This indoor feature is not reachable'),
             detail = T_(
-'''Each indoor feature should be connected to an another indoor feature or to some footpath so people can actually go to them.'''))
+'''Each indoor feature should be connected to another indoor feature or to some footpath so people can actually go to them.'''))
 
         self.callback10 = lambda res: {"class": 1, "data": [self.way_full, self.positionAsText]}
         self.callback20 = lambda res: {"class": 2, "data": [self.way_full, self.positionAsText]}

--- a/analysers/analyser_osmosis_relation_enforcement.py
+++ b/analysers/analyser_osmosis_relation_enforcement.py
@@ -57,7 +57,7 @@ class Analyser_Osmosis_Relation_Enforcement(Analyser_Osmosis):
         Analyser_Osmosis.__init__(self, config, logger)
         self.classs[1] = self.def_class(item = 1280, level = 3, tags = ['highway', 'fix:chair'],
             title = T_('Disconnected speed camera'),
-            fix = T_('Speed camera should be mapped as a node on the highway or use an enforcement relation.'))
+            fix = T_('Speed camera should be mapped as a node on the highway or use an `enforcement` relation.'))
 
     def analyser_osmosis_common(self):
         self.run(sql00, lambda res: {"class":1, "data":[self.node_full, self.positionAsText]})

--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -268,7 +268,7 @@ and `trunk`.'''),
             example = T_(
 '''![](https://wiki.openstreetmap.org/w/images/3/3a/Osmose-eg-error-3010.png)
 
-Highway level should be secondary.'''))
+Highway level should be `secondary`.'''))
         self.classs[2] = self.def_class(item = 2030, level = 2, tags = ['highway', 'roundabout', 'fix:chair'],
             title = T_('Missing oneway'),
             detail = T_(


### PR DESCRIPTION
Adds `` around text that directly refers to a tag/key/value.
Only did it for `detail/trap/fix` messages, given that `title` messages aren't formatted and there it would thus be of less effect.
(If you would want it on `title` too, especially analyser_osmosis_relation_public_transport and analyser_osmosis_highway_traffic_signal need an update)

@jocelynj Perhaps you can re-run your script of yesterday on these too to update the .po files? :)

#1333