### PR TITLE
mapcss parsing: string with int comparison triggers RuleAbort

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -121,17 +121,19 @@ class str_value_(str):
         if self.none:
             return False
         elif o.__class__ == int:
-            return self.to_n() == o
-        else:
-            return super(str_value_, self).__eq__(o)
+            try:
+                return self.to_n() == o
+            except RuleAbort: pass # Couldn't convert to numeric
+        return super(str_value_, self).__eq__(o)
 
     def __ne__(self, o):
         if self.none:
             return True
         elif o.__class__ == int:
-            return self.to_n() != o
-        else:
-            return super(str_value_, self).__ne__(o)
+            try:
+                return self.to_n() != o
+            except RuleAbort: pass # Couldn't convert to numeric
+        return super(str_value_, self).__ne__(o)
 
     def __gt__(self, o):
         if self.none:

--- a/mapcss/update.py
+++ b/mapcss/update.py
@@ -26,6 +26,12 @@ def main(mapcsss):
                 print(traceback.format_exc())
                 print(e)
 
+    # Regenerate all local files too
+    files = list(Path('plugins').rglob('*.mapcss'))
+    for file in files:
+        importlib.reload(mapcss2osmose)
+        print(file)
+        mapcss2osmose.mapcss2osmose(mapcss = file, output_path = str(file.parent))
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/plugins/Josm_DutchSpecific.py
+++ b/plugins/Josm_DutchSpecific.py
@@ -65,7 +65,6 @@ class Josm_DutchSpecific(PluginMapCSS):
         self.re_33af5199 = re.compile(r'^motorcycle(:backward|:both_ways)?(:conditional)?$')
         self.re_33fbfa8d = re.compile(r'(?i)post\W?nl$')
         self.re_345ec50a = re.compile(r'^maxweight(:forward|:backward|:both_ways)?(:conditional)?$')
-        self.re_367126ed = re.compile(r'^(yes|1)$')
         self.re_3894ceb2 = re.compile(r'^oneway:')
         self.re_389e57a2 = re.compile(r'(^|;)NL:C18\b')
         self.re_39064d44 = re.compile(r'^(motorway(_link)?|trunk(_link)?|cycleway|service|busway|construction|proposed|raceway)$')
@@ -73,11 +72,13 @@ class Josm_DutchSpecific(PluginMapCSS):
         self.re_3bd9d067 = re.compile(r'^(yes|-?1)$')
         self.re_3c163648 = re.compile(r'(?i)ball?(veld(je)?)?$')
         self.re_3cd0133e = re.compile(r'^access(:forward|:backward|:both_ways)?(:conditional)?$')
+        self.re_42dce20e = re.compile(r'^(no|0)*$')
         self.re_44720f99 = re.compile(r'(?i)^roltrap(pen)?$')
         self.re_460900e8 = re.compile(r'^maxspeed:advisory(:backward|:both_ways)?(:conditional)?$')
         self.re_467ce1ba = re.compile(r'(?i)(parkeren|parkeerplaats|parkeergarage|^garage)$')
         self.re_47aaa0f7 = re.compile(r'^(yes|designated)$')
         self.re_4cfe628c = re.compile(r'^access(:forward|:both_ways)?(:conditional)?$')
+        self.re_4d17a717 = re.compile(r'^(no|-1|0)*$')
         self.re_4d87e9ab = re.compile(r'^access(:backward|:both_ways)?(:conditional)?$')
         self.re_4e099629 = re.compile(r'^trailer(:forward|:both_ways)?(:conditional)?$')
         self.re_4e4468f8 = re.compile(r'^foot(:backward|:both_ways)?(:conditional)?$')
