### PR TITLE
Reset fixme false positives every year

### DIFF
--- a/plugins/TagRemove_Fixme.py
+++ b/plugins/TagRemove_Fixme.py
@@ -21,6 +21,7 @@
 
 from modules.OsmoseTranslation import T_
 from plugins.Plugin import Plugin
+from datetime import date
 
 
 class TagRemove_Fixme(Plugin):
@@ -34,10 +35,15 @@ class TagRemove_Fixme(Plugin):
             detail = T_(
 '''`highway=road` has been used, choose a correct value, such as
 `highway=unclassified`.'''))
+        self.currentYear = date.today().year
 
     def node(self, data, tags):
         if "fixme" in tags or "FIXME" in tags:
-            return [{"class": 40610, "subclass": 1, "text": {"en": tags['fixme'] if 'fixme' in tags else tags['FIXME']}}]
+            return [{
+                "class": 40610,
+                "subclass": self.currentYear, # Reset false positives every year
+                "text": {"en": tags['fixme'] if 'fixme' in tags else tags['FIXME']}
+            }]
         else:
             return []
 
@@ -45,7 +51,7 @@ class TagRemove_Fixme(Plugin):
         ret = self.node(data, tags)
 
         if tags.get("highway") == "road":
-            ret.append({"class": 40611, "subclass": 1})
+            ret.append({"class": 40611, "subclass": self.currentYear})
 
         return ret
 


### PR DESCRIPTION
It is impossible for a `fixme` tag to be a false positive, as the tag literally means something has to be fixed. However, still a large number of fixme issues are marked as false positives: https://osmose.openstreetmap.fr/nl/issues/false-positive?item=4061&source=&class=40610,40611&username=&bbox=

Being marked as such very likely means the "fixme-origin" wasn't resolved by the time someone reviewed it. Hence, similar to the ['finished construction' plugin](https://github.com/osm-fr/osmose-backend/blob/master/plugins/Construction.py#L98), reset the false positives every year