### PR TITLE
Fix 1742 - bad parsing of tag(...)

### DIFF
--- a/mapcss/MapCSSListenerL.py
+++ b/mapcss/MapCSSListenerL.py
@@ -107,7 +107,6 @@ class MapCSSListenerL(MapCSSListener):
             'question_mark': not (not (ctx.QUESTION_MARK())),
             'question_mark_negated': not (not (ctx.QUESTION_MARK_NEGATED())),
             'selector_index': self.selector_index}
-        self.selector_index += 1
 
 
 #    # Enter a parse tree produced by MapCSSParser#class_selector.
@@ -198,6 +197,9 @@ class MapCSSListenerL(MapCSSListener):
                 [],
             'selector_index': self.selector_index
         })
+
+    # Exit a parse tree produced by MapCSSParser#attribute_selector.
+    def exitAttribute_selector(self, ctx:MapCSSParser.Attribute_selectorContext):
         self.selector_index += 1
 
 

--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -129,7 +129,7 @@ def booleanExpression_dereference_first_operand(t, c):
     Replace first operand by the value of the tag
     """
     if len(t['operands']) >= 1 and t['operands'][0]['type'] in ('osmtag', 'quoted'):
-        t['operands'][0] = {'type': 'functionExpression', 'name': 'tag', 'params': [t['operands'][0]]}
+        t['operands'][0] = {'type': 'functionExpression', 'name': 'maintag', 'params': [t['operands'][0]]}
     return t
 
 def booleanExpression_capture_first_operand(t, c):
@@ -137,7 +137,7 @@ def booleanExpression_capture_first_operand(t, c):
     type = booleanExpression
     Capture first operand tag
     """
-    if len(t['operands']) >= 1 and t['operands'][0]['type'] == 'functionExpression' and t['operands'][0]['name'] == 'tag':
+    if len(t['operands']) >= 1 and t['operands'][0]['type'] == 'functionExpression' and t['operands'][0]['name'] == 'maintag':
         if not t['operator'] in ('!', '!=', '!~'):
             c['selector_capture'].append(t['operands'][0]['params'][0])
         t['operands'][0] = {'type': 'functionExpression', 'name': '_tag_capture', 'params': ['capture_tags', str(t['selector_index']), 'tags', t['operands'][0]['params'][0]]}
@@ -245,7 +245,7 @@ def rule_declarations_order(t, c):
     type = rule
     Order the declarations in order attended by the code generator
     """
-    t['declarations'] = sorted(t['declarations'], key = lambda d: (d.get('property') and [rule_declarations_order_map.get(d['property']) or print("W: Unknow property: " + d['property']) and -1, str(d['value'])]) or [-1, -1])
+    t['declarations'] = sorted(t['declarations'], key = lambda d: (d.get('property') and [rule_declarations_order_map.get(d['property']) or print("W: Unknown property: " + d['property']) and -1, str(d['value'])]) or [-1, -1])
     return t
 
 def selector_before_capture(t, c):
@@ -350,7 +350,7 @@ def quoted_uncapture(t, c):
 def functionExpression_runtime(t, c):
     """
     type = functionExpression
