### PR TITLE
Clarify that parking:* is bad, parking:both:* is good

### DIFF
--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -95,8 +95,8 @@ be tagged on that object instead.'''),
 '''Use `parking:left`, `parking:right` or `parking:both`.'''),
             resource = "https://wiki.openstreetmap.org/wiki/Street_parking",
             example = T_(
-'''To specify that you can only park for 2 hours in the street, you should use
-`parking:both:maxstay=2 hours`, and not `parking:maxstay=2 hours`.'''))
+'''To specify that you can only park for 2 hours in the street (on both sides),
+you should use `parking:both:maxstay=2 hours`, and not `parking:maxstay=2 hours`.'''))
         self.errors[31622] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:survey'],
             title = T_('parking:[side]:* without parking:[side] value'),
             detail = T_(

--- a/plugins/Highway_Parking_Lane.py
+++ b/plugins/Highway_Parking_Lane.py
@@ -93,7 +93,10 @@ be tagged on that object instead.'''),
 '''The side was not recognized, expected was either `left`, `right` or `both`.'''),
             fix = T_(
 '''Use `parking:left`, `parking:right` or `parking:both`.'''),
-            resource = "https://wiki.openstreetmap.org/wiki/Street_parking")
+            resource = "https://wiki.openstreetmap.org/wiki/Street_parking",
+            example = T_(
+'''To specify that you can only park for 2 hours in the street, you should use
+`parking:both:maxstay=2 hours`, and not `parking:maxstay=2 hours`.'''))
         self.errors[31622] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking', 'fix:survey'],
             title = T_('parking:[side]:* without parking:[side] value'),
             detail = T_(


### PR DESCRIPTION
Due to the large number of (incorrect) false positive entries (although all in one country, so maybe not too many different users), I added an example that `:both` is a must in the parking tagging scheme. 
http://osmose.openstreetmap.fr/en/issues/false-positive?item=3161&class=31621,31622,31623,31624,31625,31626,31627,31628,31629