### PR TITLE
Stationnement vélo Strasbourg

### DIFF
--- a/analysers/merge_bicycle_parking_FR_strasbourg.py
+++ b/analysers/merge_bicycle_parking_FR_strasbourg.py
@@ -64,9 +64,7 @@ tag_mapping1 = {
 }
 
 tag_mapping2 = {
-    "ref": (
-        lambda res["id_local"]
-    ),
+    "ref": "id_local",
 #    "access": (
 #        acces      
 #    ),
@@ -82,19 +80,11 @@ tag_mapping2 = {
     "lit": (
         lambda res: "yes" if res["lumiere"] == "vrai" else None
     ),
-    "website": (
-        lambda res["url_info"]
-    ),
-    "start_date": (
-        lambda res["d_service"]
-    ),
-    "owner": (
-        lambda res["proprietaire"]
-    ),
+    "website": "url_info",
+    "start_date": "d_service",
+    "owner": "proprietaire",
     "operator": (
         lambda res: "Eurométropole de Strasbourg" if res["gestionnaire"] == "eurometropole" else None
     ),
-    "note": (
-        lambda res["commentaires"]
-    )
+    "note": "commentaires"
 }

--- a/analysers/merge_bicycle_parking_FR_strasbourg.py
+++ b/analysers/merge_bicycle_parking_FR_strasbourg.py
@@ -23,21 +23,50 @@
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge import Analyser_Merge_Point, SourceOpenDataSoft, CSV, Load_XY, Conflate, Select, Mapping
 
-tag_mapping = {
-    "ref": (
-        lambda res["id_local"]
-    ),
+class Analyser_Merge_Bicycle_Parking_FR_Strasbourg(Analyser_Merge_Point):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8150, id = 21, level = 3, tags = ['merge', 'public equipment', 'bicycle', 'fix:survey', 'fix:picture'],
+            title = T_('Strasbourg bicycle parking not integrated'))
+
+        self.init(
+            "https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/information/",
+            "Stationnement cyclable au format BNSC",
+            CSV(SourceOpenDataSoft(
+                attribution="Ville et eurométropole de Strasbourg",
+                url="https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/")),
+            Load_XY("geo_point_2d", "geo_point_2d",
+                xFunction = lambda x: Load_XY.float_comma(x.split(',')[1]),
+                yFunction = lambda y: Load_XY.float_comma(y.split(',')[0])
+            ),
+            Conflate(
+                select = Select(
+                    types = ["nodes", "ways"],
+                    tags = {"amenity": "bicycle_parking"}),
+                conflationDistance = 20,
+                mapping = Mapping(
+                    static1 = {"amenity": "bicycle_parking"},
+                    static2 = {"source": self.source},
+                    mapping1 = tag_mapping1,
+                    mapping2 = tag_mapping2)))
+tag_mapping1 = {
     "capacity": (
         lambda res: None if res["capacite"] in (None, "0") else res["capacite"]
     ),
     "capacity:cargo_bike": (
         lambda res: None if res["capacite_cargo"] in (None, "0") else res["capacite_cargo"]
-    ),
+    )
 #    "bicycle_parking": (
 #      type_accroche
 #      mobilier
 #      protection
-#    ),
+#    )
+}
+
+tag_mapping2 = {
+    "ref": (
+        lambda res["id_local"]
+    ),
 #    "access": (
 #        acces      
 #    ),
@@ -69,29 +98,3 @@ tag_mapping = {
         lambda res["commentaires"]
     )
 }
-
-class Analyser_Merge_Bicycle_Parking_FR_Strasbourg(Analyser_Merge_Point):
-    def __init__(self, config, logger = None):
-        Analyser_Merge_Point.__init__(self, config, logger)
-        self.def_class_missing_official(item = 8150, id = 21, level = 3, tags = ['merge', 'public equipment', 'bicycle', 'fix:survey', 'fix:picture'],
-            title = T_('Strasbourg bicycle parking not integrated'))
-
-        self.init(
-            "https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/information/",
-            "Stationnement cyclable au format BNSC",
-            CSV(SourceOpenDataSoft(
-                attribution="Ville et eurométropole de Strasbourg",
-                url="https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/")),
-            Load_XY("geo_point_2d", "geo_point_2d",
-                xFunction = lambda x: Load_XY.float_comma(x.split(',')[1]),
-                yFunction = lambda y: Load_XY.float_comma(y.split(',')[0])
-            ),
-            Conflate(
-                select = Select(
-                    types = ["nodes", "ways"],
-                    tags = {"amenity": "bicycle_parking"}),
-                conflationDistance = 20,
-                mapping = Mapping(
-                    static1 = {"amenity": "bicycle_parking"},
-                    static2 = {"source": self.source},
-                    mapping1 = tag_mapping )))

--- a/analysers/merge_bicycle_parking_FR_strasbourg.py
+++ b/analysers/merge_bicycle_parking_FR_strasbourg.py
@@ -23,12 +23,6 @@
 from modules.OsmoseTranslation import T_
 from .Analyser_Merge import Analyser_Merge_Point, SourceOpenDataSoft, CSV, Load_XY, Conflate, Select, Mapping
 
