### PR TITLE
Convert 'simple' TagFix_Multiple to mapcss

### DIFF
--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -105,9 +105,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
 This is almost never the case and more specific tags should be used instead. \
 For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:access#Transport_mode_restrictions).'''))
 
-        self.errors[32302] = self.def_class(item = 3230, level = 2, tags = ['highway', 'fix:chair'],
-            title = T_('Suspicious name for a container'))
-
         self.driving_side_right = not (self.father.config.options.get("driving_side") == "left")
         self.driving_direction = "anticlockwise" if self.driving_side_right else "clockwise"
         name_parent = []
@@ -132,8 +129,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = []
         if tags.get("name") and len(key_set & self.name_parent) == 0 and tags.get("naptan:verified") != "no":
             err.append({"class": 21101, "subclass": 1})
-        if tags.get("amenity") == "recycling" and tags.get("recycling_type") != "centre" and tags.get("name"):
-            err.append({"class": 32302})
 
         if tags.get("barrier") == "fence" and "fence_type" not in tags and "material" in tags:
             err.append({"class": 303210})
@@ -243,7 +238,5 @@ class Test(TestPluginCommon):
         assert not a.way(None, {"tracktype": "foo", "leisure": "track"}, None)
 
         assert a.relation(None, {}, None)
-
-        assert a.node(None, {"amenity": "recycling", "recycling_type": "container", "name": "My nice awesome container"})
 
         assert a.node(None, {"barrier": "fence", "material": "wood"})

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -30,8 +30,6 @@ class TagFix_MultipleTag(Plugin):
         self.country = self.father.config.options.get("country")
         main_tags = ('type', 'aerialway', 'aeroway', 'amenity', 'barrier', 'boundary', 'building', "building:part", 'craft', 'entrance', 'emergency', 'geological', 'highway', 'historic', 'landuse', 'leisure', 'man_made', 'military', 'natural', 'office', 'place', 'power', 'public_transport', 'railway', 'route', 'shop', 'sport', 'tourism', 'waterway', 'mountain_pass', 'traffic_sign', 'golf', 'piste:type', 'junction', 'healthcare', 'health_facility:type', 'indoor', 'club', 'seamark:type', 'attraction', 'information', 'advertising', 'ford', 'cemetery', 'area:highway', 'checkpoint', 'telecom', 'airmark')
 
-        self.errors[30320] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway', 'fix:chair'],
-            title = T_('Watch multiple tags'))
         self.errors[30323] = self.def_class(item = 3032, level = 3, tags = ['tag', 'fix:chair'],
             title = T_('Watch multiple tags'))
         self.errors[30327] = self.def_class(item = 3032, level = 2, tags = ['tag', 'fix:chair'],
@@ -149,9 +147,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
     def way(self, data, tags, nds):
         key_set = set(tags.keys())
         err = self.common(tags, key_set)
-        if "highway" in tags and "fee" in tags:
-            err.append({"class": 30320, "subclass": 1000, "text": T_(u"Use tag \"toll\" instead of \"fee\""),
-                        "fix": {"-": ["fee"], "+": {"toll": tags["fee"]}} })
 
         if tags.get("junction") not in (None, "yes") and u"highway" not in tags and "area:highway" not in tags:
             err.append({"class": 20800, "subclass": 0})
@@ -209,7 +204,6 @@ class Test(TestPluginCommon):
             self.check_err(a.node(None, t), t)
 
         for t in [{"highway":"primary", "tunnel": "yes"},
-                  {"highway":"primary", "fee": "yes"},
                   {"junction":"roundabout", "waterway": "river"},
                   {"oneway":"yes", "building": "yes"},
                  ]:

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -92,8 +92,6 @@ separated by traffic islands at an intersection without cross).'''),
 Clockwise rotation.'''))
         self.errors[40201] = self.def_class(item = 4020, level = 1, tags = ['highway', 'roundabout'],
             title = T_('Roundabout as area'))
-        self.errors[20802] = self.def_class(item = 2080, level = 2, tags = ['highway'],
-            title = T_('Missing tag ref for emergency access point'))
 #        self.errors[70401] = self.def_class(item = 7040, level = 2, tags = ['tag', 'power', 'fix:chair'],
 #            title = T_('Bad power line kind'))
         self.errors[32200] = self.def_class(item = 3220, level = 2, tags = ['highway', 'fix:chair'],
@@ -139,9 +137,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = []
         if tags.get("name") and len(key_set & self.name_parent) == 0 and tags.get("naptan:verified") != "no":
             err.append({"class": 21101, "subclass": 1})
-
-        if tags.get('highway') == 'emergency_access_point' and not tags.get('ref'):
-            err.append({"class": 20802, "subclass": 1})
 
         if not self.country or not self.country.startswith("CZ"):
             if tags.get("amenity") == "recycling" and tags.get("recycling_type") != "centre" and tags.get("recycling:glass") == "yes":

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -92,8 +92,6 @@ separated by traffic islands at an intersection without cross).'''),
 Clockwise rotation.'''))
         self.errors[40201] = self.def_class(item = 4020, level = 1, tags = ['highway', 'roundabout'],
             title = T_('Roundabout as area'))
