### PR TITLE
Warn about farmland/farmyard mixup

### DIFF
--- a/analysers/analyser_osmosis_building_in_polygon.py
+++ b/analysers/analyser_osmosis_building_in_polygon.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose Project 2023                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Osmosis import Analyser_Osmosis
+
+sql10 = """
+SELECT
+  ways.id,
+  buildings.id,
+  -- Use the building location to point out the error, even though the landuse should be changed
+  ST_AsText(way_locate(buildings.linestring)),
+  buildings.tags->'building'
+FROM
+  buildings
+  JOIN ways ON
+    ways.is_polygon AND
+    ways.tags != ''::hstore AND
+    ways.tags?'landuse' AND
+    ways.tags->'landuse' = 'farmland' AND
+    ST_Contains(ST_Transform(ST_MakePolygon(ways.linestring), {proj}), buildings.polygon_proj)
+WHERE
+  -- ignore e.g. small utility buildings that happen to be on the farmland or are fully surrounded by farmland
+  buildings.area > 36 AND
+  (NOT buildings.tags?'location' OR buildings.tags->'location' != 'underground') AND
+  buildings.tags->'building' != 'greenhouse' -- unsure whether allowed or not, lets permit
+"""
+
+
+class Analyser_Osmosis_Building_In_Polygon(Analyser_Osmosis):
+
+    def __init__(self, config, logger = None):
+        Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
+
+        self.classs[1] = self.def_class(item = 1310, level = 3, tags = ['landuse', 'fix:chair'],
+            title = T_('Building on agricultural land'),
+            detail = T_(
+'''Buildings of a farm (houses, sheds, stables, barns, ...) are usually located on the farmyard,
+not on the farmland where the crops grow.'''),
+            fix = T_(
+'''Change or split the landuse way such that the farm buildings are on an area with `landuse=farmyard`
+and the area where crops grow are within `landuse=farmland`.'''))
+
+    requires_tables_common = ['buildings']
+
+    def analyser_osmosis_common(self):
+        self.run(sql10.format(proj=self.config.options["proj"]), lambda res: {
+            "class": 1,
+            "data": [self.way_full, self.way, self.positionAsText],
+            "text": T_("`{0}` inside `{1}`", "building=" + res[3], 'landuse=farmland')
+        })
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_building_in_polygon.osm",
+                                         config.dir_tmp + "/tests/osmosis_building_in_polygon.test.xml",
+                                         {"proj": 23032})
+
+    def test_classes(self):
+        with Analyser_Osmosis_Building_In_Polygon(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="1", elems=[("way", "100"), ("way", "101")])
+        self.check_num_err(1)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -159,6 +159,7 @@ class default_simple(template_config):
         self.analyser["osmosis_node_like_way"] = "xxx"
         self.analyser["osmosis_boundary_administrative"] = "xxx"
         self.analyser["osmosis_tag_typo"] = "xxx"
+        self.analyser["osmosis_building_in_polygon"] = "xxx"
         self.analyser["osmosis_cycleway_track"] = "xxx"
         self.analyser["osmosis_highway_features"] = "xxx"
         self.analyser["osmosis_building_shapes"] = "xxx"

--- a/tests/osmosis_building_in_polygon.osm
+++ b/tests/osmosis_building_in_polygon.osm
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85224298904' lon='5.83779408421' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85168093805' lon='5.83777845818' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85166804789' lon='5.83899361924' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85223009903' lon='5.83900924528' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85208946427' lon='5.83797330682' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85186414962' lon='5.83801416069' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85188746687' lon='5.83835120281' />
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85211278141' lon='5.83831034894' />
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85233291317' lon='5.83787681481' />
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85224004611' lon='5.83787571028' />
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85223953646' lon='5.83798801918' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85233240352' lon='5.83798912371' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8522372582' lon='5.83780505157' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8522356869' lon='5.83780502734' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85223564768' lon='5.83781169476' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85223721898' lon='5.83781171898' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85232824638' lon='5.83801693599' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227362937' lon='5.83801632619' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227335578' lon='5.83808054832' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8523279728' lon='5.83808115812' />
+  <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='1' />
+    <tag k='landuse' v='farmland' />
+  </way>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='7' />
+    <nd ref='8' />
+    <nd ref='5' />
+    <tag k='building' v='barn' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='9' />
+    <nd ref='10' />
+    <nd ref='11' />
+    <nd ref='12' />
+    <nd ref='9' />
+    <tag k='building' v='house' />
+    <tag k='note' v='Lets not trigger on minor overlap' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='13' />
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='16' />
+    <nd ref='13' />
+    <tag k='building' v='yes' />
+    <tag k='note' v='Tiny mini building, e.g. keeping a shovel, or a utility cabinet' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='17' />
+    <nd ref='18' />
+    <nd ref='19' />
+    <nd ref='20' />
+    <nd ref='17' />
+    <tag k='building' v='stable' />
+  </way>
+</osm>


### PR DESCRIPTION
Finds farmlands with significant buildings inside itself, which are very likely farmyards instead. This way, many bigger bad farmlands are still found even if the polygon_small analyser (https://github.com/osm-fr/osmose-backend/pull/1718) has a low treshold

Depending on which description belongs to the group of 3100, the item (and class) may have to be changed to that number.
I named it building_in_polygon so its easy to add more similar checks to the same file; can rename it to building_in_farmland if desired though.