-STANDS_TYPES = {
-    "Arceau autre": "stands",
-    "Arceau St-Germain": "wide_stands",
-    "Epingle vélo": "stands",
-    "Sans": "floor",
-}
 tag_mapping = {
     "ref": (
         lambda res["id_local"]

--- a/analysers/merge_bicycle_parking_FR_strasbourg.py
+++ b/analysers/merge_bicycle_parking_FR_strasbourg.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights LeJun 2023                                                 ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Merge import Analyser_Merge_Point, SourceOpenDataSoft, CSV, Load_XY, Conflate, Select, Mapping
+
+STANDS_TYPES = {
+    "Arceau autre": "stands",
+    "Arceau St-Germain": "wide_stands",
+    "Epingle vélo": "stands",
+    "Sans": "floor",
+}
+tag_mapping = {
+    "ref": (
+        lambda res["id_local"]
+    ),
+    "capacity": (
+        lambda res: None if res["capacite"] in (None, "0") else res["capacite"]
+    ),
+    "capacity:cargo_bike": (
+        lambda res: None if res["capacite_cargo"] in (None, "0") else res["capacite_cargo"]
+    ),
+#    "bicycle_parking": (
+#      type_accroche
+#      mobilier
+#      protection
+#    ),
+#    "access": (
+#        acces      
+#    ),
+    "fee": (
+        lambda res: "no" if res["gratuit"] == "vrai" else None
+    ),
+    "covered": (
+        lambda res: "yes" if res["couverture"] == "vrai" else None
+    ),
+    "surveillance": (
+        lambda res: "yes" if res["surveillance"] == "vrai" else None
+    ),
+    "lit": (
+        lambda res: "yes" if res["lumiere"] == "vrai" else None
+    ),
+    "website": (
+        lambda res["url_info"]
+    ),
+    "start_date": (
+        lambda res["d_service"]
+    ),
+    "owner": (
+        lambda res["proprietaire"]
+    ),
+    "operator": (
+        lambda res: "Eurométropole de Strasbourg" if res["gestionnaire"] == "eurometropole" else None
+    ),
+    "note": (
+        lambda res["commentaires"]
+    )
+}
+
+class Analyser_Merge_Bicycle_Parking_FR_Strasbourg(Analyser_Merge_Point):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8150, id = 21, level = 3, tags = ['merge', 'public equipment', 'bicycle', 'fix:survey', 'fix:picture'],
+            title = T_('Strasbourg bicycle parking not integrated'))
+
+        self.init(
+            "https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/information/",
+            "Stationnement cyclable au format BNSC",
+            CSV(SourceOpenDataSoft(
+                attribution="Ville et eurométropole de Strasbourg",
+                url="https://data.strasbourg.eu/explore/dataset/stationnementcyclable_ville_et_eurometropole_de_strasbourg/")),
+            Load_XY("geo_point_2d", "geo_point_2d",
+                xFunction = lambda x: Load_XY.float_comma(x.split(',')[1]),
+                yFunction = lambda y: Load_XY.float_comma(y.split(',')[0])
+            ),
+            Conflate(
+                select = Select(
+                    types = ["nodes", "ways"],
+                    tags = {"amenity": "bicycle_parking"}),
+                conflationDistance = 20,
+                mapping = Mapping(
+                    static1 = {"amenity": "bicycle_parking"},
+                    static2 = {"source": self.source},
+                    mapping1 = tag_mapping )))

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -277,11 +277,14 @@ france_departement = gen_country('europe', 'france', download_repo=OSMFR, langua
     'merge_road_FR',
 ], **{'addr:city-admin_level': '8,9'})
 
-france_departement("alsace/bas_rhin", 7415, "FR-67")
+france_departement("alsace/bas_rhin", 7415, "FR-67"), include=[
+    # Strasbourg
+    'merge_bicycle_parking_FR_strasbourg',
+])
 france_departement("alsace/haut_rhin", 7403, "FR-68")
 
 include_aquitaine = [
-    # Aquitiane
+    # Aquitaine
     'merge_tourism_FR_aquitaine_camp_caravan',
     'merge_tourism_FR_aquitaine_museum',
     'merge_sport_FR_aquitaine_equestrian',

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -277,7 +277,7 @@ france_departement = gen_country('europe', 'france', download_repo=OSMFR, langua
     'merge_road_FR',
 ], **{'addr:city-admin_level': '8,9'})
 
-france_departement("alsace/bas_rhin", 7415, "FR-67"), include=[
+france_departement("alsace/bas_rhin", 7415, "FR-67", include=[
     # Strasbourg
     'merge_bicycle_parking_FR_strasbourg',
 ])


### PR DESCRIPTION
Hi, making my first steps onto osmose backend with bicycle parking data provided by Strasbourg. Adapted the analyser file from the Paris one (which itself is based upon the Bordeaux one).

I’d like to bring some attention on the fact that provided data are under the [Base Nationale du Stationnement Cyclable](https://transport.data.gouv.fr/datasets/stationnements-cyclables-issus-dopenstreetmap) which aims to ease the conversion between OSM and local data. I didn’t find any ready-made template to adapt from which is why I tried to do so myself, left as many fields as possible (before commenting them out) so that may become a template for future uses.