### PR TITLE
Ignore `dvalue_nolink=1`, require exact matches

### DIFF
--- a/plugins/TagFix_Deprecated.py
+++ b/plugins/TagFix_Deprecated.py
@@ -75,12 +75,11 @@ class TagFix_Deprecated(Plugin):
 
                 k, v = param.split('=', 1)
                 # k will always start with the param because we removed whitespace around | earlier
-                # We don't use == because there could be space before the = character
-                if (k.startswith('dkey')):
+                if (k.rstrip() == 'dkey'):
                     src_key = v
-                elif (k.startswith('dvalue')):
+                elif (k.rstrip() == 'dvalue'):
                     src_val = v
-                elif (k.startswith('suggestion')):
+                elif (k.rstrip() == 'suggestion'):
                     dest = v
 
             # Sanity check in case formatting changes or something


### PR DESCRIPTION
The entry for `highway=incline_steep` is now:
```
{{Deprecated features/item|lang={{{lang|}}}|date=2008-06-12
|dkey=highway|dvalue=incline_steep|dvalue_nolink=1
|suggestion={{Tag|incline}}
|3}}
```
(See: [wiki edit history](https://wiki.openstreetmap.org/w/index.php?title=Template%3ADeprecated_features&type=revision&diff=2456444&oldid=2455457) )
Hence I suspect the assertionErrors originate from `dvalue_nolink` being used instead of `dvalue`.

