### PR TITLE
Disable bump sign in DE

### DIFF
--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -873,6 +873,9 @@
     ],
     "conflation": 300,
     "title": "road bump",
+    "not_for": [
+      "DE"
+    ],
     "object": [
       "information--road-bump--g1",
       "warning--road-bump--g1",


### PR DESCRIPTION
See #1790
The traffic bump sign doesn't exist in Germany (https://en.wikipedia.org/wiki/Road_signs_in_Germany) hence every detection must be a false positive.