-        self.errors[21202] = self.def_class(item = 2120, level = 3, tags = ['indoor'],
-            title = T_('Indoor or building:part tag missing'))
         self.errors[20802] = self.def_class(item = 2080, level = 2, tags = ['highway'],
             title = T_('Missing tag ref for emergency access point'))
 #        self.errors[70401] = self.def_class(item = 7040, level = 2, tags = ['tag', 'power', 'fix:chair'],
@@ -141,9 +139,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = []
         if tags.get("name") and len(key_set & self.name_parent) == 0 and tags.get("naptan:verified") != "no":
             err.append({"class": 21101, "subclass": 1})
-
-        if tags.get("room") and not tags.get("indoor") and not tags.get("buildingpart"):
-            err.append({"class": 21202, "subclass": 2, "fix":[{"+": {"indoor": "room"}}, {"+": {"buildingpart": "room"}}]})
 
         if tags.get('highway') == 'emergency_access_point' and not tags.get('ref'):
             err.append({"class": 20802, "subclass": 1})
@@ -267,8 +262,6 @@ class Test(TestPluginCommon):
         self.check_err(a.way(None, {"waterway": "stream", "level": "-1"}, None))
 
         assert a.way(None, {"area": "yes", "highway": "secondary", "junction": "roundabout"}, None)
-
-        assert a.node(None, {"room": "office"})
 
         assert a.way(None, {"highway": "track", "access": "yes"}, None)
         assert a.way(None, {"highway": "trunk", "access": "yes"}, None)

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -92,8 +92,6 @@ separated by traffic islands at an intersection without cross).'''),
 Clockwise rotation.'''))
         self.errors[40201] = self.def_class(item = 4020, level = 1, tags = ['highway', 'roundabout'],
             title = T_('Roundabout as area'))
-#        self.errors[70401] = self.def_class(item = 7040, level = 2, tags = ['tag', 'power', 'fix:chair'],
-#            title = T_('Bad power line kind'))
         self.errors[32200] = self.def_class(item = 3220, level = 2, tags = ['highway', 'fix:chair'],
             title = T_('Overly permissive access'),
             detail = T_(
@@ -150,9 +148,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
             if (self.driving_side_right and clockwise) or (not self.driving_side_right and anticlockwise):
                 err.append({"class": 1050, "subclass": 1000, "text": T_("mini roundabout direction in this country is usually \"{0}\"", self.driving_direction),
                             "fix": {"-": ["direction"]}})
-#            if (self.driving_side_right and anticlockwise) or (not self.driving_side_right and clockwise):
-#                err.append({"class": 1050, "subclass": 1001, "text": T_("Mini roundabout direction in this country is \"{0}\" by default, useless direction tag", self.driving_direction),
-#                            "fix": {"-": ["direction"]}})
 
         return err
 
@@ -177,15 +172,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
 
         if "highway" in tags and tags.get('junction') == 'roundabout' and tags.get('area') not in (None, 'no', 'false'):
             err.append({"class": 40201, "subclass": 0, "fix": [{"-": ["area"]}, {"-": ["junction"]}]})
-
-#        if tags.get("power") in ("line", "minor_line") and "voltage" in tags:
-#            voltage = map(int, filter(lambda x: x.isdigit(), map(lambda x: x.strip(), tags["voltage"].split(";"))))
-#            if voltage:
-#                voltage = max(voltage)
-#                if voltage > 45000 and tags["power"] == "minor_line":
-#                    err.append({"class": 70401, "subclass": 0, "fix": {"~": {"power": "line"}}})
-#                elif voltage <= 45000 and tags["power"] == "line":
-#                    err.append({"class": 70401, "subclass": 1, "fix": {"~": {"power": "minor_line"}}})
 
         if tags.get("access") in ("yes", "permissive"):
             if tags.get("highway") in ("motorway", "trunk"):
@@ -231,7 +217,6 @@ class Test(TestPluginCommon):
                   {"highway":"primary", "fee": "yes"},
                   {"junction":"roundabout", "waterway": "river"},
                   {"oneway":"yes", "building": "yes"},
-#                  {"power":"line", "voltage": "1"},
                  ]:
             self.check_err(a.way(None, t, None), t)
 

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -92,8 +92,6 @@ separated by traffic islands at an intersection without cross).'''),
 Clockwise rotation.'''))
         self.errors[40201] = self.def_class(item = 4020, level = 1, tags = ['highway', 'roundabout'],
             title = T_('Roundabout as area'))
