### PR TITLE
Add analyser for intersecting ways for transport and incompatible landuses

### DIFF
--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose project 2023                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Osmosis import Analyser_Osmosis
+
+sql10 = """
+CREATE TEMP TABLE mobility_ways AS
+SELECT
+  *
+FROM (
+  SELECT
+    id,
+    linestring,
+    'highway' AS type,
+    tags
+  FROM
+    highways
+  WHERE
+    level <= 3
+  UNION ALL
+  SELECT
+    id,
+    linestring,
+    CASE
+      WHEN tags?'waterway' THEN 'waterway'
+      WHEN tags?'railway' THEN 'railway'
+      WHEN tags?'aeroway' THEN 'aeroway'
+    END AS type,
+    tags
+  FROM
+    ways
+  WHERE
+    tags != ''::hstore AND
+    (
+      (
+        tags?'railway' AND
+        tags->'railway' NOT IN ('abandoned', 'construction', 'disused', 'dismantled', 'miniature', 'proposed', 'razed', 'subway') AND
+        NOT is_polygon
+      ) OR (
+        tags?'waterway' AND
+        tags->'waterway' IN ('river', 'canal') AND -- big waterways
+        (NOT tags?'seasonal' OR tags->'seasonal' = 'no') AND
+        (NOT tags?'intermittent' OR tags->'intermittent' = 'no')
+      ) OR (
+        tags?'aeroway' AND
+        tags->'aeroway' IN ('apron', 'helipad', 'runway', 'taxilane', 'taxiway') -- aircraft moving places
+      )
+    )
+  ) AS t
+WHERE
+  NOT tags?'abandoned' AND
+  NOT tags?'disused' AND
+  NOT tags?'razed' AND
+  (NOT tags?'bridge' OR tags->'bridge' = 'no') AND
+  (NOT tags?'tunnel' OR tags->'tunnel' = 'no')
+"""
+
+sql11 = """
+SELECT
+  mobility_ways.id,
+  ways.id,
+  ST_AsText(ST_Centroid(ST_Intersection(ST_MakePolygon(ways.linestring), mobility_ways.linestring))),
+  mobility_ways.type,
+  CONCAT(mobility_ways.type, '=', mobility_ways.tags->mobility_ways.type),
+  CASE
+    WHEN ways.tags?'landuse' THEN CONCAT('landuse=', ways.tags->'landuse')
+    WHEN ways.tags?'natural' THEN CONCAT('natural=', ways.tags->'natural')
+  END
+FROM
+  mobility_ways
+  JOIN ways ON
+    ways.is_polygon AND
+    ways.tags != ''::hstore AND
+    (
+      (
+        --ways.tags?'landuse' (...) sometimes causes bad route
+        (
+          ways.tags?'landuse' AND
+          ways.tags->'landuse' NOT IN ('basin', 'civic_admin', 'commercial', 'construction', 'education', 'grass', 'harbour', 'industrial', 'military', 'port', 'proposed', 'railway', 'recreation_ground', 'religious', 'reservoir', 'residential', 'retail', 'salt_pond', 'winter_sports')
+        ) OR (
+          ways.tags->'landuse' = 'grass' AND
+          mobility_ways.type = 'waterway'
+        ) OR (
+          ways.tags->'landuse' IN ('basin', 'reservoir', 'recreation_ground', 'salt_pond') AND
+          mobility_ways.type != 'waterway'
+        )
+      ) OR (
+        --ways.tags?'natural' (...) sometimes causes bad route
+        ways.tags->'natural' IN ('cliff', 'scrub', 'shrubbery', 'sinkhole', 'tree_group', 'wood') OR
+        (
+          ways.tags->'natural' IN ('bay', 'water', 'wetland') AND
+          mobility_ways.type != 'waterway' AND
+          mobility_ways.type != 'highway' --Caught by item 1070 class 4/5
+        )
+      )
+    ) AND
+    (
+      NOT ways.tags?'layer' AND NOT mobility_ways.tags?'layer' OR
+      (
+        ways.tags?'layer' AND mobility_ways.tags?'layer' AND
+        ways.tags->'layer' = mobility_ways.tags->'layer'
+      )
+    ) AND
+    ways.linestring && mobility_ways.linestring AND
+    -- Only find ways where the highway/railway/waterway/aeroway actually enters the
+    -- polygon. Exclude cases where the polygon is tied to the way without going inside.
+    ST_Intersects(ST_MakePolygon(ways.linestring), mobility_ways.linestring) AND
+    NOT ST_Touches(ST_MakePolygon(ways.linestring), mobility_ways.linestring) AND
+    (
+      -- Ignore very minor overlaps. The distance between the center of the overlap and one of the ways must be at least 1m
+      ST_Distance(ST_Centroid(ST_Transform(ST_Intersection(ST_MakePolygon(ways.linestring), mobility_ways.linestring), {proj})), ST_Transform(mobility_ways.linestring, {proj})) > 1 OR
+      ST_Distance(ST_Centroid(ST_Transform(ST_Intersection(ST_MakePolygon(ways.linestring), mobility_ways.linestring), {proj})), ST_Transform(ways.linestring, {proj})) > 1
+    )
+"""
+
+class Analyser_Osmosis_Polygon_Intersects(Analyser_Osmosis):
+
+    def __init__(self, config, logger = None):
+        Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
+
+        self.classIndex = {'highway': 12, 'railway': 13, 'waterway': 14, 'aeroway': 15}
+
+        detailTxt = T_(
+'''A way meant for transport (such as a highway or a waterway) intersects with a
+land coverage that would pose an obstacle for this transportation mode.''')
+        exampleTxt = T_(
+'''A major highway usually does not have trees growing on it, so a crossing between
+`landuse=forest` and `highway=trunk` is unlikely.
+The same applies for a railway running through an area with `natural=water`,
+without bridge or tunnel.''')
+        fixTxt = T_(
+'''If the way for transportation (such as a highway) has i.e. a forest growing on
+either side of the way, cut out the shape of the highway from the forest polygon.
+However, if the way for transportation is a tunnel or a bridge, add `tunnel=*` or
+`bridge=*` where appropriate, together with `layer=*` if needed.''')
+
+        self.classs[self.classIndex["highway"]] = self.def_class(
+            item = 1070, level = 2, tags = ['landuse', 'fix:chair', 'highway'],
+            title = T_('Bad intersection with major highway'),
+            detail = detailTxt, example = exampleTxt, fix = fixTxt)
+        self.classs[self.classIndex["railway"]] = self.def_class(
+            item = 1070, level = 2, tags = ['landuse', 'fix:chair', 'railway'],
+            title = T_('Bad intersection with railway'),
+            detail = detailTxt, example = exampleTxt, fix = fixTxt)
+        self.classs[self.classIndex["waterway"]] = self.def_class(
+            item = 1070, level = 2, tags = ['landuse', 'fix:chair', 'waterway'],
+            title = T_('Bad intersection with waterway'),
+            detail = detailTxt, example = exampleTxt, fix = fixTxt)
+        self.classs[self.classIndex["aeroway"]] = self.def_class(
+            item = 1070, level = 2, tags = ['landuse', 'fix:chair'],
+            title = T_('Bad intersection with aeroway'),
+            detail = detailTxt, example = exampleTxt, fix = fixTxt)
+
+    requires_tables_common = ['highways']
+
+    def analyser_osmosis_common(self):
+        self.run(sql10)
+        self.run(sql11.format(proj=self.config.options["proj"]), lambda res: {
+            "class": self.classIndex[res[3]],
+            "data": [self.way, self.way, self.positionAsText],
+            "text": T_("`{0}` intersects `{1}`", res[4], res[5])
+        })
+
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_polygon_intersects.osm",
+                                         config.dir_tmp + "/tests/osmosis_polygon_intersects.test.xml",
+                                         {"proj": 23032})
+
+    def test_classes(self):
+        with Analyser_Osmosis_Polygon_Intersects(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1012"), ("way", "1011")])
+        self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1013"), ("way", "1011")])
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1017"), ("way", "1016")])
+        self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1018"), ("way", "1016")])
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1019"), ("way", "1016")])
+        self.check_err(cl=str(a.classIndex["waterway"]), elems=[("way", "1020"), ("way", "1016")])
+        self.check_err(cl=str(a.classIndex["waterway"]), elems=[("way", "1022"), ("way", "1021")])
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1025"), ("way", "1023")])
+        self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1026"), ("way", "1023")])
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1027"), ("way", "1023")])
+        self.check_err(cl=str(a.classIndex["waterway"]), elems=[("way", "1028"), ("way", "1023")])
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1036"), ("way", "1035")])
+        self.check_num_err(12)

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -138,7 +138,7 @@ CREATE INDEX idx_landusage_linestring ON landusage USING GIST(linestring);
 """
 
 sql13 = """
--- Collect high|rail|water|aeroways either entering or fully inside landuse/natural geometries
+-- Collect highway|rail|water|aeroways either entering or fully inside landuse/natural geometries
 CREATE TEMP TABLE intersecting_geometries AS
 SELECT
   mobility_ways.id AS mobility_way_id,

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -194,6 +194,7 @@ class default_simple(template_config):
         self.analyser["osmosis_camp_pitch_out_of_camp_site"] = "xxx"
         self.analyser["osmosis_relation_open"] = "xxx"
         self.analyser["osmosis_polygon_small"] = "xxx"
+        self.analyser["analyser_osmosis_polygon_intersects"] = "xxx"
 
 class default_country_simple(default_simple):
     def __init__(self, part, country, polygon_id=None, analyser_options=None,

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -20,7 +20,6 @@
   <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84329159026' lon='5.87749715111' />
   <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84762032093' lon='5.84830190437' />
   <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85239254148' lon='5.83958824612' />
-  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84429056505' lon='5.88010226543' />
   <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8488407173' lon='5.88993529442' />
   <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84434823974' lon='5.88652448736' />
   <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84151603281' lon='5.89501782252' />
@@ -94,6 +93,31 @@
   <node id='113' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83743703653' lon='5.92321303075' />
   <node id='114' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8411213414' lon='5.89360697052' />
   <node id='115' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84716028534' lon='5.89836231429' />
+  <node id='116' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82872463058' lon='5.91461238835' />
+  <node id='117' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82375614285' lon='5.91053105279' />
+  <node id='118' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82165996151' lon='5.9172109797' />
+  <node id='119' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82662868044' lon='5.92129231526' />
+  <node id='120' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83884825641' lon='5.93181932164' />
+  <node id='121' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83257464546' lon='5.92676282234' />
+  <node id='122' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82977539683' lon='5.9358578288' />
+  <node id='123' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8357887713' lon='5.93084230356' />
+  <node id='124' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83320172303' lon='5.92856697664' />
+  <node id='125' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83183242297' lon='5.93306076452' />
+  <node id='126' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83414873452' lon='5.93074394091' />
+  <node id='127' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83300596353' lon='5.93134779408' />
+  <node id='128' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82679060687' lon='5.92600731029' />
+  <node id='129' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82051531604' lon='5.92095081099' />
+  <node id='130' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81771531791' lon='5.93004581745' />
+  <node id='131' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8239784455' lon='5.92656152491' />
+  <node id='132' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82139071877' lon='5.92428619799' />
+  <node id='133' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82046430609' lon='5.92704390799' />
+  <node id='134' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8284579374' lon='5.9194216561' />
+  <node id='135' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82127341597' lon='5.9128547528' />
+  <node id='136' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82187094864' lon='5.9260593457' />
+  <node id='137' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81795168778' lon='5.92228526335' />
+  <node id='138' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82161975426' lon='5.920818174' />
+  <node id='139' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82292372537' lon='5.92977335689' />
+  <node id='140' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82107421744' lon='5.91683567931' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -312,4 +336,78 @@
     <nd ref='115' />
     <tag k='highway' v='track' />
   </way>
+  <way id='1042' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='116' />
+    <nd ref='117' />
+    <nd ref='118' />
+  </way>
+  <way id='1043' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='118' />
+    <nd ref='119' />
+    <nd ref='116' />
+  </way>
+  <way id='1044' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='120' />
+    <nd ref='121' />
+    <nd ref='122' />
+    <nd ref='120' />
+  </way>
+  <way id='1045' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='123' />
+    <nd ref='124' />
+    <nd ref='125' />
+    <nd ref='123' />
+    <tag k='landuse' v='grass' />
+  </way>
+  <way id='1046' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='126' />
+    <nd ref='127' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1047' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='128' />
+    <nd ref='129' />
+    <nd ref='130' />
+    <nd ref='128' />
+  </way>
+  <way id='1048' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='131' />
+    <nd ref='132' />
+    <nd ref='133' />
+    <nd ref='131' />
+    <tag k='landuse' v='grass' />
+  </way>
+  <way id='1049' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='134' />
+    <nd ref='135' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='1050' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='136' />
+    <nd ref='137' />
+    <tag k='railway' v='tram' />
+  </way>
+  <way id='1051' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='138' />
+    <nd ref='139' />
+    <tag k='waterway' v='canal' />
+  </way>
+  <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1045' role='inner' />
+    <member type='way' ref='1044' role='outer' />
+    <tag k='landuse' v='forest' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='10001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1048' role='inner' />
+    <member type='way' ref='1047' role='outer' />
+    <tag k='natural' v='water' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='10002' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1042' role='outer' />
+    <member type='way' ref='1043' role='outer' />
+    <tag k='landuse' v='forest' />
+    <tag k='type' v='multipolygon' />
+  </relation>
 </osm>

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -1,0 +1,315 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85510744393' lon='5.84583342452' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8505121182' lon='5.8395422119' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84740641013' lon='5.84548750106' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85200205297' lon='5.85177871368' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84851028289' lon='5.85266732201' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85411470485' lon='5.8418875386' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85277229305' lon='5.87254036978' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84780408976' lon='5.86855012927' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.846717464' lon='5.87209556791' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85168578723' lon='5.87608580842' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85417019069' lon='5.87611335092' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84839929719' lon='5.87117261686' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8514595242' lon='5.88091284586' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8467172411' lon='5.87731168628' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84536247281' lon='5.88198663085' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85010489865' lon='5.88558779043' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85344680103' lon='5.88567182019' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84329159026' lon='5.87749715111' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84762032093' lon='5.84830190437' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85239254148' lon='5.83958824612' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84429056505' lon='5.88010226543' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8488407173' lon='5.88993529442' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84434823974' lon='5.88652448736' />
+  <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84151603281' lon='5.89501782252' />
+  <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84610591068' lon='5.89858583475' />
+  <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84234809371' lon='5.88639047242' />
+  <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84972903892' lon='5.89240918482' />
+  <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84417584495' lon='5.84244254564' />
+  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.836935154' lon='5.83448427908' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.835274964' lon='5.83844074563' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84251592193' lon='5.8463990122' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83973950034' lon='5.83338987066' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83552102954' lon='5.84327133878' />
+  <node id='40' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.841626583' lon='5.83653397415' />
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83774132659' lon='5.84506796935' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84895215431' lon='5.89447530998' />
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84512302711' lon='5.8910617119' />
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8393628241' lon='5.86114804763' />
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83135753244' lon='5.85348639706' />
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82998571267' lon='5.85723990675' />
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83799124818' lon='5.86490155732' />
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83768478592' lon='5.85474302228' />
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83329958832' lon='5.86471432194' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83629711135' lon='5.85366504394' />
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83241139504' lon='5.86219903914' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83485388443' lon='5.85168875032' />
+  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8306349559' lon='5.86157021844' />
+  <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83480044408' lon='5.86422883704' />
+  <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8375758427' lon='5.85794063005' />
+  <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83738553234' lon='5.87306430287' />
+  <node id='59' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83368066672' lon='5.86995938914' />
+  <node id='60' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8323796763' lon='5.87402482485' />
+  <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83608464895' lon='5.87712973857' />
+  <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83613162215' lon='5.87066995495' />
+  <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83335613451' lon='5.87695816194' />
+  <node id='64' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83491042866' lon='5.88477350491' />
+  <node id='65' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82863741291' lon='5.88028192849' />
+  <node id='66' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82691634435' lon='5.88585148325' />
+  <node id='67' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83341164593' lon='5.8904328912' />
+  <node id='68' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84134907581' lon='5.89151086954' />
+  <node id='69' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84784229589' lon='5.89654143513' />
+  <node id='70' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83127440651' lon='5.87906920285' />
+  <node id='71' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82705514264' lon='5.88895067098' />
+  <node id='72' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83271774815' lon='5.88104549648' />
+  <node id='73' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82883172297' lon='5.88957949168' />
+  <node id='74' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83410553303' lon='5.88212347482' />
+  <node id='75' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82971998686' lon='5.89209477447' />
+  <node id='76' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83399658114' lon='5.88532108258' />
+  <node id='77' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83122096191' lon='5.89160928957' />
+  <node id='78' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83544319967' lon='5.85984018376' />
+  <node id='90' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84758077063' lon='5.90685571254' />
+  <node id='91' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83801200954' lon='5.8995574517' />
+  <node id='92' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8416167569' lon='5.90230667322' />
+  <node id='93' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84452845089' lon='5.90452748658' />
+  <node id='94' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84458644894' lon='5.90964130828' />
+  <node id='95' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8377366194' lon='5.90401440489' />
+  <node id='96' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82884478953' lon='5.89576052323' />
+  <node id='97' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83175730951' lon='5.89798133659' />
+  <node id='98' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83181532401' lon='5.90309515829' />
+  <node id='99' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82496355138' lon='5.8974682549' />
+  <node id='100' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83481049515' lon='5.90030956255' />
+  <node id='101' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82523901964' lon='5.89301130171' />
+  <node id='102' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82988727516' lon='5.89819253765' />
+  <node id='103' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84115314098' lon='5.90683680794' />
+  <node id='104' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83671586788' lon='5.90322288858' />
+  <node id='105' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84615789848' lon='5.91132860863' />
+  <node id='108' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84254504257' lon='5.91860160766' />
+  <node id='109' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84140657059' lon='5.92283788833' />
+  <node id='110' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83499970025' lon='5.91832758587' />
+  <node id='111' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83613833424' lon='5.9140913052' />
+  <node id='112' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84156467073' lon='5.91509168326' />
+  <node id='113' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83743703653' lon='5.92321303075' />
+  <node id='114' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8411213414' lon='5.89360697052' />
+  <node id='115' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84716028534' lon='5.89836231429' />
+  <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='1' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='1001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='5' />
+    <nd ref='6' />
+    <tag k='waterway' v='river' />
+  </way>
+  <way id='1004' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='13' />
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='16' />
+    <nd ref='13' />
+    <tag k='landuse' v='grass' />
+  </way>
+  <way id='1005' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='17' />
+    <nd ref='18' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1006' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='19' />
+    <nd ref='20' />
+    <nd ref='21' />
+    <nd ref='22' />
+    <nd ref='19' />
+    <tag k='landuse' v='industrial' />
+  </way>
+  <way id='1007' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='23' />
+    <nd ref='24' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1008' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='25' />
+    <nd ref='26' />
+    <tag k='bridge' v='yes' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1009' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='28' />
+    <nd ref='29' />
+    <nd ref='30' />
+    <nd ref='31' />
+    <nd ref='28' />
+    <tag k='landuse' v='forest' />
+  </way>
+  <way id='1010' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='32' />
+    <nd ref='33' />
+    <tag k='abandoned' v='yes' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1011' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='34' />
+    <nd ref='35' />
+    <nd ref='36' />
+    <nd ref='37' />
+    <nd ref='34' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='1012' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='38' />
+    <nd ref='39' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1013' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='40' />
+    <nd ref='41' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1015' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='44' />
+    <nd ref='45' />
+    <tag k='railway' v='disused' />
+  </way>
+  <way id='1016' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='46' />
+    <nd ref='47' />
+    <nd ref='48' />
+    <nd ref='49' />
+    <nd ref='46' />
+    <tag k='natural' v='wood' />
+  </way>
+  <way id='1017' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='50' />
+    <nd ref='78' />
+    <nd ref='51' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1018' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='52' />
+    <nd ref='53' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1019' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='54' />
+    <nd ref='55' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1020' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='57' />
+    <nd ref='56' />
+    <tag k='waterway' v='river' />
+  </way>
+  <way id='1021' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='58' />
+    <nd ref='59' />
+    <nd ref='60' />
+    <nd ref='61' />
+    <nd ref='58' />
+    <tag k='landuse' v='grass' />
+  </way>
+  <way id='1022' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='62' />
+    <nd ref='63' />
+    <tag k='waterway' v='river' />
+  </way>
+  <way id='1023' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='64' />
+    <nd ref='65' />
+    <nd ref='66' />
+    <nd ref='67' />
+    <nd ref='64' />
+    <tag k='landuse' v='forest' />
+  </way>
+  <way id='1024' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='68' />
+    <nd ref='69' />
+    <tag k='railway' v='rail' />
+    <tag k='tunnel' v='yes' />
+  </way>
+  <way id='1025' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='70' />
+    <nd ref='71' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1026' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='72' />
+    <nd ref='73' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1027' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='74' />
+    <nd ref='75' />
+    <tag k='highway' v='trunk' />
+  </way>
+  <way id='1028' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='76' />
+    <nd ref='77' />
+    <tag k='waterway' v='river' />
+  </way>
+  <way id='1033' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='90' />
+    <nd ref='93' />
+    <nd ref='92' />
+    <nd ref='91' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1034' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='92' />
+    <nd ref='93' />
+    <nd ref='94' />
+    <nd ref='103' />
+    <nd ref='95' />
+    <nd ref='92' />
+    <tag k='landuse' v='forest' />
+  </way>
+  <way id='1035' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='96' />
+    <nd ref='97' />
+    <nd ref='98' />
+    <nd ref='99' />
+    <nd ref='96' />
+    <tag k='landuse' v='forest' />
+  </way>
+  <way id='1036' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='100' />
+    <nd ref='97' />
+    <nd ref='102' />
+    <nd ref='96' />
+    <nd ref='101' />
+    <tag k='highway' v='secondary' />
+  </way>
+  <way id='1037' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='104' />
+    <nd ref='95' />
+    <nd ref='94' />
+    <nd ref='105' />
+    <tag k='note' v='A very tiny difference with the forest' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1039' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='108' />
+    <nd ref='109' />
+    <nd ref='110' />
+    <nd ref='111' />
+    <nd ref='108' />
+    <tag k='landuse' v='plant_nursery' />
+    <tag k='layer' v='-1' />
+    <tag k='note' v='Underground' />
+  </way>
+  <way id='1040' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='112' />
+    <nd ref='113' />
+    <tag k='aeroway' v='taxiway' />
+  </way>
+  <way id='1041' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='114' />
+    <nd ref='115' />
+    <tag k='highway' v='track' />
+  </way>
+</osm>

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -82,9 +82,6 @@
   <node id='100' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83481049515' lon='5.90030956255' />
   <node id='101' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82523901964' lon='5.89301130171' />
   <node id='102' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82988727516' lon='5.89819253765' />
-  <node id='103' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84115314098' lon='5.90683680794' />
-  <node id='104' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83671586788' lon='5.90322288858' />
-  <node id='105' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84615789848' lon='5.91132860863' />
   <node id='108' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84254504257' lon='5.91860160766' />
   <node id='109' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84140657059' lon='5.92283788833' />
   <node id='110' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83499970025' lon='5.91832758587' />
@@ -117,7 +114,24 @@
   <node id='137' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81795168778' lon='5.92228526335' />
   <node id='138' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82161975426' lon='5.920818174' />
   <node id='139' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82292372537' lon='5.92977335689' />
-  <node id='140' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82107421744' lon='5.91683567931' />
+  <node id='140' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82267467041' lon='5.94159338716' />
+  <node id='141' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82005935627' lon='5.94349752755' />
+  <node id='142' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82227709281' lon='5.94579326988' />
+  <node id='143' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82686495872' lon='5.94256804254' />
+  <node id='144' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82456882378' lon='5.94234950757' />
+  <node id='145' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82438457003' lon='5.94741738097' />
+  <node id='146' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82668071436' lon='5.94763591594' />
+  <node id='147' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82421436679' lon='5.93926669031' />
+  <node id='148' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82293704431' lon='5.95041761517' />
+  <node id='149' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82094115543' lon='5.9489537872' />
+  <node id='150' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8220056405' lon='5.93862088385' />
+  <node id='151' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82599413576' lon='5.94441935296' />
+  <node id='152' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82498364284' lon='5.94419808202' />
+  <node id='153' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82603212378' lon='5.94623869185' />
+  <node id='154' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82677670517' lon='5.95076241652' />
+  <node id='155' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82735410949' lon='5.93945301264' />
+  <node id='156' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82900157915' lon='5.8820351702' />
+  <node id='157' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82801107079' lon='5.8846363293' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -287,7 +301,6 @@
     <nd ref='92' />
     <nd ref='93' />
     <nd ref='94' />
-    <nd ref='103' />
     <nd ref='95' />
     <nd ref='92' />
     <tag k='landuse' v='forest' />
@@ -309,11 +322,8 @@
     <tag k='highway' v='secondary' />
   </way>
   <way id='1037' timestamp='2014-03-31T22:00:00Z' version='1'>
-    <nd ref='104' />
     <nd ref='95' />
     <nd ref='94' />
-    <nd ref='105' />
-    <tag k='note' v='A very tiny difference with the forest' />
     <tag k='railway' v='rail' />
   </way>
   <way id='1039' timestamp='2014-03-31T22:00:00Z' version='1'>
@@ -392,6 +402,50 @@
     <nd ref='139' />
     <tag k='waterway' v='canal' />
   </way>
+  <way id='1052' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='140' />
+    <nd ref='141' />
+    <nd ref='142' />
+    <nd ref='140' />
+  </way>
+  <way id='1053' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='143' />
+    <nd ref='144' />
+    <nd ref='145' />
+    <nd ref='146' />
+    <nd ref='143' />
+  </way>
+  <way id='1054' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='147' />
+    <nd ref='148' />
+    <tag k='note' v='Between multipolygon outers' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1055' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='149' />
+    <nd ref='150' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1056' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='151' />
+    <nd ref='152' />
+    <nd ref='153' />
+    <nd ref='151' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='1057' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='154' />
+    <nd ref='146' />
+    <nd ref='143' />
+    <nd ref='155' />
+    <tag k='note' v='Only touching the MP outer' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1058' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='156' />
+    <nd ref='157' />
+    <tag k='aeroway' v='runway' />
+  </way>
   <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='1045' role='inner' />
     <member type='way' ref='1044' role='outer' />
@@ -407,6 +461,13 @@
   <relation id='10002' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='1042' role='outer' />
     <member type='way' ref='1043' role='outer' />
+    <tag k='landuse' v='forest' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='10003' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1052' role='outer' />
+    <member type='way' ref='1053' role='outer' />
+    <member type='way' ref='1056' role='inner' />
     <tag k='landuse' v='forest' />
     <tag k='type' v='multipolygon' />
   </relation>


### PR DESCRIPTION
Detects (major) highways/active railways/big permanent waterways/plane-carrying aeroways intersecting with landuses (including `natural`) that are incompatible. For example, a runway intersecting with a forest (which typically doesn't end well) or a motorway in the water (without bridge or tunnel).
See #1726

Ignores 'snapped' ways (in some countries this seems to be the common method: to snap a highway to the nearby landuse) and very minor overlaps (<1m, to avoid overloading the map with balloons)

Includes tests.

(Note that I disabled `ways.tags?'landuse'` as this would result in a very slow analysis for some countries as the SQL parser made a poor choise)