### PR TITLE
Convert 'simple' TagFix_Multiple to mapcss (part 2)

### DIFF
--- a/mapcss/item_map.py
+++ b/mapcss/item_map.py
@@ -156,6 +156,7 @@ item_map = \
                             '{0} on a relation without {1}': 9001003},
                   'item': 9001,
                   'prefix': 'Josm_',
+                  'subclass_blacklist': [643796350, 317760248],
                   'tags': ['tag'],
                   'url': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/combinations.mapcss?format=txt',
                   'url_display': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/combinations.mapcss'},

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -38,12 +38,6 @@ class TagFix_MultipleTag(Plugin):
             trap = T_('Remove level and check if layer is needed instead'))
         self.errors[303210] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Fence with material tag, better use fence_type tag'))
-        self.errors[20800] = self.def_class(item = 2080, level = 1, tags = ['tag', 'highway', 'roundabout', 'fix:chair'],
-            title = T_('Tag highway missing on junction'),
-            detail = T_(
-'''The way has a tag `junction=*` but without `highway=*`.'''),
-            trap = T_(
-'''Check if it is really a highway and it is not already mapped.'''))
         self.errors[20801] = self.def_class(item = 2080, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Tag highway missing on oneway'),
             detail = T_(
@@ -146,8 +140,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         key_set = set(tags.keys())
         err = self.common(tags, key_set)
 
-        if tags.get("junction") not in (None, "yes") and u"highway" not in tags and "area:highway" not in tags:
-            err.append({"class": 20800, "subclass": 0})
 
         if u"oneway" in tags and not (u"highway" in tags or u"railway" in tags or u"aerialway" in tags or u"waterway" in tags or u"aeroway" in tags or u"piste:type" in tags):
             err.append({"class": 20801, "subclass": 0})
@@ -199,13 +191,11 @@ class Test(TestPluginCommon):
             self.check_err(a.node(None, t), t)
 
         for t in [{"highway":"primary", "tunnel": "yes"},
-                  {"junction":"roundabout", "waterway": "river"},
                   {"oneway":"yes", "building": "yes"},
                  ]:
             self.check_err(a.way(None, t, None), t)
 
         for t in [{"highway":"", "cycleway": "opposite", "oneway": "yes"},
-                  {"junction": "yes"},
                  ]:
             assert not a.way(None, t, None), t
 

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -38,12 +38,6 @@ class TagFix_MultipleTag(Plugin):
             trap = T_('Remove level and check if layer is needed instead'))
         self.errors[303210] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Fence with material tag, better use fence_type tag'))
-        self.errors[20801] = self.def_class(item = 2080, level = 1, tags = ['tag', 'highway', 'fix:chair'],
-            title = T_('Tag highway missing on oneway'),
-            detail = T_(
-'''The way has a tag `oneway=*` but without `highway=*`.'''),
-            trap = T_(
-'''Check if it is really a highway and it is not already mapped.'''))
         self.errors[20803] = self.def_class(item = 2080, level = 2, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Tag highway missing for tracktype or lanes'))
         self.errors[71301] = self.def_class(item = 7130, level = 3, tags = ['tag', 'highway', 'maxheight', 'fix:survey'],
@@ -141,9 +135,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         err = self.common(tags, key_set)
 
 
-        if u"oneway" in tags and not (u"highway" in tags or u"railway" in tags or u"aerialway" in tags or u"waterway" in tags or u"aeroway" in tags or u"piste:type" in tags):
-            err.append({"class": 20801, "subclass": 0})
-
         if tags.get("highway") in ("motorway_link", "trunk_link", "primary", "primary_link", "secondary", "secondary_link") and not "maxheight" in tags and not "maxheight:physical" in tags and (("tunnel" in tags and tags["tunnel"] != "no") or tags.get("covered") not in (None, "no")):
             err.append({"class": 71301, "subclass": 0})
 
@@ -191,13 +182,8 @@ class Test(TestPluginCommon):
             self.check_err(a.node(None, t), t)
 
         for t in [{"highway":"primary", "tunnel": "yes"},
-                  {"oneway":"yes", "building": "yes"},
                  ]:
             self.check_err(a.way(None, t, None), t)
-
-        for t in [{"highway":"", "cycleway": "opposite", "oneway": "yes"},
-                 ]:
-            assert not a.way(None, t, None), t
 
         assert a.node(None, {"name": "foo"})
         assert not a.node(None, {"name": "foo", "disused:highway": "bar"})

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -36,11 +36,6 @@ class TagFix_MultipleTag(Plugin):
             title = T_('Fence with material tag, better use fence_type tag'))
         self.errors[20803] = self.def_class(item = 2080, level = 2, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Tag highway missing for tracktype or lanes'))
-        self.errors[71301] = self.def_class(item = 7130, level = 3, tags = ['tag', 'highway', 'maxheight', 'fix:survey'],
-            title = T_('Missing maxheight tag'),
-            detail = T_(
-'''Missing `maxheight=*` or `maxheight:*` for a tunnel or a way under a
-bridge.'''))
         self.errors[21101] = self.def_class(item = 2110, level = 2, tags = ['tag'],
             title = T_('Untagged named object'),
             detail = T_('The object is missing any tag which defines what kind of feature it is. This is unexpected for something with a `name` tag.'),
@@ -126,10 +121,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         key_set = set(tags.keys())
         err = self.common(tags, key_set)
 
-
-        if tags.get("highway") in ("motorway_link", "trunk_link", "primary", "primary_link", "secondary", "secondary_link") and not "maxheight" in tags and not "maxheight:physical" in tags and (("tunnel" in tags and tags["tunnel"] != "no") or tags.get("covered") not in (None, "no")):
-            err.append({"class": 71301, "subclass": 0})
-
         if tags.get("access") in ("yes", "permissive"):
             if tags.get("highway") in ("motorway", "trunk"):
                 err.append({"class": 32200, "subclass": 0, "text": T_("Including ski, horse, moped, hazmat and so on, unless explicitly excluded")})
@@ -166,10 +157,6 @@ class Test(TestPluginCommon):
         for d in ["clockwise"]:
             t = {"highway":"mini_roundabout", "direction":d}
             self.check_err(a.node(None, t), t)
-
-        for t in [{"highway":"primary", "tunnel": "yes"},
-                 ]:
-            self.check_err(a.way(None, t, None), t)
 
         assert a.node(None, {"name": "foo"})
         assert not a.node(None, {"name": "foo", "disused:highway": "bar"})

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -32,10 +32,6 @@ class TagFix_MultipleTag(Plugin):
 
         self.errors[30323] = self.def_class(item = 3032, level = 3, tags = ['tag', 'fix:chair'],
             title = T_('Watch multiple tags'))
-        self.errors[30327] = self.def_class(item = 3032, level = 2, tags = ['tag', 'fix:chair'],
-            title = T_('Waterway with level'),
-            detail = T_('Level should be used for buildings, shops, amenities, etc.'),
-            trap = T_('Remove level and check if layer is needed instead'))
         self.errors[303210] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway', 'fix:chair'],
             title = T_('Fence with material tag, better use fence_type tag'))
         self.errors[20803] = self.def_class(item = 2080, level = 2, tags = ['tag', 'highway', 'fix:chair'],
@@ -138,9 +134,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
         if tags.get("highway") in ("motorway_link", "trunk_link", "primary", "primary_link", "secondary", "secondary_link") and not "maxheight" in tags and not "maxheight:physical" in tags and (("tunnel" in tags and tags["tunnel"] != "no") or tags.get("covered") not in (None, "no")):
             err.append({"class": 71301, "subclass": 0})
 
-        if "waterway" in tags and "level" in tags:
-            err.append({"class": 30327, "subclass": 0, "fix": [{"-": ["level"]}, {"-": ["level"], "+": {"layer": tags["level"]}}]})
-
         if tags.get("access") in ("yes", "permissive"):
             if tags.get("highway") in ("motorway", "trunk"):
                 err.append({"class": 32200, "subclass": 0, "text": T_("Including ski, horse, moped, hazmat and so on, unless explicitly excluded")})
@@ -191,8 +184,6 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"name": "foo", "historic:railway": "station"})
         assert not a.node(None, {"name": "foo", "building:part": "yes"})
         assert not a.node(None, {"name": "foo", "traffic_sign:forward": "city_limit;DE:310", "traffic_sign:backward": "city_limit;DE:311"})
-
-        self.check_err(a.way(None, {"waterway": "stream", "level": "-1"}, None))
 
         assert a.way(None, {"highway": "track", "access": "yes"}, None)
         assert a.way(None, {"highway": "trunk", "access": "yes"}, None)

--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -49,10 +49,6 @@ bridge.'''))
                 {'en': ', '.join(map(lambda x: '`{}`'.format(x), sorted(main_tags)))} ),
             trap = T_('It may be more appropriate to remove the object completely if it isn\'t useful.')
         )
-        self.errors[21102] = self.def_class(item = 2110, level = 2, tags = ['tag'],
-            title = T_('Missing relation type'),
-            detail = T_('The relation is missing a `type` tag to define what it represents.')
-        )
         self.errors[1050] = self.def_class(item = 1050, level = 1, tags = ['highway', 'roundabout', 'fix:chair'],
             title = T_('Reverse roundabout'),
             detail = T_(
@@ -148,9 +144,6 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
     def relation(self, data, tags, members):
         err = self.common(tags, set(tags.keys()))
 
-        if not "type" in tags:
-            err.append({"class": 21102})
-
         return err
 
 ###########################################################################
@@ -190,7 +183,5 @@ class Test(TestPluginCommon):
 
         assert a.way(None, {"tracktype": "foo"}, None)
         assert not a.way(None, {"tracktype": "foo", "leisure": "track"}, None)
-
-        assert a.relation(None, {}, None)
 
         assert a.node(None, {"barrier": "fence", "material": "wood"})

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -120,3 +120,12 @@ way[waterway][level] {
     -osmoseDetail: tr("Level should be used for buildings, shops, amenities, etc.");
     -osmoseTrap: tr("Remove level and check if layer is needed instead");
 }
+
+
+relation[!type] {
+    throwWarning: tr("Missing relation type");
+    assertMatch: "relation";
+    -osmoseItemClassLevel: "2110/21102/2";
+    -osmoseTags: list("tag");
+    -osmoseDetail: tr("The relation is missing a `type` tag to define what it represents.");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -98,3 +98,14 @@ way[junction][junction!=yes][!highway][!area:highway] {
     -osmoseDetail: tr("The way has a tag `junction=*` but without `highway=*`.");
     -osmoseTrap: tr("Check if it is really a highway and it is not already mapped.");
 }
+
+
+way[oneway][!highway][!railway][!aerialway][!waterway][!aeroway][!piste:type] {
+    throwWarning: tr("Tag highway missing on oneway");
+    assertMatch: "way oneway=yes building=yes";
+    assertNoMatch: "way highway=x cycleway=opposite oneway=yes";
+    -osmoseItemClassLevel: "2080/20801:0/1";
+    -osmoseTags: list("tag", "highway", "fix:chair");
+    -osmoseDetail: tr("The way has a tag `oneway=*` but without `highway=*`.");
+    -osmoseTrap: tr("Check if it is really a highway and it is not already mapped.");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -122,6 +122,19 @@ way[waterway][level] {
 }
 
 
+way[tunnel ][highway=~/^(motorway_link|trunk_link|primary|primary_link|secondary|secondary_link)$/][!maxheight][!maxheight:physical][tunnel!=no],
+way[covered][highway=~/^(motorway_link|trunk_link|primary|primary_link|secondary|secondary_link)$/][!maxheight][!maxheight:physical][covered!=no] {
+    throwWarning: tr("Missing maxheight tag");
+    assertMatch: "way highway=primary tunnel=yes";
+    assertMatch: "way highway=primary covered=yes";
+    assertNoMatch: "way highway=primary tunnel=yes maxheight=2.4";
+    assertNoMatch: "way highway=primary covered=no";
+    -osmoseItemClassLevel: "7130/71301:0/3";
+    -osmoseTags: list("tag", "highway", "maxheight", "fix:survey");
+    -osmoseDetail: tr("Missing `maxheight=*` or `maxheight:physical=*` for a tunnel or a way under a bridge.");
+}
+
+
 relation[!type] {
     throwWarning: tr("Missing relation type");
     assertMatch: "relation";

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -86,3 +86,15 @@ way[highway][junction=roundabout][area][area!=no] {
     -osmoseItemClassLevel: "4020/40201:0/1";
     -osmoseTags: list("fix:chair", "highway", "roundabout");
 }
+
+
+way[junction][junction!=yes][!highway][!area:highway] {
+    throwWarning: tr("Tag highway missing on junction");
+    assertMatch: "way junction=roundabout waterway=river";
+    assertNoMatch: "way junction=yes";
+    assertNoMatch: "way junction=roundabout highway=service";
+    -osmoseItemClassLevel: "2080/20800:0/1";
+    -osmoseTags: list("tag", "highway", "roundabout", "fix:chair");
+    -osmoseDetail: tr("The way has a tag `junction=*` but without `highway=*`.");
+    -osmoseTrap: tr("Check if it is really a highway and it is not already mapped.");
+}

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -109,3 +109,14 @@ way[oneway][!highway][!railway][!aerialway][!waterway][!aeroway][!piste:type] {
     -osmoseDetail: tr("The way has a tag `oneway=*` but without `highway=*`.");
     -osmoseTrap: tr("Check if it is really a highway and it is not already mapped.");
 }
+
+
+way[waterway][level] {
+    throwWarning: tr("Waterway with level");
+    assertMatch: "way waterway=stream level=-1";
+    fixChangeKey: "level=>layer";
+    -osmoseItemClassLevel: "3032/30327:0/2";
+    -osmoseTags: list("tag", "fix:chair");
+    -osmoseDetail: tr("Level should be used for buildings, shops, amenities, etc.");
+    -osmoseTrap: tr("Remove level and check if layer is needed instead");
+}


### PR DESCRIPTION
Continuation of #1765
Now including the rules that were previously impossible without losing details (as we didn't have `-osmoseDetail` and such back then)
Also disables 2 JOSM rules that duplicated class 1050

Rules I skipped were:
- Class [20803](https://github.com/Famlam/osmose-backend/blob/7d7ca8996886364880515d50e910b5bcb5ebfe94/plugins/TagFix_MultipleTag.py#L130-L131) (We are missing a lot of exceptions if compared to [JOSMs near-identical rule](https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/combinations.mapcss#L500); maybe this rule should be deleted, what do you think?)
- Class 303210 (I disagree with the rule)
- Classes 1050, 32200 and 32201 because mapcss doesn't support multiline strings (and we shouldn't add that because otherwise people can't load the rules in JOSM anymore)
- Class 21101 as it's not possible to do this in mapcss