### PR TITLE
Fix test due to Wiki update

### DIFF
--- a/plugins/TagWatchFrViPofm.py
+++ b/plugins/TagWatchFrViPofm.py
@@ -141,13 +141,13 @@ class Test(TestPluginCommon):
         self.check_err(a.relation(None, {"aera": "plop"}, None))
         self.check_err(a.node(None, {"administrative": "boundary"}))
         self.check_err(a.node(None, {"name": "FIXME"}))
-        self.check_err(a.node(None, {"trafic_calming ": "yes"}))
+        self.check_err(a.node(None, {"Area": "plop"}))
         self.check_err(a.node(None, {"Fixme": "yes"}))
         self.check_err(a.node(None, {"voltage": "10kV"}))
         assert not a.node(None, {"area": "plop"})
         assert not a.node(None, {"boundary": "administrative"})
         assert not a.node(None, {"name": "Belleville"})
-        assert not a.node(None, {"traffic_calming ": "yes"})
+        assert not a.node(None, {"traffic_calming": "yes"})
 
     def test_only_for_none(self):
         a = TagWatchFrViPofm(None)


### PR DESCRIPTION
[Someone removed `trafic_calming` from the wiki](https://wiki.openstreetmap.org/w/index.php?title=Tagging_Mistakes&type=revision&diff=2468534&oldid=2468507) (probably because it doesn't occur in OSM anymore, but there's no change reason given), hence replacing it by a similar item that does still exist, so the tests don't fail anymore.

p.s. the other failing test (Construction.py) I didn't fix yet: `not_correct_dates = ["22/01/2023",`, do you just mean "not expired dates"? Because the format seems to be equally incorrect as `"22/01/2012"` the line above 