### PR TITLE
Add missing `-osmoseExample`

### DIFF
--- a/doc/2-PluginMapCSS.md
+++ b/doc/2-PluginMapCSS.md
@@ -223,15 +223,16 @@ If required, a sub class id can also be defined with `[class]:[subclass]`:
     -osmoseItemClassLevel: "4030/40301:887554/2";
 ```
 
-Additionally, the following three properties can be used to give extra information regarding an issue:
+Additionally, the following four properties can be used to give extra information regarding an issue:
 ```css
-    -osmoseDetail: "message containing extra details about the issue";
-    -osmoseFix: "message containing a description of how to fix an issue";
-    -osmoseTrap: "message warning about potential mistakes";
+    -osmoseDetail: "Message containing extra details about the issue.";
+    -osmoseExample: "Message containing an example related to the issue.";
+    -osmoseFix: "Message containing a description of how to fix an issue.";
+    -osmoseTrap: "Message warning about potential mistakes.";
 ```
 These are purely textual and will not affect any auto-fix. They support translations, placeholders and markdown formatting. For example:
 ```css
-    -osmoseFix: tr("Create two separate objects, one with `{0}` and one with `{1}`", "highway=*", "building=*");
+    -osmoseFix: tr("Create two separate objects, one with `{0}` and one with `{1}`.", "highway=*", "building=*");
 ```
 
 Lastly, one can add a link to a relevant webpage with additional resources (such as the wiki) using the extension `-osmoseResource`:
@@ -239,7 +240,7 @@ Lastly, one can add a link to a relevant webpage with additional resources (such
     -osmoseResource: "https://wiki.openstreetmap.org/wiki/Useful_Page";
 ```
 
-Note that `-osmoseTags`, `-osmoseDetail`, `-osmoseFix`, `-osmoseTrap` and `-osmoseResource` apply to all rules that share the same class.
+Note that `-osmoseTags`, `-osmoseDetail`, `-osmoseExample`, `-osmoseFix`, `-osmoseTrap` and `-osmoseResource` apply to all rules that share the same class.
 
 ### Set, define MapCSS class
 

--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -226,6 +226,7 @@ rule_declarations_order_map = {
     '-osmoseDetail': 2,
     '-osmoseTrap': 2,
     '-osmoseFix': 2,
+    '-osmoseExample': 2,
     '-osmoseResource': 2,
     # text
     'throwError': 3,
@@ -646,7 +647,7 @@ def to_p(t):
         elif t['property'] == '-osmoseItemClassLevel':
             item, class_id, level = t['value']['value']['value'].split('/')
             item, class_id, subclass_id, level = int(item), int(class_id.split(':')[0]), ':' in class_id and int(class_id.split(':')[1]), int(level)
-        elif t['property'] in ('-osmoseDetail', '-osmoseTrap', '-osmoseFix', '-osmoseResource'):
+        elif t['property'] in ('-osmoseDetail', '-osmoseTrap', '-osmoseFix', '-osmoseResource', '-osmoseExample'):
             whichMsg = t['property'][7:].lower()
             text = to_p(t['value'])
             if t['value']['type'] == 'functionExpression' and t['value']['name'] == 'mapcss.tr':
@@ -654,7 +655,7 @@ def to_p(t):
             elif whichMsg == 'resource':
                 class_info_text[whichMsg] = text # hyperlink as string, no need for language
             else:
-                class_info_text[whichMsg] = '{"en": "' + text + '"}'
+                class_info_text[whichMsg] = '{"en": ' + text + '}'
         elif t['property'] in ('throwError', 'throwWarning', 'throwOther'):
             text = to_p(t['value'])
             text_class = t['value']['params'][0] if t['value']['type'] == 'functionExpression' and t['value']['name'] == 'mapcss.tr' else t['value']

--- a/plugins/Josm_geometry.py
+++ b/plugins/Josm_geometry.py
@@ -275,6 +275,7 @@ class Josm_geometry(PluginMapCSS):
         # node[natural=sand]
         # node[natural=scree]
         # node[natural=scrub]
+        # node[natural=shrubbery]
         # node[natural=water]
         # node[natural=wetland]
         # node[natural=wood]
@@ -356,6 +357,10 @@ class Josm_geometry(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'natural') == mapcss._value_capture(capture_tags, 0, 'shrubbery')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
                 try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'natural') == mapcss._value_capture(capture_tags, 0, 'water')))
                 except mapcss.RuleAbort: pass
             if not match:
@@ -408,7 +413,7 @@ class Josm_geometry(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if match:
                 # throwWarning:tr("{0} on a node. Should be drawn as an area.","{0.tag}")
-                err.append({'class': 9003003, 'subclass': 628017354, 'text': mapcss.tr('{0} on a node. Should be drawn as an area.', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 9003003, 'subclass': 916650129, 'text': mapcss.tr('{0} on a node. Should be drawn as an area.', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # node[type=multipolygon]
         # node[interval]

--- a/plugins/tests/test_mapcss_parsing_evalutation.py
+++ b/plugins/tests/test_mapcss_parsing_evalutation.py
@@ -28,9 +28,9 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
         self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
         self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
         self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
-        self.errors[97] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), fix = {"en": "'This may fix it.'"}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
+        self.errors[97] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
         self.errors[98] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
-        self.errors[99] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), fix = {"en": "'This may fix it.'"}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
+        self.errors[99] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
 
         self.re_3d3faeb5 = re.compile(r'(?i).*Straße.*')
         self.re_49048f80 = re.compile(r'd')
@@ -421,13 +421,21 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # -osmoseTags:list("osmose_rules")
                 # -osmoseTrap:tr("Don't do this!")
                 # -osmoseDetail:tr("More {0}.","`info`")
+                # -osmoseExample:"Look at me, I haven't lost my apostrophe"
                 # -osmoseItemClassLevel:"4/97:2/1"
                 # -osmoseFix:"This may fix it."
                 # -osmoseResource:"https://wiki.openstreetmap.org/wiki/Useful_Page"
                 # throwOther:tr("test")
+                # fixRemove:"x"
+                # fixAdd:"y=z"
                 # assertMatch:"way x=yes"
                 # assertNoMatch:"way y=yes"
-                err.append({'class': 97, 'subclass': 2, 'text': mapcss.tr('test')})
+                err.append({'class': 97, 'subclass': 2, 'text': mapcss.tr('test'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['y','z']]),
+                    '-': ([
+                    'x'])
+                }})
 
         # way[x]
         if ('x' in keys):
@@ -441,13 +449,21 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # -osmoseTags:list("osmose_rules")
                 # -osmoseTrap:tr("Don't do this!")
                 # -osmoseDetail:tr("More {0}.","`info`")
+                # -osmoseExample:"Look at me, I haven't lost my apostrophe"
                 # -osmoseItemClassLevel:"4/99:2/1"
                 # -osmoseFix:"This may fix it."
                 # -osmoseResource:"https://wiki.openstreetmap.org/wiki/Useful_Page"
                 # throwOther:tr("test")
+                # fixRemove:"x"
+                # fixAdd:"y=z"
                 # assertMatch:"way x=yes"
                 # assertNoMatch:"way y=yes"
-                err.append({'class': 99, 'subclass': 2, 'text': mapcss.tr('test')})
+                err.append({'class': 99, 'subclass': 2, 'text': mapcss.tr('test'), 'allow_fix_override': True, 'fix': {
+                    '+': dict([
+                    ['y','z']]),
+                    '-': ([
+                    'x'])
+                }})
 
         # way[maxspeed>5000]
         if ('maxspeed' in keys):

--- a/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
@@ -154,9 +154,12 @@ way[x] {
   -osmoseItemClassLevel: "4/97:2/1";
   -osmoseTags: list("osmose_rules");
   -osmoseTrap: tr("Don't do this!");
+  -osmoseExample: "Look at me, I haven't lost my apostrophe";
   -osmoseDetail: tr("More {0}.", "`info`");
   -osmoseFix: "This may fix it.";
   -osmoseResource: "https://wiki.openstreetmap.org/wiki/Useful_Page";
+  fixAdd: "y=z";
+  fixRemove: "x";
   throwOther: tr("test");
   group: tr("test");
   assertMatch: "way x=yes";
@@ -168,9 +171,12 @@ way[x] {
   assertMatch: "way x=yes";
   group: tr("test");
   throwOther: tr("test");
+  fixRemove: "x";
+  fixAdd: "y=z";
   -osmoseResource: "https://wiki.openstreetmap.org/wiki/Useful_Page";
   -osmoseFix: "This may fix it.";
   -osmoseDetail: tr("More {0}.", "`info`");
+  -osmoseExample: "Look at me, I haven't lost my apostrophe";
   -osmoseTrap: tr("Don't do this!");
   -osmoseTags: list("osmose_rules");
   -osmoseItemClassLevel: "4/99:2/1";


### PR DESCRIPTION
This implements the `example` key which I forgot earlier. Fixes #1598
Also fixes a minor bug where, if `tr(...)` is not used, additional `'` would be printed around the text (as the parsed text already contains quotes)