-    Add runtime pyhton paramter and function name
+    Add runtime python parameter and function name
     """
     if t['name'] == 'osm_id':
         return "dada['id']"

--- a/plugins/Josm_combinations.py
+++ b/plugins/Josm_combinations.py
@@ -1315,7 +1315,7 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss._tag_capture(capture_tags, 3, tags, 'voltage:secondary') < mapcss._value_capture(capture_tags, 3, mapcss.tag(tags, 'voltage:primary'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss.tag(tags, 'voltage:secondary') < mapcss.tag(tags, 'voltage:primary')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -2873,31 +2873,31 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'turn:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'turn:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'turn:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'turn:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'change:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'change:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'change:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'change:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'maxspeed:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'maxspeed:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'maxspeed:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'maxspeed:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'minspeed:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'minspeed:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'minspeed:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'minspeed:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:ref:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:ref:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:ref:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:ref:lanes')))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:symbol:lanes')) and (mapcss._tag_capture(capture_tags, 3, tags, 'lanes') != mapcss._value_capture(capture_tags, 3, mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:symbol:lanes'))))))
+                try: match = ((set_MotorwayTrunk) and (mapcss._tag_capture(capture_tags, 1, tags, 'lanes')) and (mapcss._tag_capture(capture_tags, 2, tags, 'destination:symbol:lanes')) and (mapcss.tag(tags, 'lanes') != mapcss.count(mapcss.split('|', mapcss.tag(tags, 'destination:symbol:lanes')))))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -3438,7 +3438,7 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss._tag_capture(capture_tags, 3, tags, 'voltage:secondary') < mapcss._value_capture(capture_tags, 3, mapcss.tag(tags, 'voltage:primary'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss.tag(tags, 'voltage:secondary') < mapcss.tag(tags, 'voltage:primary')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")
@@ -4458,7 +4458,7 @@ class Josm_combinations(PluginMapCSS):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss._tag_capture(capture_tags, 3, tags, 'voltage:secondary') < mapcss._value_capture(capture_tags, 3, mapcss.tag(tags, 'voltage:primary'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'voltage:primary')) and (mapcss._tag_capture(capture_tags, 1, tags, 'voltage:secondary')) and (mapcss._tag_capture(capture_tags, 2, tags, 'transformer') == mapcss._value_capture(capture_tags, 2, 'generator')) and (mapcss.tag(tags, 'voltage:secondary') < mapcss.tag(tags, 'voltage:primary')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("suspicious tag combination")

--- a/plugins/Josm_unnecessary.py
+++ b/plugins/Josm_unnecessary.py
@@ -354,11 +354,11 @@ class Josm_unnecessary(PluginMapCSS):
         # *[name][name=~/^(?i)(school|école|Школа)$/][amenity!=school]
         # *[name][name=~/^(?i)(house|rumah|vivienda)$/][building][building!=house][building!=no]
         # *[name][name=~/^(?i)(casa)$/][building][building!=house][building!=no][outside("FR")]
-        if ('amenity' in keys and 'building' in keys and 'name' in keys) or ('building' in keys and 'name' in keys) or ('name' in keys):
+        if ('building' in keys and 'name' in keys) or ('name' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'building') == mapcss._value_capture(capture_tags, 2, 'chapel') or mapcss._tag_capture(capture_tags, 3, tags, 'amenity') == mapcss._value_capture(capture_tags, 3, 'place_of_worship')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.tag(tags, 'building') == 'chapel' or mapcss.tag(tags, 'amenity') == 'place_of_worship'))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
@@ -805,11 +805,11 @@ class Josm_unnecessary(PluginMapCSS):
         # *[name][name=~/^(?i)(school|école|Школа)$/][amenity!=school]
         # *[name][name=~/^(?i)(house|rumah|vivienda)$/][building][building!=house][building!=no]
         # *[name][name=~/^(?i)(casa)$/][building][building!=house][building!=no][outside("FR")]
-        if ('amenity' in keys and 'building' in keys and 'name' in keys) or ('building' in keys and 'name' in keys) or ('name' in keys):
+        if ('building' in keys and 'name' in keys) or ('name' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'building') == mapcss._value_capture(capture_tags, 2, 'chapel') or mapcss._tag_capture(capture_tags, 3, tags, 'amenity') == mapcss._value_capture(capture_tags, 3, 'place_of_worship')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.tag(tags, 'building') == 'chapel' or mapcss.tag(tags, 'amenity') == 'place_of_worship'))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
@@ -1145,11 +1145,11 @@ class Josm_unnecessary(PluginMapCSS):
         # *[name][name=~/^(?i)(school|école|Школа)$/][amenity!=school]
         # *[name][name=~/^(?i)(house|rumah|vivienda)$/][building][building!=house][building!=no]
         # *[name][name=~/^(?i)(casa)$/][building][building!=house][building!=no][outside("FR")]
-        if ('amenity' in keys and 'building' in keys and 'name' in keys) or ('building' in keys and 'name' in keys) or ('name' in keys):
+        if ('building' in keys and 'name' in keys) or ('name' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss._tag_capture(capture_tags, 2, tags, 'building') == mapcss._value_capture(capture_tags, 2, 'chapel') or mapcss._tag_capture(capture_tags, 3, tags, 'amenity') == mapcss._value_capture(capture_tags, 3, 'place_of_worship')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'name')) and (mapcss.regexp_test(mapcss._value_capture(capture_tags, 1, self.re_7c3e64db), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.tag(tags, 'building') == 'chapel' or mapcss.tag(tags, 'amenity') == 'place_of_worship'))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}

--- a/plugins/tests/test_mapcss_parsing_evalutation.py
+++ b/plugins/tests/test_mapcss_parsing_evalutation.py
@@ -24,8 +24,10 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
         self.errors[9] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
         self.errors[10] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
         self.errors[11] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
-        self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
+        self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
         self.errors[40301] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
 
         self.re_3d3faeb5 = re.compile(r'(?i).*Straße.*')
@@ -352,12 +354,27 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way x=y"
                 err.append({'class': 11, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
-        # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
-        if ('amenity' in keys and 'building' in keys and 'name' in keys and 'x' in keys):
+        # way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x]
+        if ('name' in keys and 'x' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss.string_contains(mapcss._tag_capture(capture_tags, 0, tags, 'name'), mapcss._value_capture(capture_tags, 0, 'Trigger'))) and (mapcss._tag_capture(capture_tags, 1, tags, 'building') == mapcss._value_capture(capture_tags, 1, 'chapel') and mapcss._tag_capture(capture_tags, 2, tags, 'amenity') == mapcss._value_capture(capture_tags, 2, 'place_of_worship')) and (mapcss._tag_capture(capture_tags, 4, tags, 'x')))
+                try: match = ((mapcss.string_contains(mapcss._tag_capture(capture_tags, 0, tags, 'name'), mapcss._value_capture(capture_tags, 0, 'Trigger'))) and (mapcss.tag(tags, 'building') == 'chapel' or mapcss.tag(tags, 'amenity') == 'place_of_worship') and (mapcss._tag_capture(capture_tags, 2, tags, 'x')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #1303, #1742 {0}","{2.key}")
+                # assertMatch:"way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes"
+                # assertMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
+                # assertNoMatch:"way amenity=place_of_worship name=Westminster x=yes"
+                # assertMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
+                err.append({'class': 12, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
+        if ('name' in keys and 'x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.string_contains(mapcss._tag_capture(capture_tags, 0, tags, 'name'), mapcss._value_capture(capture_tags, 0, 'Trigger'))) and (mapcss.tag(tags, 'building') == 'chapel' and mapcss.tag(tags, 'amenity') == 'place_of_worship') and (mapcss._tag_capture(capture_tags, 2, tags, 'x')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwWarning:tr("test #1303 {0}","{2.key}")
@@ -365,7 +382,19 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way amenity=place_of_worship building=chapel name=Westminster x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 12, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 13, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # way[inside(FR)][x]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.inside(self.father.config.options, 'FR')) and (mapcss._tag_capture(capture_tags, 1, tags, 'x')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test #1742 - {0}","{1.tag}")
+                # -osmoseAssertMatchWithContext:list("way x=y","inside=FR")
+                err.append({'class': 14, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[a][a=*b]
         if ('a' in keys):
@@ -391,7 +420,23 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way maxspeed=5000"
                 # assertNoMatch:"way maxspeed=default"
                 # assertNoMatch:"way"
-                err.append({'class': 13, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+                err.append({'class': 15, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+
+        # way[tag(a)>tag(b)]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.tag(tags, 'a') > mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertNoMatch:"way a=0 b=1"
+                # assertNoMatch:"way a=0 b=yes"
+                # assertMatch:"way a=1 b=0"
+                # assertMatch:"way a=1.5 b=0"
+                # assertNoMatch:"way a=no b=yes"
+                err.append({'class': 6, 'subclass': 384294833, 'text': {'en': 'test'}})
 
         return err
 
@@ -539,14 +584,25 @@ class Test(TestPluginMapcss):
         self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 11, 'subclass': 722694187})
         self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 11, 'subclass': 722694187})
         self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 11, 'subclass': 722694187})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1140742172})
-        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 13, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 13, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 13, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {}, [0]), expected={'class': 13, 'subclass': 2063115534})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
+        with with_options(n, {'country': 'FR'}):
+            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 14, 'subclass': 1132689531})
+        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 15, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 15, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 15, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {}, [0]), expected={'class': 15, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'a': '0', 'b': '1'}, [0]), expected={'class': 6, 'subclass': 384294833})
+        self.check_not_err(n.way(data, {'a': '0', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
+        self.check_err(n.way(data, {'a': '1', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})
+        self.check_err(n.way(data, {'a': '1.5', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})
+        self.check_not_err(n.way(data, {'a': 'no', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_not_err(n.relation(data, {'ABC': 'DEF'}, []), expected={'class': 4, 'subclass': 1371556921})
         self.check_err(n.relation(data, {'abc': 'def'}, []), expected={'class': 4, 'subclass': 1371556921})
         self.check_not_err(n.relation(data, {'abc': 'ghi'}, []), expected={'class': 4, 'subclass': 1371556921})

--- a/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
@@ -117,20 +117,26 @@ way[oneway?!] {
   assertNoMatch: "way x=y";
 }
 
-/*
+
 way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x] {
   assertMatch: "way amenity=place_of_worship name=OsmoseRuleTrigger x=yes";
   assertMatch: "way building=chapel name=OsmoseRuleTrigger x=yes";
   assertMatch: "way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes";
   assertNoMatch: "way amenity=place_of_worship name=Westminster x=yes";
   throwWarning: tr("test #1303, #1742 {0}", "{2.key}");
-}*/
+}
 way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x] {
   assertMatch: "way amenity=place_of_worship building=chapel name=OsmoseRuleTrigger x=yes";
   assertNoMatch: "way amenity=place_of_worship building=chapel name=Westminster x=yes";
   assertNoMatch: "way amenity=place_of_worship name=OsmoseRuleTrigger x=yes";
   assertNoMatch: "way building=chapel name=OsmoseRuleTrigger x=yes";
   throwWarning: tr("test #1303 {0}", "{2.key}");
+}
+
+
+way[inside(FR)][x] {
+  throwWarning: tr("test #1742 - {0}", "{1.tag}");
+  -osmoseAssertMatchWithContext:list("way x=y", "inside=FR");
 }
 
 
@@ -159,4 +165,12 @@ way[maxspeed > 5000] {
   assertNoMatch: "way maxspeed=5000";
   assertNoMatch: "way maxspeed=default";
   assertNoMatch: "way";
+}
+way[tag(a) > tag(b)] {
+  throwWarning: "test";
+  assertMatch: "way a=1 b=0";
+  assertMatch: "way a=1.5 b=0";
+  assertNoMatch: "way a=0 b=1";
+  assertNoMatch: "way a=0 b=yes";
+  assertNoMatch: "way a=no b=yes";
 }


### PR DESCRIPTION
~Depends on #1740 to be merged first, hence keeping it as draft for now.~

It was a combined issue of:
1. "tag" being used for both `tag(...)` and `[tag]`
2. `booleanExpression` being used to increase the selector count, while booleanExpression can be called multiple times per [...] block

Fixes #1742 