-        self.errors[21201] = self.def_class(item = 2120, level = 3, tags = ['indoor'],
-            title = T_('Level or repeat_on tag missing'))
         self.errors[21202] = self.def_class(item = 2120, level = 3, tags = ['indoor'],
             title = T_('Indoor or building:part tag missing'))
         self.errors[20802] = self.def_class(item = 2080, level = 2, tags = ['highway'],
@@ -143,9 +141,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = []
         if tags.get("name") and len(key_set & self.name_parent) == 0 and tags.get("naptan:verified") != "no":
             err.append({"class": 21101, "subclass": 1})
-
-        if tags.get("indoor") not in [None, "yes", "no"] and not tags.get("level") and not tags.get("repeat_on"):
-            err.append({"class": 21201, "subclass": 1})
 
         if tags.get("room") and not tags.get("indoor") and not tags.get("buildingpart"):
             err.append({"class": 21202, "subclass": 2, "fix":[{"+": {"indoor": "room"}}, {"+": {"buildingpart": "room"}}]})
@@ -272,8 +267,6 @@ class Test(TestPluginCommon):
         self.check_err(a.way(None, {"waterway": "stream", "level": "-1"}, None))
 
         assert a.way(None, {"area": "yes", "highway": "secondary", "junction": "roundabout"}, None)
-
-        assert a.node(None, {"indoor": "room"})
 
         assert a.node(None, {"room": "office"})
 

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -107,9 +107,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
 This is almost never the case and more specific tags should be used instead. \
 For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:access#Transport_mode_restrictions).'''))
 
-        if not self.country or not self.country.startswith("CZ"):
-            self.errors[32301] = self.def_class(item = 3230, level = 2, tags = ['highway', 'fix:chair'],
-                title = T_('Probably only for bottles, not any type of glass'))
         self.errors[32302] = self.def_class(item = 3230, level = 2, tags = ['highway', 'fix:chair'],
             title = T_('Suspicious name for a container'))
 
@@ -137,10 +134,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = []
         if tags.get("name") and len(key_set & self.name_parent) == 0 and tags.get("naptan:verified") != "no":
             err.append({"class": 21101, "subclass": 1})
-
-        if not self.country or not self.country.startswith("CZ"):
-            if tags.get("amenity") == "recycling" and tags.get("recycling_type") != "centre" and tags.get("recycling:glass") == "yes":
-                err.append({"class": 32301, "fix": {"-": ["recycling:glass"], "+": {"recycling:glass_bottles": "yes"}}})
         if tags.get("amenity") == "recycling" and tags.get("recycling_type") != "centre" and tags.get("name"):
             err.append({"class": 32302})
 
@@ -266,7 +259,6 @@ class Test(TestPluginCommon):
 
         assert a.relation(None, {}, None)
 
-        assert a.node(None, {"amenity": "recycling", "recycling_type": "container", "recycling:glass": "yes"})
         assert a.node(None, {"amenity": "recycling", "recycling_type": "container", "name": "My nice awesome container"})
 
         assert a.node(None, {"barrier": "fence", "material": "wood"})

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -88,8 +88,6 @@ separated by traffic islands at an intersection without cross).'''),
 '''![](https://wiki.openstreetmap.org/w/images/6/68/Osmose-eg-error-1050.png)
 
 Clockwise rotation.'''))
-        self.errors[40201] = self.def_class(item = 4020, level = 1, tags = ['highway', 'roundabout'],
-            title = T_('Roundabout as area'))
         self.errors[32200] = self.def_class(item = 3220, level = 2, tags = ['highway', 'fix:chair'],
             title = T_('Overly permissive access'),
             detail = T_(
@@ -160,9 +158,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         if "waterway" in tags and "level" in tags:
             err.append({"class": 30327, "subclass": 0, "fix": [{"-": ["level"]}, {"-": ["level"], "+": {"layer": tags["level"]}}]})
 
-        if "highway" in tags and tags.get('junction') == 'roundabout' and tags.get('area') not in (None, 'no', 'false'):
-            err.append({"class": 40201, "subclass": 0, "fix": [{"-": ["area"]}, {"-": ["junction"]}]})
-
         if tags.get("access") in ("yes", "permissive"):
             if tags.get("highway") in ("motorway", "trunk"):
                 err.append({"class": 32200, "subclass": 0, "text": T_("Including ski, horse, moped, hazmat and so on, unless explicitly excluded")})
@@ -222,8 +217,6 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"name": "foo", "traffic_sign:forward": "city_limit;DE:310", "traffic_sign:backward": "city_limit;DE:311"})
 
         self.check_err(a.way(None, {"waterway": "stream", "level": "-1"}, None))
-
-        assert a.way(None, {"area": "yes", "highway": "secondary", "junction": "roundabout"}, None)
 
         assert a.way(None, {"highway": "track", "access": "yes"}, None)
         assert a.way(None, {"highway": "trunk", "access": "yes"}, None)

--- a/plugins/TagFix_MultipleTag2.py
+++ b/plugins/TagFix_MultipleTag2.py
@@ -13,7 +13,12 @@ class TagFix_MultipleTag2(PluginMapCSS):
     def init(self, logger):
         super().init(logger)
         tags = capture_tags = {} # noqa
+        self.errors[20802] = self.def_class(item = 2080, level = 2, tags = mapcss.list_('tag') + mapcss.list_('highway'), title = mapcss.tr('Missing tag ref for emergency access point'))
+        self.errors[30320] = self.def_class(item = 3032, level = 1, tags = mapcss.list_('tag') + mapcss.list_('fix:chair', 'highway', 'tag'), title = mapcss.tr('Watch multiple tags'))
         self.errors[30322] = self.def_class(item = 3032, level = 3, tags = mapcss.list_('tag'), title = mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}')))
+        self.errors[32301] = self.def_class(item = 3230, level = 2, tags = mapcss.list_('tag') + mapcss.list_('fix:chair'), title = mapcss.tr('Probably only for bottles, not any type of glass'))
+        self.errors[32302] = self.def_class(item = 3230, level = 2, tags = mapcss.list_('tag') + mapcss.list_('fix:chair'), title = mapcss.tr('Suspicious name for a container'))
+        self.errors[40201] = self.def_class(item = 4020, level = 1, tags = mapcss.list_('tag') + mapcss.list_('fix:chair', 'highway', 'roundabout'), title = mapcss.tr('Roundabout as area'))
 
 
 
@@ -34,6 +39,55 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # -osmoseItemClassLevel:"3032/30322/3"
                 # throwWarning:tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.","{0.tag}","{1.tag}","{0.value}","{1.key}")
                 err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
+
+        # *[highway=emergency_access_point][!ref]
+        if ('highway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'emergency_access_point')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'ref')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway")
+                # -osmoseItemClassLevel:"2080/20802:1/2"
+                # throwWarning:tr("Missing tag ref for emergency access point")
+                err.append({'class': 20802, 'subclass': 1, 'text': mapcss.tr('Missing tag ref for emergency access point')})
+
+        # *[amenity=recycling][recycling_type!=centre][recycling:glass=yes][outside("CZ")]
+        if ('amenity' in keys and 'recycling:glass' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'recycling:glass') == mapcss._value_capture(capture_tags, 2, 'yes')) and (mapcss.outside(self.father.config.options, 'CZ')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32301/2"
+                # throwWarning:tr("Probably only for bottles, not any type of glass")
+                # fixRemove:"recycling:glass"
+                # fixAdd:"recycling:glass_bottles=yes"
+                # -osmoseAssertNoMatchWithContext:list("node amenity=recycling recycling_type=container recycling:glass=yes","inside=CZ")
+                # -osmoseAssertMatchWithContext:list("node amenity=recycling recycling_type=container recycling:glass=yes","inside=FR")
+                err.append({'class': 32301, 'subclass': 0, 'text': mapcss.tr('Probably only for bottles, not any type of glass'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['recycling:glass_bottles','yes']]),
+                    '-': ([
+                    'recycling:glass'])
+                }})
+
+        # *[amenity=recycling][recycling_type!=centre][name]
+        if ('amenity' in keys and 'name' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'name')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32302/2"
+                # throwWarning:tr("Suspicious name for a container")
+                # assertMatch:"node amenity=recycling recycling_type=container name=\"My nice awesome container\""
+                err.append({'class': 32302, 'subclass': 0, 'text': mapcss.tr('Suspicious name for a container')})
 
         return err
 
@@ -56,6 +110,91 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # assertMatch:"way building=roof amenity=fuel"
                 err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
 
+        # *[highway=emergency_access_point][!ref]
+        if ('highway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'emergency_access_point')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'ref')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway")
+                # -osmoseItemClassLevel:"2080/20802:1/2"
+                # throwWarning:tr("Missing tag ref for emergency access point")
+                err.append({'class': 20802, 'subclass': 1, 'text': mapcss.tr('Missing tag ref for emergency access point')})
+
+        # *[amenity=recycling][recycling_type!=centre][recycling:glass=yes][outside("CZ")]
+        if ('amenity' in keys and 'recycling:glass' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'recycling:glass') == mapcss._value_capture(capture_tags, 2, 'yes')) and (mapcss.outside(self.father.config.options, 'CZ')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32301/2"
+                # throwWarning:tr("Probably only for bottles, not any type of glass")
+                # fixRemove:"recycling:glass"
+                # fixAdd:"recycling:glass_bottles=yes"
+                err.append({'class': 32301, 'subclass': 0, 'text': mapcss.tr('Probably only for bottles, not any type of glass'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['recycling:glass_bottles','yes']]),
+                    '-': ([
+                    'recycling:glass'])
+                }})
+
+        # *[amenity=recycling][recycling_type!=centre][name]
+        if ('amenity' in keys and 'name' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'name')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32302/2"
+                # throwWarning:tr("Suspicious name for a container")
+                err.append({'class': 32302, 'subclass': 0, 'text': mapcss.tr('Suspicious name for a container')})
+
+        # way[highway][fee]
+        if ('fee' in keys and 'highway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'fee')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # group:tr("Watch multiple tags")
+                # -osmoseTags:list("fix:chair","highway","tag")
+                # -osmoseItemClassLevel:"3032/30320:1000/1"
+                # throwWarning:tr("Use tag \"toll\" instead of \"fee\"")
+                # fixChangeKey:"fee=>toll"
+                # assertMatch:"way highway=primary fee=yes"
+                err.append({'class': 30320, 'subclass': 1000, 'text': mapcss.tr('Use tag "toll" instead of "fee"'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['toll', mapcss.tag(tags, 'fee')]]),
+                    '-': ([
+                    'fee'])
+                }})
+
+        # way[highway][junction=roundabout][area][area!=no]
+        if ('area' in keys and 'highway' in keys and 'junction' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'junction') == mapcss._value_capture(capture_tags, 1, 'roundabout')) and (mapcss._tag_capture(capture_tags, 2, tags, 'area')) and (mapcss._tag_capture(capture_tags, 3, tags, 'area') != mapcss._value_const_capture(capture_tags, 3, 'no', 'no')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair","highway","roundabout")
+                # -osmoseItemClassLevel:"4020/40201:0/1"
+                # throwWarning:tr("Roundabout as area")
+                # fixRemove:"area"
+                # assertMatch:"way area=yes highway=secondary junction=roundabout"
+                err.append({'class': 40201, 'subclass': 0, 'text': mapcss.tr('Roundabout as area'), 'allow_fix_override': True, 'fix': {
+                    '-': ([
+                    'area'])
+                }})
+
         return err
 
     def relation(self, data, tags, members):
@@ -76,6 +215,52 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # throwWarning:tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.","{0.tag}","{1.tag}","{0.value}","{1.key}")
                 err.append({'class': 30322, 'subclass': 0, 'text': mapcss.tr('{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
 
+        # *[highway=emergency_access_point][!ref]
+        if ('highway' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway') == mapcss._value_capture(capture_tags, 0, 'emergency_access_point')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'ref')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway")
+                # -osmoseItemClassLevel:"2080/20802:1/2"
+                # throwWarning:tr("Missing tag ref for emergency access point")
+                err.append({'class': 20802, 'subclass': 1, 'text': mapcss.tr('Missing tag ref for emergency access point')})
+
+        # *[amenity=recycling][recycling_type!=centre][recycling:glass=yes][outside("CZ")]
+        if ('amenity' in keys and 'recycling:glass' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'recycling:glass') == mapcss._value_capture(capture_tags, 2, 'yes')) and (mapcss.outside(self.father.config.options, 'CZ')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32301/2"
+                # throwWarning:tr("Probably only for bottles, not any type of glass")
+                # fixRemove:"recycling:glass"
+                # fixAdd:"recycling:glass_bottles=yes"
+                err.append({'class': 32301, 'subclass': 0, 'text': mapcss.tr('Probably only for bottles, not any type of glass'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['recycling:glass_bottles','yes']]),
+                    '-': ([
+                    'recycling:glass'])
+                }})
+
+        # *[amenity=recycling][recycling_type!=centre][name]
+        if ('amenity' in keys and 'name' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'recycling')) and (mapcss._tag_capture(capture_tags, 1, tags, 'recycling_type') != mapcss._value_const_capture(capture_tags, 1, 'centre', 'centre')) and (mapcss._tag_capture(capture_tags, 2, tags, 'name')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("fix:chair")
+                # -osmoseItemClassLevel:"3230/32302/2"
+                # throwWarning:tr("Suspicious name for a container")
+                err.append({'class': 32302, 'subclass': 0, 'text': mapcss.tr('Suspicious name for a container')})
+
         return err
 
 
@@ -93,4 +278,11 @@ class Test(TestPluginMapcss):
         n.init(None)
         data = {'id': 0, 'lat': 0, 'lon': 0}
 
+        with with_options(n, {'country': 'CZ'}):
+            self.check_not_err(n.node(data, {'amenity': 'recycling', 'recycling:glass': 'yes', 'recycling_type': 'container'}), expected={'class': 32301, 'subclass': 0})
+        with with_options(n, {'country': 'FR'}):
+            self.check_err(n.node(data, {'amenity': 'recycling', 'recycling:glass': 'yes', 'recycling_type': 'container'}), expected={'class': 32301, 'subclass': 0})
+        self.check_err(n.node(data, {'amenity': 'recycling', 'name': 'My nice awesome container', 'recycling_type': 'container'}), expected={'class': 32302, 'subclass': 0})
         self.check_err(n.way(data, {'amenity': 'fuel', 'building': 'roof'}, [0]), expected={'class': 30322, 'subclass': 0})
+        self.check_err(n.way(data, {'fee': 'yes', 'highway': 'primary'}, [0]), expected={'class': 30320, 'subclass': 1000})
+        self.check_err(n.way(data, {'area': 'yes', 'highway': 'secondary', 'junction': 'roundabout'}, [0]), expected={'class': 40201, 'subclass': 0})

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -42,3 +42,14 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
     -osmoseItemClassLevel: "2080/20802:1/2";
     -osmoseTags: list("highway");
 }
+
+
+*[amenity=recycling][recycling_type!=centre][recycling:glass=yes][outside("CZ")] {
+    throwWarning: tr("Probably only for bottles, not any type of glass");
+    fixAdd: "recycling:glass_bottles=yes";
+    fixRemove: "recycling:glass";
+    -osmoseItemClassLevel: "3230/32301/2";
+    -osmoseTags: list("fix:chair");
+    -osmoseAssertMatchWithContext: list("node amenity=recycling recycling_type=container recycling:glass=yes", "inside=FR");
+    -osmoseAssertNoMatchWithContext: list("node amenity=recycling recycling_type=container recycling:glass=yes", "inside=CZ");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -72,3 +72,13 @@ way[highway][fee] {
     -osmoseItemClassLevel: "3032/30320:1000/1";
     -osmoseTags: list("fix:chair", "highway", "tag");
 }
+
+
+way[highway][junction=roundabout][area][area!=no] {
+    /* Note: partial duplicate of JOSM rule */
+    throwWarning: tr("Roundabout as area");
+    assertMatch: "way area=yes highway=secondary junction=roundabout";
+    fixRemove: "area";
+    -osmoseItemClassLevel: "4020/40201:0/1";
+    -osmoseTags: list("fix:chair", "highway", "roundabout");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -62,3 +62,13 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
     -osmoseItemClassLevel: "3230/32302/2";
     -osmoseTags: list("fix:chair");
 }
+
+
+way[highway][fee] {
+    throwWarning: tr("Use tag \"toll\" instead of \"fee\"");
+    group: tr("Watch multiple tags");
+    assertMatch: "way highway=primary fee=yes";
+    fixChangeKey: "fee=>toll";
+    -osmoseItemClassLevel: "3032/30320:1000/1";
+    -osmoseTags: list("fix:chair", "highway", "tag");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -31,7 +31,14 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
 
 /* Amenities are not typically not located on/in a roof, but underneath */
 *[building=roof][amenity][amenity!=shelter] {
-  throwWarning: tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.", "{0.tag}", "{1.tag}", "{0.value}", "{1.key}");
-  assertMatch: "way building=roof amenity=fuel";
-  -osmoseItemClassLevel: "3032/30322/3";
+    throwWarning: tr("{0} together with {1}, usually {1} is located underneath the {2}. Tag the {3} as a separate object.", "{0.tag}", "{1.tag}", "{0.value}", "{1.key}");
+    assertMatch: "way building=roof amenity=fuel";
+    -osmoseItemClassLevel: "3032/30322/3";
+}
+
+
+*[highway=emergency_access_point][!ref] {
+    throwWarning: tr("Missing tag ref for emergency access point");
+    -osmoseItemClassLevel: "2080/20802:1/2";
+    -osmoseTags: list("highway");
 }

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -53,3 +53,12 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
     -osmoseAssertMatchWithContext: list("node amenity=recycling recycling_type=container recycling:glass=yes", "inside=FR");
     -osmoseAssertNoMatchWithContext: list("node amenity=recycling recycling_type=container recycling:glass=yes", "inside=CZ");
 }
+
+
+*[amenity=recycling][recycling_type!=centre][name] {
+    /* Note: duplicate of JOSM rule */
+    throwWarning: tr("Suspicious name for a container");
+    assertMatch: "node amenity=recycling recycling_type=container name=\"My nice awesome container\"";
+    -osmoseItemClassLevel: "3230/32302/2";
+    -osmoseTags: list("fix:chair");
+}

--- a/plugins/indoor.py
+++ b/plugins/indoor.py
@@ -16,6 +16,8 @@ class indoor(PluginMapCSS):
         self.errors[50] = self.def_class(item = 1300, level = 3, tags = mapcss.list_('indoor', 'geom') + mapcss.list_('fix:survey'), title = mapcss.tr('This indoor feature should be a closed and valid polygon'))
         self.errors[51] = self.def_class(item = 1300, level = 3, tags = mapcss.list_('indoor', 'geom') + mapcss.list_('fix:survey'), title = mapcss.tr('This indoor feature should have a level'))
         self.errors[52] = self.def_class(item = 1300, level = 3, tags = mapcss.list_('indoor', 'geom') + mapcss.list_('fix:survey', 'shop'), title = mapcss.tr('This indoor shop should probably be inside a room'))
+        self.errors[21201] = self.def_class(item = 2120, level = 3, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('`{0}` without `{1}` or `{2}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[21202] = self.def_class(item = 2120, level = 3, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')))
 
         self.re_2a047336 = re.compile(r'room|corridor|area|level')
 
@@ -45,6 +47,36 @@ class indoor(PluginMapCSS):
                 # -osmoseAssertMatchWithContext:list("node indoor=room","inside=FR")
                 # -osmoseAssertMatchWithContext:list("node room=shop","inside=DE")
                 err.append({'class': 50, 'subclass': 0, 'text': mapcss.tr('This indoor feature should be a closed and valid polygon')})
+
+        # *[indoor][!level][!repeat_on][indoor!=yes][indoor!=no]
+        if ('indoor' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'level')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'repeat_on')) and (mapcss._tag_capture(capture_tags, 3, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 3, 'yes', 'yes')) and (mapcss._tag_capture(capture_tags, 4, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 4, 'no', 'no')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21201:1/3"
+                # throwWarning:tr("`{0}` without `{1}` or `{2}`","{0.tag}","{1.key}","{2.key}")
+                # assertMatch:"node indoor=room"
+                err.append({'class': 21201, 'subclass': 1, 'text': mapcss.tr('`{0}` without `{1}` or `{2}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # *[room][!indoor][!buildingpart]
+        if ('room' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21202:2/3"
+                # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
+                # fixAdd:"indoor=room"
+                # assertMatch:"node room=office"
+                err.append({'class': 21202, 'subclass': 2, 'text': mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['indoor','room']])
+                }})
 
         return err
 
@@ -112,6 +144,70 @@ class indoor(PluginMapCSS):
                     ['indoor','room']])
                 }})
 
+        # *[indoor][!level][!repeat_on][indoor!=yes][indoor!=no]
+        if ('indoor' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'level')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'repeat_on')) and (mapcss._tag_capture(capture_tags, 3, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 3, 'yes', 'yes')) and (mapcss._tag_capture(capture_tags, 4, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 4, 'no', 'no')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21201:1/3"
+                # throwWarning:tr("`{0}` without `{1}` or `{2}`","{0.tag}","{1.key}","{2.key}")
+                err.append({'class': 21201, 'subclass': 1, 'text': mapcss.tr('`{0}` without `{1}` or `{2}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # *[room][!indoor][!buildingpart]
+        if ('room' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21202:2/3"
+                # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
+                # fixAdd:"indoor=room"
+                err.append({'class': 21202, 'subclass': 2, 'text': mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['indoor','room']])
+                }})
+
+        return err
+
+    def relation(self, data, tags, members):
+        capture_tags = {}
+        keys = tags.keys()
+        err = []
+
+
+        # *[indoor][!level][!repeat_on][indoor!=yes][indoor!=no]
+        if ('indoor' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'level')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'repeat_on')) and (mapcss._tag_capture(capture_tags, 3, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 3, 'yes', 'yes')) and (mapcss._tag_capture(capture_tags, 4, tags, 'indoor') != mapcss._value_const_capture(capture_tags, 4, 'no', 'no')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21201:1/3"
+                # throwWarning:tr("`{0}` without `{1}` or `{2}`","{0.tag}","{1.key}","{2.key}")
+                err.append({'class': 21201, 'subclass': 1, 'text': mapcss.tr('`{0}` without `{1}` or `{2}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+
+        # *[room][!indoor][!buildingpart]
+        if ('room' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseItemClassLevel:"2120/21202:2/3"
+                # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
+                # fixAdd:"indoor=room"
+                err.append({'class': 21202, 'subclass': 2, 'text': mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['indoor','room']])
+                }})
+
         return err
 
 
@@ -133,6 +229,8 @@ class Test(TestPluginMapcss):
             self.check_err(n.node(data, {'indoor': 'room'}), expected={'class': 50, 'subclass': 0})
         with with_options(n, {'country': 'DE'}):
             self.check_err(n.node(data, {'room': 'shop'}), expected={'class': 50, 'subclass': 0})
+        self.check_err(n.node(data, {'indoor': 'room'}), expected={'class': 21201, 'subclass': 1})
+        self.check_err(n.node(data, {'room': 'office'}), expected={'class': 21202, 'subclass': 2})
         with with_options(n, {'country': 'DE'}):
             self.check_not_err(n.way(data, {'indoor': 'room', 'level': '-0.5'}, [0]), expected={'class': 51, 'subclass': 0})
         with with_options(n, {'country': 'FR'}):

--- a/plugins/indoor.validator.mapcss
+++ b/plugins/indoor.validator.mapcss
@@ -77,7 +77,14 @@ way:closed[indoor=corridor][shop][inside("DE,CH,FR")] {
 
 
 *[indoor][!level][!repeat_on][indoor!=yes][indoor!=no] {
-  throwWarning: tr("`{0}` without `{1}` or `{2}`", "{0.tag}", "{1.key}", "{2.key}");
-	-osmoseItemClassLevel: "2120/21201:1/3";
-	assertMatch: "node indoor=room";
+    throwWarning: tr("`{0}` without `{1}` or `{2}`", "{0.tag}", "{1.key}", "{2.key}");
+    -osmoseItemClassLevel: "2120/21201:1/3";
+    assertMatch: "node indoor=room";
+}
+
+*[room][!indoor][!buildingpart] {
+    throwWarning: tr("`{0}` without `{1}`", "{0.tag}", "{1.key}");
+    -osmoseItemClassLevel: "2120/21202:2/3";
+    fixAdd: "indoor=room";
+    assertMatch: "node room=office";
 }

--- a/plugins/indoor.validator.mapcss
+++ b/plugins/indoor.validator.mapcss
@@ -74,3 +74,10 @@ way:closed[indoor=corridor][shop][inside("DE,CH,FR")] {
     -osmoseAssertMatchWithContext: list("way indoor=corridor shop=tickets", "inside=FR");
     -osmoseAssertNoMatchWithContext: list("way indoor=room room=shop shop=florist", "inside=DE");
 }
+
+
+*[indoor][!level][!repeat_on][indoor!=yes][indoor!=no] {
+  throwWarning: tr("`{0}` without `{1}` or `{2}`", "{0.tag}", "{1.key}", "{2.key}");
+	-osmoseItemClassLevel: "2120/21201:1/3";
+	assertMatch: "node indoor=room";
+}


### PR DESCRIPTION
See https://github.com/osm-fr/osmose-backend/issues/1761#issuecomment-1434571780 : 

### Convert simple rules from TagFix_Multiple to mapcss rules ### 
(which can be loaded in JOSM and area probably also easier to maintain) 


Exceptions:
I did not touch the following simple ones:

- Because I kind-of disagree with the rule 😉 :
```py
        if tags.get("barrier") == "fence" and "fence_type" not in tags and "material" in tags:
            err.append({"class": 303210})
```

- Because it seems that we're missing a lot of exceptions, compared to [JOSM's very similar rule](https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/combinations.mapcss#L496)
```py
if (tags.get("tracktype") or tags.get("lanes")) and not tags.get("highway") and not tags.get("disused:highway") and not tags.get("abandoned:highway") and not tags.get("construction:highway") and not tags.get("proposed:highway") and not tags.get("planned:highway") and not tags.get("leisure") == "track":
            err.append({"class": 20803})
```

- And a couple because the python code has `detail`, `fix` or `trap` text, which would be lost if I go to mapcss


Additionally I made the following modifications:
- dropped `buildingpart` from the fix suggestions as it's considered a tagging mistake on the wiki 
- removed tag `highway` from the `amenity=recycling` rules
- Slightly modified the text of the two indoor rules to make sure it's clear we're talking about key names, not words that should be translated