### PR TITLE
Warn about amenity on/in roof

### DIFF
--- a/plugins/TagFix_MultipleTag2.py
+++ b/plugins/TagFix_MultipleTag2.py
@@ -1,0 +1,96 @@
+#-*- coding: utf-8 -*-
+import modules.mapcss_lib as mapcss
+import regex as re # noqa
+
+from plugins.Plugin import with_options # noqa
+from plugins.PluginMapCSS import PluginMapCSS
+
+
+class TagFix_MultipleTag2(PluginMapCSS):
+
+
+
+    def init(self, logger):
+        super().init(logger)
+        tags = capture_tags = {} # noqa
+        self.errors[30322] = self.def_class(item = 3032, level = 3, tags = mapcss.list_('tag'), title = mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}')))
+
+
+
+    def node(self, data, tags):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # *[building=roof][amenity][amenity!=shelter]
+        if ('amenity' in keys and 'building' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'building') == mapcss._value_capture(capture_tags, 0, 'roof')) and (mapcss._tag_capture(capture_tags, 1, tags, 'amenity')) and (mapcss._tag_capture(capture_tags, 2, tags, 'amenity') != mapcss._value_const_capture(capture_tags, 2, 'shelter', 'shelter')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"3032/30322/3"
+                # throwWarning:tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.","{0.tag}","{1.tag}","{0.value}","{1.key}")
+                err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        return err
+
+    def way(self, data, tags, nds):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # *[building=roof][amenity][amenity!=shelter]
+        if ('amenity' in keys and 'building' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'building') == mapcss._value_capture(capture_tags, 0, 'roof')) and (mapcss._tag_capture(capture_tags, 1, tags, 'amenity')) and (mapcss._tag_capture(capture_tags, 2, tags, 'amenity') != mapcss._value_const_capture(capture_tags, 2, 'shelter', 'shelter')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"3032/30322/3"
+                # throwWarning:tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.","{0.tag}","{1.tag}","{0.value}","{1.key}")
+                # assertMatch:"way building=roof amenity=fuel"
+                err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        return err
+
+    def relation(self, data, tags, members):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # *[building=roof][amenity][amenity!=shelter]
+        if ('amenity' in keys and 'building' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'building') == mapcss._value_capture(capture_tags, 0, 'roof')) and (mapcss._tag_capture(capture_tags, 1, tags, 'amenity')) and (mapcss._tag_capture(capture_tags, 2, tags, 'amenity') != mapcss._value_const_capture(capture_tags, 2, 'shelter', 'shelter')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"3032/30322/3"
+                # throwWarning:tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.","{0.tag}","{1.tag}","{0.value}","{1.key}")
+                err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        return err
+
+
+from plugins.PluginMapCSS import TestPluginMapcss
+
+
+class Test(TestPluginMapcss):
+    def test(self):
+        n = TagFix_MultipleTag2(None)
+        class _config:
+            options = {"country": None, "language": None}
+        class father:
+            config = _config()
+        n.father = father()
+        n.init(None)
+        data = {'id': 0, 'lat': 0, 'lon': 0}
+
+        self.check_err(n.way(data, {'amenity': 'fuel', 'building': 'roof'}, [0]), expected={'class': 30322, 'subclass': 0})

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -1,0 +1,37 @@
+/*#########################################################################
+##                                                                       ##
+## Copyrights Osmose project 2023                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+#########################################################################*/
+
+meta {
+    title: "Osmose-QA – Tag combinations";
+    description: "Validation of combinations of tags";
+    author: "Osmose";
+    min-josm-version: 14481;
+    -osmoseTags: list("tag");
+}
+meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for translation */
+    description: tr("Validation of combinations of tags");
+}
+
+
+/* Amenities are not typically not located on/in a roof, but underneath */
+*[building=roof][amenity][amenity!=shelter] {
+  throwWarning: tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.", "{0.tag}", "{1.tag}", "{0.value}", "{1.key}");
+  assertMatch: "way building=roof amenity=fuel";
+  -osmoseItemClassLevel: "3032/30322/3";
+}


### PR DESCRIPTION
Fixes #1761

Add rule to warn about `amenity` (such as fuel stations) together with `building=roof`.
I excluded amenity=shelter as I can see how that could be a valid combination, if the shelter is literally a roof only. (Wouldn't be my preferred tagging though)