### PR TITLE
Disable warning / bad fix suggestion for highway=* + fee=* + amenity=*

### DIFF
--- a/plugins/TagFix_MultipleTag2.py
+++ b/plugins/TagFix_MultipleTag2.py
@@ -156,12 +156,12 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # throwWarning:tr("Suspicious name for a container")
                 err.append({'class': 32302, 'subclass': 0, 'text': mapcss.tr('Suspicious name for a container')})
 
-        # way[highway][fee]
+        # way[highway][fee][!amenity][!leisure]
         if ('fee' in keys and 'highway' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'fee')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'fee')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'amenity')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'leisure')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("Watch multiple tags")
@@ -170,6 +170,7 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # throwWarning:tr("Use tag \"toll\" instead of \"fee\"")
                 # fixChangeKey:"fee=>toll"
                 # assertMatch:"way highway=primary fee=yes"
+                # assertNoMatch:"way highway=service fee=yes amenity=weighbridge"
                 err.append({'class': 30320, 'subclass': 1000, 'text': mapcss.tr('Use tag "toll" instead of "fee"'), 'allow_fix_override': True, 'fix': {
                     '+': dict([
                     ['toll', mapcss.tag(tags, 'fee')]]),
@@ -285,4 +286,5 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'amenity': 'recycling', 'name': 'My nice awesome container', 'recycling_type': 'container'}), expected={'class': 32302, 'subclass': 0})
         self.check_err(n.way(data, {'amenity': 'fuel', 'building': 'roof'}, [0]), expected={'class': 30322, 'subclass': 0})
         self.check_err(n.way(data, {'fee': 'yes', 'highway': 'primary'}, [0]), expected={'class': 30320, 'subclass': 1000})
+        self.check_not_err(n.way(data, {'amenity': 'weighbridge', 'fee': 'yes', 'highway': 'service'}, [0]), expected={'class': 30320, 'subclass': 1000})
         self.check_err(n.way(data, {'area': 'yes', 'highway': 'secondary', 'junction': 'roundabout'}, [0]), expected={'class': 40201, 'subclass': 0})

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -64,10 +64,11 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
 }
 
 
-way[highway][fee] {
+way[highway][fee][!amenity][!leisure] {
     throwWarning: tr("Use tag \"toll\" instead of \"fee\"");
     group: tr("Watch multiple tags");
     assertMatch: "way highway=primary fee=yes";
+    assertNoMatch: "way highway=service fee=yes amenity=weighbridge";
     fixChangeKey: "fee=>toll";
     -osmoseItemClassLevel: "3032/30320:1000/1";
     -osmoseTags: list("fix:chair", "highway", "tag");


### PR DESCRIPTION
See #1769
Bad combinations of `highway` and `amenity` or `leisure` are already handled by TagRemove_Incompatibles, so it is very likely that the wrong warning is shown: the key `fee` probably refers to the amenity/leisure, rather than the highway, and hence conversion to `toll` would lead to wrong fixes. 
TagRemove_Incompatibles will give a warning that the tags should not be combined