@@ -1161,47 +1162,47 @@ class Josm_DutchSpecific(PluginMapCSS):
                 # assertMatch:"way highway=residential traffic_sign=NL:C21[2.1]"
                 err.append({'class': 5, 'subclass': 1126640278, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
-        # way[highway][traffic_sign~="NL:C2"][oneway!=yes][/^oneway:/!~/^(yes|-?1)$/][oneway!=-1][highway!=construction]
-        # way[highway][traffic_sign~="NL:C02"][oneway!=yes][/^oneway:/!~/^(yes|-?1)$/][oneway!=-1][highway!=construction]
-        # way[highway][traffic_sign~="NL:C3"][oneway!=yes][/^oneway:/!~/^(yes|-?1)$/][oneway!=-1][highway!=construction]
-        # way[highway][traffic_sign~="NL:C03"][oneway!=yes][/^oneway:/!~/^(yes|-?1)$/][oneway!=-1][highway!=construction]
-        # way[highway][traffic_sign:forward~="NL:C3"][oneway!=yes][/^oneway:/!~/^(yes|1)$/][highway!=construction][traffic_sign:backward!~/\bNL:C0?2\b/]
-        # way[highway][traffic_sign:forward~="NL:C03"][oneway!=yes][/^oneway:/!~/^(yes|1)$/][highway!=construction][traffic_sign:backward!~/\bNL:C0?2\b/]
-        # way[highway][traffic_sign:backward~="NL:C2"][oneway!=yes][/^oneway:/!~/^(yes|1)$/][highway!=construction]
-        # way[highway][traffic_sign:backward~="NL:C02"][oneway!=yes][/^oneway:/!~/^(yes|1)$/][highway!=construction]
+        # way[highway][traffic_sign~="NL:C2"][oneway!=yes][regexp_test("^(no|0)*$",join_list("",tag_regex("^oneway:")))][oneway!=-1][highway!=construction]
+        # way[highway][traffic_sign~="NL:C02"][oneway!=yes][regexp_test("^(no|0)*$",join_list("",tag_regex("^oneway:")))][oneway!=-1][highway!=construction]
+        # way[highway][traffic_sign~="NL:C3"][oneway!=yes][regexp_test("^(no|0)*$",join_list("",tag_regex("^oneway:")))][oneway!=-1][highway!=construction]
+        # way[highway][traffic_sign~="NL:C03"][oneway!=yes][regexp_test("^(no|0)*$",join_list("",tag_regex("^oneway:")))][oneway!=-1][highway!=construction]
+        # way[highway][traffic_sign:forward~="NL:C3"][oneway!=yes][regexp_test("^(no|-1|0)*$",join_list("",tag_regex("^oneway:")))][highway!=construction][traffic_sign:backward!~/\bNL:C0?2\b/]
+        # way[highway][traffic_sign:forward~="NL:C03"][oneway!=yes][regexp_test("^(no|-1|0)*$",join_list("",tag_regex("^oneway:")))][highway!=construction][traffic_sign:backward!~/\bNL:C0?2\b/]
+        # way[highway][traffic_sign:backward~="NL:C2"][oneway!=yes][regexp_test("^(no|-1|0)*$",join_list("",tag_regex("^oneway:")))][highway!=construction]
+        # way[highway][traffic_sign:backward~="NL:C02"][oneway!=yes][regexp_test("^(no|-1|0)*$",join_list("",tag_regex("^oneway:")))][highway!=construction]
         if ('highway' in keys and 'traffic_sign' in keys) or ('highway' in keys and 'traffic_sign:backward' in keys) or ('highway' in keys and 'traffic_sign:forward' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C2'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_3bd9d067, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C2'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_42dce20e, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C02'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_3bd9d067, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C02'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_42dce20e, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C3'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_3bd9d067, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C3'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_42dce20e, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C03'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_3bd9d067, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign'), mapcss._value_capture(capture_tags, 1, 'NL:C03'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_42dce20e, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'oneway') != mapcss._value_capture(capture_tags, 4, -1)) and (mapcss._tag_capture(capture_tags, 5, tags, 'highway') != mapcss._value_const_capture(capture_tags, 5, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:forward'), mapcss._value_capture(capture_tags, 1, 'NL:C3'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_367126ed, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 5, self.re_1d478f9e, '\bNL:C0?2\b'), mapcss._tag_capture(capture_tags, 5, tags, 'traffic_sign:backward'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:forward'), mapcss._value_capture(capture_tags, 1, 'NL:C3'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_4d17a717, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 5, self.re_1d478f9e, '\bNL:C0?2\b'), mapcss._tag_capture(capture_tags, 5, tags, 'traffic_sign:backward'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:forward'), mapcss._value_capture(capture_tags, 1, 'NL:C03'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_367126ed, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 5, self.re_1d478f9e, '\bNL:C0?2\b'), mapcss._tag_capture(capture_tags, 5, tags, 'traffic_sign:backward'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:forward'), mapcss._value_capture(capture_tags, 1, 'NL:C03'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_4d17a717, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 5, self.re_1d478f9e, '\bNL:C0?2\b'), mapcss._tag_capture(capture_tags, 5, tags, 'traffic_sign:backward'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:backward'), mapcss._value_capture(capture_tags, 1, 'NL:C2'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_367126ed, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:backward'), mapcss._value_capture(capture_tags, 1, 'NL:C2'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_4d17a717, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:backward'), mapcss._value_capture(capture_tags, 1, 'NL:C02'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (not mapcss.regexp_test(self.re_367126ed, mapcss._match_regex(tags, self.re_3894ceb2))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss.list_contains(mapcss._tag_capture(capture_tags, 1, tags, 'traffic_sign:backward'), mapcss._value_capture(capture_tags, 1, 'NL:C02'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'oneway') != mapcss._value_const_capture(capture_tags, 2, 'yes', 'yes')) and (mapcss.regexp_test(self.re_4d17a717, mapcss.join_list('', mapcss.tag_regex(tags, self.re_3894ceb2)))) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'construction', 'construction')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("NL traffic signs")
@@ -1209,10 +1210,12 @@ class Josm_DutchSpecific(PluginMapCSS):
                 # assertMatch:"way highway=residential traffic_sign:backward=\"NL:C02;NL:OB58\""
                 # assertNoMatch:"way highway=residential traffic_sign:backward=\"NL:C2\" oneway:motor_vehicle=yes"
                 # assertNoMatch:"way highway=residential traffic_sign:backward=\"NL:C2\" oneway=yes oneway:bicycle=no"
+                # assertMatch:"way highway=residential traffic_sign:forward=\"NL:C3\" oneway:motor_vehicle=-1"
                 # assertNoMatch:"way highway=residential traffic_sign:forward=\"NL:C3\" oneway:motor_vehicle=yes"
                 # assertMatch:"way highway=residential traffic_sign:forward=\"NL:C3\" oneway=-1"
                 # assertNoMatch:"way highway=residential traffic_sign:forward=\"NL:C3\" oneway=yes"
                 # assertMatch:"way highway=residential traffic_sign:forward=\"NL:C3\""
+                # assertMatch:"way highway=residential traffic_sign=\"NL:C02\" oneway:bicycle=no oneway=no"
                 # assertMatch:"way highway=residential traffic_sign=\"NL:C02\""
                 # assertNoMatch:"way highway=residential traffic_sign=\"NL:C02;NL:OB58\" oneway=-1"
                 # assertNoMatch:"way highway=residential traffic_sign=\"NL:C02;NL:OB58\" oneway=yes"
@@ -1220,7 +1223,7 @@ class Josm_DutchSpecific(PluginMapCSS):
                 # assertNoMatch:"way highway=residential traffic_sign=\"NL:C3\" oneway:motor_vehicle=-1"
                 # assertNoMatch:"way highway=residential traffic_sign=\"NL:C3\" oneway:motor_vehicle=yes"
                 # assertMatch:"way highway=residential traffic_sign=\"NL:C3;NL:OB58\""
-                err.append({'class': 5, 'subclass': 1059189470, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
+                err.append({'class': 5, 'subclass': 2031953960, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
 
         # way[highway][traffic_sign~="NL:C5"][oneway?][highway!=construction]
         # way[highway][traffic_sign~="NL:C05"][oneway?][highway!=construction]
@@ -2686,20 +2689,22 @@ class Test(TestPluginMapcss):
         self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign:forward': 'NL:C21[2.1]'}, [0]), expected={'class': 5, 'subclass': 1126640278})
         self.check_not_err(n.way(data, {'highway': 'residential', 'maxweight': '2.1', 'traffic_sign': 'NL:C21[2.1]'}, [0]), expected={'class': 5, 'subclass': 1126640278})
         self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C21[2.1]'}, [0]), expected={'class': 5, 'subclass': 1126640278})
-        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign:backward': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign:backward': 'NL:C2'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'oneway:bicycle': 'no', 'traffic_sign:backward': 'NL:C2'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_err(n.way(data, {'highway': 'residential', 'oneway': '-1', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C02'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': '-1', 'traffic_sign': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'traffic_sign': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'no', 'oneway:agricultural': 'no', 'oneway:motor_vehicle': 'yes', 'oneway:motorcycle': 'no', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': '-1', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 1059189470})
-        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C3;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 1059189470})
+        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign:backward': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign:backward': 'NL:C2'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'oneway:bicycle': 'no', 'traffic_sign:backward': 'NL:C2'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': '-1', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'oneway': '-1', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign:forward': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'oneway': 'no', 'oneway:bicycle': 'no', 'traffic_sign': 'NL:C02'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C02'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': '-1', 'traffic_sign': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'traffic_sign': 'NL:C02;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'no', 'oneway:agricultural': 'no', 'oneway:motor_vehicle': 'yes', 'oneway:motorcycle': 'no', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': '-1', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_not_err(n.way(data, {'highway': 'residential', 'oneway:motor_vehicle': 'yes', 'traffic_sign': 'NL:C3'}, [0]), expected={'class': 5, 'subclass': 2031953960})
+        self.check_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C3;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 2031953960})
         self.check_err(n.way(data, {'highway': 'residential', 'oneway': 'yes', 'traffic_sign': 'NL:C05'}, [0]), expected={'class': 5, 'subclass': 560436831})
         self.check_not_err(n.way(data, {'highway': 'residential', 'traffic_sign': 'NL:C05'}, [0]), expected={'class': 5, 'subclass': 560436831})
         self.check_not_err(n.way(data, {'highway': 'residential', 'oneway': 'no', 'traffic_sign': 'NL:C5;NL:OB58'}, [0]), expected={'class': 5, 'subclass': 560436831})

--- a/plugins/tests/test_mapcss_parsing_evalutation.py
+++ b/plugins/tests/test_mapcss_parsing_evalutation.py
@@ -1,0 +1,553 @@
+#-*- coding: utf-8 -*-
+import modules.mapcss_lib as mapcss
+import regex as re # noqa
+
+from plugins.Plugin import with_options # noqa
+from plugins.PluginMapCSS import PluginMapCSS
+
+
+class test_mapcss_parsing_evalutation(PluginMapCSS):
+
+
+
+    def init(self, logger):
+        super().init(logger)
+        tags = capture_tags = {} # noqa
+        self.errors[1] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1740'})
+        self.errors[2] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #994 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[3] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #328 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.key}')))
+        self.errors[4] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd'})
+        self.errors[5] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #327'))
+        self.errors[6] = self.def_class(item = 0, level = 2, tags = [], title = {'en': 'test'})
+        self.errors[7] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
+        self.errors[8] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[9] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
+        self.errors[10] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
+        self.errors[11] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
+        self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
+        self.errors[40301] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
+
+        self.re_3d3faeb5 = re.compile(r'(?i).*Straße.*')
+        self.re_49048f80 = re.compile(r'd')
+        self.re_4961c1fa = re.compile(r'abc')
+        self.re_75974701 = re.compile(r'^(parking|motorcycle_parking)$')
+        self.re_7f42aaa6 = re.compile(r'def')
+
+
+    def node(self, data, tags):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # node[x=0]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x') == mapcss._value_capture(capture_tags, 0, 0)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:survey")
+                # -osmoseItemClassLevel:"4030/40301:0/2"
+                # throwWarning:"test #1740"
+                # assertMatch:"node x=0"
+                # assertNoMatch:"node x=1"
+                # assertNoMatch:"node x=1.0"
+                # assertNoMatch:"node x=Osmose"
+                err.append({'class': 40301, 'subclass': 0, 'text': {'en': 'test #1740'}})
+
+        # node[x!=0]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x') != mapcss._value_capture(capture_tags, 0, 0)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test #1740"
+                # assertNoMatch:"node x=0"
+                # assertMatch:"node x=1"
+                # assertMatch:"node x=1.0"
+                # assertMatch:"node x=Osmose"
+                err.append({'class': 1, 'subclass': 659546685, 'text': {'en': 'test #1740'}})
+
+        # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
+        if ('parking' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'parking')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_75974701, '^(parking|motorcycle_parking)$'), mapcss._tag_capture(capture_tags, 1, tags, 'amenity'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #994 - {0}{1}","{0.key}","{1.tag}")
+                # assertMatch:"node parking=yes amenity=osmose"
+                # assertNoMatch:"node parking=yes amenity=parking"
+                err.append({'class': 2, 'subclass': 650362898, 'text': mapcss.tr('test #994 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # *[a][!c]
+        # *[b][!/d/]
+        if ('a' in keys) or ('b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'c')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'b')) and (not mapcss._tag_capture(capture_tags, 1, tags, self.re_49048f80)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #328 - {0}{1}","{0.key}","{1.key}")
+                err.append({'class': 3, 'subclass': 1004069731, 'text': mapcss.tr('test #328 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        # *[/abc/=~/def/]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(self.re_7f42aaa6, mapcss._match_regex(tags, self.re_4961c1fa))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd"
+                err.append({'class': 4, 'subclass': 1371556921, 'text': {'en': 'test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd'}})
+
+        # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
+        if ('addr:street' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_3d3faeb5), mapcss._tag_capture(capture_tags, 0, tags, 'addr:street'))) and (mapcss.inside(self.father.config.options, 'LI,CH')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #327")
+                # -osmoseAssertNoMatchWithContext:list("node addr:street=Neuestraßebahn","inside=FR")
+                # -osmoseAssertMatchWithContext:list("node addr:street=Neuestraßebahn","inside=LI")
+                err.append({'class': 5, 'subclass': 43561107, 'text': mapcss.tr('test #327')})
+
+        # *[a][a=*b]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'a') == mapcss._value_capture(capture_tags, 1, mapcss.tag(tags, 'b'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:"test"
+                # assertMatch:"node a=x b=x"
+                # assertNoMatch:"node a=x b=y"
+                # assertNoMatch:"node a=x"
+                err.append({'class': 6, 'subclass': 1343056298, 'text': {'en': 'test'}})
+
+        # node[lit][eval(number_of_tags())=1]
+        if ('lit' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'lit')) and (len(tags) == 1))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertNoMatch:"node abc=def lit=yes"
+                # assertMatch:"node lit=yes"
+                err.append({'class': 6, 'subclass': 130427469, 'text': {'en': 'test'}})
+
+        # node[lit][number_of_tags()==1]
+        if ('lit' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'lit')) and (len(tags) == 1))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertNoMatch:"node abc=def lit=yes"
+                # assertMatch:"node lit=yes"
+                err.append({'class': 6, 'subclass': 612979508, 'text': {'en': 'test'}})
+
+        return err
+
+    def way(self, data, tags, nds):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # way[x~=C1]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.list_contains(mapcss._tag_capture(capture_tags, 0, tags, 'x'), mapcss._value_capture(capture_tags, 0, 'C1'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test #1610"
+                # assertMatch:"way x=C00;C1;C22"
+                # assertMatch:"way x=C1"
+                # assertNoMatch:"way x=C12"
+                err.append({'class': 7, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
+
+        # way:righthandtraffic[x=y][z?]
+        if ('x' in keys and 'z' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 1, tags, 'x') == mapcss._value_capture(capture_tags, 1, 'y')) and (mapcss._tag_capture(capture_tags, 2, tags, 'z') in ('yes', 'true', '1')) and (mapcss.setting(self.father.config.options, 'driving_side') != 'left'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #1603 - {0}{1}","{1.tag}","{2.tag}")
+                # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
+                err.append({'class': 8, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
+
+        # way[x=y][z?]:righthandtraffic
+        if ('x' in keys and 'z' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x') == mapcss._value_capture(capture_tags, 0, 'y')) and (mapcss._tag_capture(capture_tags, 1, tags, 'z') in ('yes', 'true', '1')) and (mapcss.setting(self.father.config.options, 'driving_side') != 'left'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #1603 - {0}{1}","{0.tag}","{1.tag}")
+                # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
+                err.append({'class': 8, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
+        if ('parking' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'parking')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_75974701, '^(parking|motorcycle_parking)$'), mapcss._tag_capture(capture_tags, 1, tags, 'amenity'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #994 - {0}{1}","{0.key}","{1.tag}")
+                err.append({'class': 2, 'subclass': 650362898, 'text': mapcss.tr('test #994 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # *[a][!c]
+        # *[b][!/d/]
+        if ('a' in keys) or ('b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'c')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'b')) and (not mapcss._tag_capture(capture_tags, 1, tags, self.re_49048f80)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #328 - {0}{1}","{0.key}","{1.key}")
+                # assertNoMatch:"way a=b c=d"
+                # assertMatch:"way a=b"
+                # assertNoMatch:"way b=a d=c"
+                # assertMatch:"way b=c"
+                err.append({'class': 3, 'subclass': 1004069731, 'text': mapcss.tr('test #328 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        # *[/abc/=~/def/]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(self.re_7f42aaa6, mapcss._match_regex(tags, self.re_4961c1fa))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd"
+                err.append({'class': 4, 'subclass': 1371556921, 'text': {'en': 'test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd'}})
+
+        # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
+        if ('addr:street' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_3d3faeb5), mapcss._tag_capture(capture_tags, 0, tags, 'addr:street'))) and (mapcss.inside(self.father.config.options, 'LI,CH')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #327")
+                err.append({'class': 5, 'subclass': 43561107, 'text': mapcss.tr('test #327')})
+
+        # way:righthandtraffic
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.setting(self.father.config.options, 'driving_side') != 'left'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test righthandtraffic")
+                # -osmoseAssertNoMatchWithContext:list("way","driving_side=left")
+                # -osmoseAssertMatchWithContext:list("way","driving_side=right")
+                err.append({'class': 9, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
+
+        # way!:righthandtraffic
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.setting(self.father.config.options, 'driving_side') == 'left'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test lefthandtraffic")
+                # -osmoseAssertMatchWithContext:list("way","driving_side=left")
+                # -osmoseAssertNoMatchWithContext:list("way","driving_side=right")
+                err.append({'class': 10, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
+
+        # way[count(uniq_list(tag_regex("abc")))==2]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.count(mapcss.uniq_list(mapcss.tag_regex(tags, self.re_4961c1fa))) == 2))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertNoMatch:"way abc=def abcdef=def"
+                # assertMatch:"way abc=def abcdef=ghi abcd=ghi"
+                # assertMatch:"way abc=def abcdef=ghi"
+                # assertNoMatch:"way abc=def def=def"
+                err.append({'class': 6, 'subclass': 346020981, 'text': {'en': 'test'}})
+
+        # way[count(uniq_list(tag_regex("abc")))==2.0]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.count(mapcss.uniq_list(mapcss.tag_regex(tags, self.re_4961c1fa))) == 2.0))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertNoMatch:"way abc=def abcdef=def"
+                # assertMatch:"way abc=def abcdef=ghi abcd=ghi"
+                # assertMatch:"way abc=def abcdef=ghi"
+                # assertNoMatch:"way abc=def def=def"
+                err.append({'class': 6, 'subclass': 57938147, 'text': {'en': 'test'}})
+
+        # way[oneway?]
+        if ('oneway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'oneway') in ('yes', 'true', '1')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test {0}","{0.tag}")
+                # assertMatch:"way oneway=1"
+                # assertNoMatch:"way oneway=4.0"
+                # assertNoMatch:"way oneway=no"
+                # assertMatch:"way oneway=yes"
+                # assertNoMatch:"way x=y"
+                err.append({'class': 11, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # way[oneway?!]
+        if ('oneway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'oneway') not in ('yes', 'true', '1')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test {0}","{0.tag}")
+                # assertMatch:"way oneway=0"
+                # assertMatch:"way oneway=no"
+                # assertNoMatch:"way oneway=yes"
+                # assertNoMatch:"way x=y"
+                err.append({'class': 11, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
+        if ('amenity' in keys and 'building' in keys and 'name' in keys and 'x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.string_contains(mapcss._tag_capture(capture_tags, 0, tags, 'name'), mapcss._value_capture(capture_tags, 0, 'Trigger'))) and (mapcss._tag_capture(capture_tags, 1, tags, 'building') == mapcss._value_capture(capture_tags, 1, 'chapel') and mapcss._tag_capture(capture_tags, 2, tags, 'amenity') == mapcss._value_capture(capture_tags, 2, 'place_of_worship')) and (mapcss._tag_capture(capture_tags, 4, tags, 'x')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #1303 {0}","{2.key}")
+                # assertMatch:"way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes"
+                # assertNoMatch:"way amenity=place_of_worship building=chapel name=Westminster x=yes"
+                # assertNoMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
+                # assertNoMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
+                err.append({'class': 12, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # *[a][a=*b]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'a') == mapcss._value_capture(capture_tags, 1, mapcss.tag(tags, 'b'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:"test"
+                err.append({'class': 6, 'subclass': 1343056298, 'text': {'en': 'test'}})
+
+        # way[maxspeed>5000]
+        if ('maxspeed' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'maxspeed') > mapcss._value_capture(capture_tags, 0, 5000)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test {0}{1}","text","{0.key}")
+                # assertMatch:"way maxspeed=10000"
+                # assertNoMatch:"way maxspeed=5000"
+                # assertNoMatch:"way maxspeed=default"
+                # assertNoMatch:"way"
+                err.append({'class': 13, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+
+        return err
+
+    def relation(self, data, tags, members):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
+        if ('parking' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'parking')) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_75974701, '^(parking|motorcycle_parking)$'), mapcss._tag_capture(capture_tags, 1, tags, 'amenity'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #994 - {0}{1}","{0.key}","{1.tag}")
+                err.append({'class': 2, 'subclass': 650362898, 'text': mapcss.tr('test #994 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # *[a][!c]
+        # *[b][!/d/]
+        if ('a' in keys) or ('b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'c')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'b')) and (not mapcss._tag_capture(capture_tags, 1, tags, self.re_49048f80)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #328 - {0}{1}","{0.key}","{1.key}")
+                err.append({'class': 3, 'subclass': 1004069731, 'text': mapcss.tr('test #328 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        # *[/abc/=~/def/]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(self.re_7f42aaa6, mapcss._match_regex(tags, self.re_4961c1fa))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd"
+                # assertNoMatch:"relation ABC=DEF"
+                # assertMatch:"relation abc=def"
+                # assertNoMatch:"relation abc=ghi"
+                # assertMatch:"relation xabcx=xdefx"
+                err.append({'class': 4, 'subclass': 1371556921, 'text': {'en': 'test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd'}})
+
+        # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
+        if ('addr:street' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_3d3faeb5), mapcss._tag_capture(capture_tags, 0, tags, 'addr:street'))) and (mapcss.inside(self.father.config.options, 'LI,CH')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #327")
+                err.append({'class': 5, 'subclass': 43561107, 'text': mapcss.tr('test #327')})
+
+        # *[a][a=*b]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'a') == mapcss._value_capture(capture_tags, 1, mapcss.tag(tags, 'b'))))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:"test"
+                err.append({'class': 6, 'subclass': 1343056298, 'text': {'en': 'test'}})
+
+        return err
+
+
+from plugins.PluginMapCSS import TestPluginMapcss
+
+
+class Test(TestPluginMapcss):
+    def test(self):
+        n = test_mapcss_parsing_evalutation(None)
+        class _config:
+            options = {"country": None, "language": None}
+        class father:
+            config = _config()
+        n.father = father()
+        n.init(None)
+        data = {'id': 0, 'lat': 0, 'lon': 0}
+
+        self.check_err(n.node(data, {'x': '0'}), expected={'class': 40301, 'subclass': 0})
+        self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 40301, 'subclass': 0})
+        self.check_not_err(n.node(data, {'x': '1.0'}), expected={'class': 40301, 'subclass': 0})
+        self.check_not_err(n.node(data, {'x': 'Osmose'}), expected={'class': 40301, 'subclass': 0})
+        self.check_not_err(n.node(data, {'x': '0'}), expected={'class': 1, 'subclass': 659546685})
+        self.check_err(n.node(data, {'x': '1'}), expected={'class': 1, 'subclass': 659546685})
+        self.check_err(n.node(data, {'x': '1.0'}), expected={'class': 1, 'subclass': 659546685})
+        self.check_err(n.node(data, {'x': 'Osmose'}), expected={'class': 1, 'subclass': 659546685})
+        self.check_err(n.node(data, {'amenity': 'osmose', 'parking': 'yes'}), expected={'class': 2, 'subclass': 650362898})
+        self.check_not_err(n.node(data, {'amenity': 'parking', 'parking': 'yes'}), expected={'class': 2, 'subclass': 650362898})
+        with with_options(n, {'country': 'FR'}):
+            self.check_not_err(n.node(data, {'addr:street': 'Neuestraßebahn'}), expected={'class': 5, 'subclass': 43561107})
+        with with_options(n, {'country': 'LI'}):
+            self.check_err(n.node(data, {'addr:street': 'Neuestraßebahn'}), expected={'class': 5, 'subclass': 43561107})
+        self.check_err(n.node(data, {'a': 'x', 'b': 'x'}), expected={'class': 6, 'subclass': 1343056298})
+        self.check_not_err(n.node(data, {'a': 'x', 'b': 'y'}), expected={'class': 6, 'subclass': 1343056298})
+        self.check_not_err(n.node(data, {'a': 'x'}), expected={'class': 6, 'subclass': 1343056298})
+        self.check_not_err(n.node(data, {'abc': 'def', 'lit': 'yes'}), expected={'class': 6, 'subclass': 130427469})
+        self.check_err(n.node(data, {'lit': 'yes'}), expected={'class': 6, 'subclass': 130427469})
+        self.check_not_err(n.node(data, {'abc': 'def', 'lit': 'yes'}), expected={'class': 6, 'subclass': 612979508})
+        self.check_err(n.node(data, {'lit': 'yes'}), expected={'class': 6, 'subclass': 612979508})
+        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 7, 'subclass': 1785050832})
+        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 7, 'subclass': 1785050832})
+        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 7, 'subclass': 1785050832})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 8, 'subclass': 169712264})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 8, 'subclass': 2074848923})
+        self.check_not_err(n.way(data, {'a': 'b', 'c': 'd'}, [0]), expected={'class': 3, 'subclass': 1004069731})
+        self.check_err(n.way(data, {'a': 'b'}, [0]), expected={'class': 3, 'subclass': 1004069731})
+        self.check_not_err(n.way(data, {'b': 'a', 'd': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
+        self.check_err(n.way(data, {'b': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
+        with with_options(n, {'driving_side': 'left'}):
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 9, 'subclass': 529680562})
+        with with_options(n, {'driving_side': 'right'}):
+            self.check_err(n.way(data, {}, [0]), expected={'class': 9, 'subclass': 529680562})
+        with with_options(n, {'driving_side': 'left'}):
+            self.check_err(n.way(data, {}, [0]), expected={'class': 10, 'subclass': 877255184})
+        with with_options(n, {'driving_side': 'right'}):
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 10, 'subclass': 877255184})
+        self.check_not_err(n.way(data, {'abc': 'def', 'abcdef': 'def'}, [0]), expected={'class': 6, 'subclass': 346020981})
+        self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
+        self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
+        self.check_not_err(n.way(data, {'abc': 'def', 'def': 'def'}, [0]), expected={'class': 6, 'subclass': 346020981})
+        self.check_not_err(n.way(data, {'abc': 'def', 'abcdef': 'def'}, [0]), expected={'class': 6, 'subclass': 57938147})
+        self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
+        self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
+        self.check_not_err(n.way(data, {'abc': 'def', 'def': 'def'}, [0]), expected={'class': 6, 'subclass': 57938147})
+        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 11, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 11, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 11, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 11, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 11, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 11, 'subclass': 722694187})
+        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 11, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 11, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 11, 'subclass': 722694187})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
+        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 13, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 13, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 13, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {}, [0]), expected={'class': 13, 'subclass': 2063115534})
+        self.check_not_err(n.relation(data, {'ABC': 'DEF'}, []), expected={'class': 4, 'subclass': 1371556921})
+        self.check_err(n.relation(data, {'abc': 'def'}, []), expected={'class': 4, 'subclass': 1371556921})
+        self.check_not_err(n.relation(data, {'abc': 'ghi'}, []), expected={'class': 4, 'subclass': 1371556921})
+        self.check_err(n.relation(data, {'xabcx': 'xdefx'}, []), expected={'class': 4, 'subclass': 1371556921})

--- a/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
@@ -1,0 +1,162 @@
+/* Disclaimer: 
+This document only serves to contain test cases to evaluate
+the parsing and evaluation of mapcss files, and is therefore
+not supposed to be used in JOSM for validation of OSM data */
+
+
+node[x=0] {
+  throwWarning: "test #1740";
+  assertMatch: "node x=0";
+  assertNoMatch: "node x=1";
+  assertNoMatch: "node x=1.0";
+  assertNoMatch: "node x=Osmose";
+  -osmoseTags: list("fix:survey");
+  -osmoseItemClassLevel: "4030/40301:0/2";
+}
+node[x!=0] {
+  throwWarning: "test #1740";
+  assertMatch: "node x=1";
+  assertMatch: "node x=1.0";
+  assertMatch: "node x=Osmose";
+  assertNoMatch: "node x=0";
+}
+
+
+way[x~=C1] {
+  throwWarning: "test #1610";
+  assertMatch: "way x=C1";
+  assertMatch: "way x=C00;C1;C22";
+  assertNoMatch: "way x=C12";
+}
+
+
+way:righthandtraffic[x=y][z?] {
+  throwWarning: tr("test #1603 - {0}{1}", "{1.tag}", "{2.tag}");
+  -osmoseAssertMatchWithContext:list("way x=y z=yes", "inside=NL");
+}
+way[x=y][z?]:righthandtraffic {
+  throwWarning: tr("test #1603 - {0}{1}", "{0.tag}", "{1.tag}");
+  -osmoseAssertMatchWithContext:list("way x=y z=yes", "inside=NL");
+}
+
+
+*[parking][amenity!~/^(parking|motorcycle_parking)$/] {
+  throwWarning: tr("test #994 - {0}{1}", "{0.key}", "{1.tag}");
+  assertMatch: "node parking=yes amenity=osmose";
+  assertNoMatch: "node parking=yes amenity=parking";
+}
+
+
+*[a][!c],
+*[b][!/d/] {
+  throwWarning: tr("test #328 - {0}{1}", "{0.key}", "{1.key}");
+  assertMatch: "way a=b";
+  assertMatch: "way b=c";
+  assertNoMatch: "way a=b c=d";
+  assertNoMatch: "way b=a d=c";
+}
+
+
+*[/abc/=~/def/] {
+  assertMatch: "relation xabcx=xdefx";
+  assertMatch: "relation abc=def";
+  assertNoMatch: "relation abc=ghi";
+  assertNoMatch: "relation ABC=DEF";
+  throwWarning: "test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd"
+}
+
+
+*[addr:street =~ /(?i).*Straße.*/][inside("LI,CH")] {
+  -osmoseAssertMatchWithContext:list("node addr:street=Neuestraßebahn", "inside=LI");
+  -osmoseAssertNoMatchWithContext:list("node addr:street=Neuestraßebahn", "inside=FR");
+  throwWarning: tr("test #327");
+}
+
+
+way:righthandtraffic {
+  throwWarning: tr("test righthandtraffic");
+  -osmoseAssertMatchWithContext:list("way", "driving_side=right");
+  -osmoseAssertNoMatchWithContext:list("way", "driving_side=left");
+}
+way!:righthandtraffic {
+  throwWarning: tr("test lefthandtraffic");
+  -osmoseAssertMatchWithContext:list("way", "driving_side=left");
+  -osmoseAssertNoMatchWithContext:list("way", "driving_side=right");
+}
+
+
+way[count(uniq_list(tag_regex("abc"))) == 2] {
+  throwWarning: "test";
+  assertMatch: "way abc=def abcdef=ghi abcd=ghi";
+  assertMatch: "way abc=def abcdef=ghi";
+  assertNoMatch: "way abc=def def=def";
+  assertNoMatch: "way abc=def abcdef=def";
+}
+way[count(uniq_list(tag_regex("abc"))) == 2.0] {
+  throwWarning: "test";
+  assertMatch: "way abc=def abcdef=ghi abcd=ghi";
+  assertMatch: "way abc=def abcdef=ghi";
+  assertNoMatch: "way abc=def def=def";
+  assertNoMatch: "way abc=def abcdef=def";
+}
+
+
+way[oneway?] {
+  throwWarning: tr("test {0}", "{0.tag}");
+  assertMatch: "way oneway=1";
+  assertMatch: "way oneway=yes";
+  assertNoMatch: "way oneway=no";
+  assertNoMatch: "way oneway=4.0";
+  assertNoMatch: "way x=y";
+}
+way[oneway?!] {
+  throwWarning: tr("test {0}", "{0.tag}");
+  assertMatch: "way oneway=0";
+  assertMatch: "way oneway=no";
+  assertNoMatch: "way oneway=yes";
+  assertNoMatch: "way x=y";
+}
+
+/*
+way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x] {
+  assertMatch: "way amenity=place_of_worship name=OsmoseRuleTrigger x=yes";
+  assertMatch: "way building=chapel name=OsmoseRuleTrigger x=yes";
+  assertMatch: "way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes";
+  assertNoMatch: "way amenity=place_of_worship name=Westminster x=yes";
+  throwWarning: tr("test #1303, #1742 {0}", "{2.key}");
+}*/
+way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x] {
+  assertMatch: "way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes";
+  assertNoMatch: "way amenity=place_of_worship building=chapel name=Westminster x=yes";
+  assertNoMatch: "way amenity=place_of_worship name=OsmoseRuleTrigger x=yes";
+  assertNoMatch: "way building=chapel name=OsmoseRuleTrigger x=yes";
+  throwWarning: tr("test #1303 {0}", "{2.key}");
+}
+
+
+*[a][a=*b] {
+  throwError: "test";
+  assertMatch: "node a=x b=x";
+  assertNoMatch: "node a=x b=y";
+  assertNoMatch: "node a=x";
+}
+
+
+node[lit][eval(number_of_tags()) = 1] {
+  throwWarning: "test";
+  assertMatch: "node lit=yes";
+  assertNoMatch: "node abc=def lit=yes";
+}
+node[lit][number_of_tags() == 1] {
+  throwWarning: "test";
+  assertMatch: "node lit=yes";
+  assertNoMatch: "node abc=def lit=yes";
+}
+
+way[maxspeed > 5000] {
+  throwWarning: tr("test {0}{1}", "text", "{0.key}");
+  assertMatch: "way maxspeed=10000";
+  assertNoMatch: "way maxspeed=5000";
+  assertNoMatch: "way maxspeed=default";
+  assertNoMatch: "way";
+}


### PR DESCRIPTION
Have this as an example (minimal) mapcss rule:
```css
*[x!=0] {
  assertMatch: "node x=\"0.5 osmose\"";
  throwWarning: "x";
}
```

Compile the python code and run the test. The match fails due to `modules.mapcss_lib.RuleAbort` being raised by `to_n` - called by `__ne__` - as it tries to convert the nonconvertible string `0.5 osmose` to a float:
https://github.com/osm-fr/osmose-backend/blob/fe158f2c45eac2d0a210cd22a8d0f0d9af68087e/mapcss/mapcss_lib.py#L158-L165
(The error is caught by the `try`/`except` in the mapcss2osmose-generated .py file)

For comparison: JOSM only uses numerical comparisons if the types match: https://josm.openstreetmap.de/browser/josm/trunk/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java#L722

Unfortunately there was no assertMatch in any mapcss file that revealed this behaviour. I've added one to the Dutch rules now (as this one contains a rule that did trigger the error, thereby causing false negatives)

p.s.: please note that the mapcss update was necessary as there's also a difference in how JOSM and Osmose treat `[/regex/!~/regex/]` rules, and fixing this bug revealed that difference. Since this is undocumented behaviour, I decided to just modify the Dutch mapcss so that both give the same result. Unfortunately I made a little mistake there, hence the double mapcss update.