### PR TITLE
Add analyser for unexpected barriers on highway

### DIFF
--- a/analysers/analyser_osmosis_highway_area_access.py
+++ b/analysers/analyser_osmosis_highway_area_access.py
@@ -91,6 +91,58 @@ WHERE
     NOT barrier.waytags->'{vehicle}' IN ('no', 'use_sidepath', 'unknown')
 """
 
+sql31 = """
+SELECT
+  highways.id,
+  barrier.id,
+  ST_AsText(barrier.geom)
+FROM
+  highways
+  JOIN nodes AS barrier ON
+    barrier.tags != ''::hstore AND
+    barrier.id = ANY(highways.nodes) AND
+    --barrier.tags?'barrier' AND -- commented to prevent slow route
+    barrier.tags->'barrier' NOT IN ('border_control', 'cattle_grid', 'entrance', 'height_restrictor', 'toll_booth') AND
+    NOT (barrier.tags?'access' OR barrier.tags?'access:conditional') AND
+    NOT (barrier.tags?'vehicle' OR barrier.tags?'vehicle:conditional') AND
+    NOT (barrier.tags?'motor_vehicle' OR barrier.tags?'motor_vehicle:conditional')
+WHERE
+  highways.level <= 3 AND
+  NOT (highways.tags?'access' OR highways.tags?'access:conditional') AND
+  NOT (highways.tags?'vehicle' OR highways.tags?'vehicle:conditional') AND
+  NOT (highways.tags?'motor_vehicle' OR highways.tags?'motor_vehicle:conditional')
+"""
+
+
+sql41 = """
+SELECT
+  ways.id,
+  barrier.id,
+  ST_AsText(barrier.geom)
+FROM
+  highways AS ways
+  JOIN way_nodes ON
+    way_nodes.way_id = ways.id
+  JOIN nodes AS barrier ON
+    barrier.tags != ''::hstore AND
+    barrier.id = way_nodes.node_id AND
+    --barrier.id = ANY(ways.nodes) will cause a very slow planning (focused on the X.tags?'Y') on some countries (e.g. japan_chubu)
+    barrier.tags?'barrier' AND
+    barrier.tags->'barrier' NOT IN ('bollard', 'border_control', 'cattle_grid', 'entrance', 'height_restrictor', 'toll_booth') AND
+    barrier.id != ways.nodes[1] AND barrier.id != ways.nodes[array_length(ways.nodes,1)] AND -- Barrier is not an end node
+    NOT (barrier.tags?'access' OR barrier.tags?'access:conditional') AND
+    NOT (barrier.tags?'vehicle' OR barrier.tags?'vehicle:conditional') AND
+    NOT (barrier.tags?'motor_vehicle' OR barrier.tags?'motor_vehicle:conditional')
+  JOIN highways AS minor_highway ON
+    barrier.id = ANY(minor_highway.nodes) AND
+    (minor_highway.level IS NULL OR minor_highway.level > 4)
+WHERE
+  ways.level = 4 AND
+  NOT (ways.tags?'access' OR ways.tags?'access:conditional') AND
+  NOT (ways.tags?'vehicle' OR ways.tags?'vehicle:conditional') AND
+  NOT (ways.tags?'motor_vehicle' OR ways.tags?'motor_vehicle:conditional')
+"""
+
 
 class Analyser_Osmosis_HighwayAreaAccess(Analyser_Osmosis):
 
@@ -113,6 +165,25 @@ class Analyser_Osmosis_HighwayAreaAccess(Analyser_Osmosis):
 '''Sometimes a barrier can exist on an (otherwise uninterrupted) highway to prevent vehicles from using it for purposes other than destination traffic.'''),
             fix = T_(
 '''Copy the appropriate access tag to the barrier node.'''))
+        self.classs[3] = self.def_class(item = 2130, level = 2, tags = ['highway', 'routing'],
+            title = T_('Barrier blocking major highway'),
+            detail = T_(
+'''A barrier is blocking a major highway. Typically, major highways (`tertiary` and above) are meant for passing traffic.'''),
+            fix = T_(
+'''Check if there is really a barrier on the highway itself (instead of for instance a connecting minor way only).
+If there is no such barrier, remove it, or move it to the appropriate connecting way.
+If there is a barrier, check if it has the appropriate (conditional) access keys.'''))
+        self.classs[4] = self.def_class(item = 2130, level = 3, tags = ['highway', 'routing'],
+            title = T_('Barrier blocking highway'),
+            detail = T_(
+'''A barrier is blocking a residential or unclassified way on a crossing with a minor highway.
+Likely the barrier was only supposed to be present on the minor road.'''),
+            trap = T_(
+'''Sometimes a barrier can exist on an (otherwise uninterrupted) highway to prevent vehicles from using it for purposes other than destination traffic.'''),
+            fix = T_(
+'''Check if there is really a barrier on the highway itself (instead of for instance a connecting minor way only).
+If there is no such barrier, remove it, or move it to the appropriate connecting way.
+If there is a barrier, check if it has the appropriate (conditional) access keys.'''))
         self.callback10 = lambda res: {"class":1, "data":[self.node_full, self.way_full, self.positionAsText],
             "text": T_("Inconsistent motor_vehicle values ('{0}'!='{1}')", res[3] if res[3] else '', res[4] if res[4] else '') }
 
@@ -127,6 +198,13 @@ class Analyser_Osmosis_HighwayAreaAccess(Analyser_Osmosis):
             self.run(sql21.format(barriertype='bus_trap', vehicle=vehicle), lambda res: {
                 "class":2, "data":[self.way_full, self.node_full, self.positionAsText],
                 "text": T_("Inconsistent {0} access: '{1}' on highway, not set on barrier", vehicle, res[3])})
+
+        self.run(sql31, lambda res: {
+            "class": 3, "data":[self.way, self.node_full, self.positionAsText]
+        })
+        self.run(sql41, lambda res: {
+            "class": 4, "data":[self.way, self.node_full, self.positionAsText]
+        })
 
     def analyser_osmosis_full(self):
         self.run(sql10.format("", ""), self.callback10)
@@ -160,4 +238,8 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl="1", elems=[("node", "30"), ("way", "110")])
         self.check_err(cl="2", elems=[("node", "20"), ("way", "107")])
         self.check_err(cl="2", elems=[("node", "37"), ("way", "107")])
-        self.check_num_err(5)
+        self.check_err(cl="3", elems=[("node", "46"), ("way", "116")])
+        self.check_err(cl="3", elems=[("node", "47"), ("way", "116")])
+        self.check_err(cl="4", elems=[("node", "55"), ("way", "118")])
+        self.check_err(cl="4", elems=[("node", "56"), ("way", "118")])
+        self.check_num_err(9)

--- a/tests/osmosis_highway_access_barrier.osm
+++ b/tests/osmosis_highway_access_barrier.osm
@@ -92,14 +92,56 @@
     <tag k='barrier' v='bollard' />
     <tag k='vehicle' v='private' />
   </node>
-  <node id='41' timestamp='2014-03-31T22:00:00Z' lat='51.83095287618' lon='5.85577926076' version='1'>
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83095287618' lon='5.85577926076'>
     <tag k='barrier' v='bollard' />
   </node>
-  <node id='42' timestamp='2014-03-31T22:00:00Z' lat='51.83167236111' lon='5.85577926076' version='1'>
+  <node id='42' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83167236111' lon='5.85577926076'>
     <tag k='barrier' v='bollard' />
   </node>
-  <node id='43' timestamp='2014-03-31T22:00:00Z' lat='51.83132895975' lon='5.85577926076' version='1' />
-  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <node id='43' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83132895975' lon='5.85577926076' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83571500747' lon='5.87458318579'>
+    <tag k='access:conditional' v='no @ Su' />
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83617299543' lon='5.88067686471' />
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83619252699' lon='5.87351216832'>
+    <tag k='barrier' v='bollard' />
+  </node>
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83618959092' lon='5.87458919441'>
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83618084657' lon='5.87779685907'>
+    <tag k='access:conditional' v='no @ Su' />
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83617886792' lon='5.878522681'>
+    <tag k='barrier' v='height_restrictor' />
+  </node>
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8361765063' lon='5.87938898459'>
+    <tag k='barrier' v='toll_booth' />
+  </node>
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83526872492' lon='5.87457753554' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.87466526594'>
+    <tag k='barrier' v='cycle_barrier' />
+  </node>
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.88461555965' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83207348415' lon='5.87567819988' />
+  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.87666131273'>
+    <tag k='barrier' v='kerb' />
+  </node>
+  <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.87847858195'>
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83242327433' lon='5.87844879065' />
+  <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83360149493' lon='5.87847858195' />
+  <node id='59' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.88017668596' />
+  <node id='60' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.88273873764'>
+    <tag k='barrier' v='block' />
+    <tag k='bicycle' v='yes' />
+    <tag k='foot' v='yes' />
+    <tag k='note' v='No through-traffic allowed' />
+  </node>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='3' />
     <nd ref='2' />
@@ -109,21 +151,21 @@
     <tag k='motorcycle' v='destination' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='5' />
     <nd ref='9' />
     <nd ref='2' />
     <tag k='highway' v='footway' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='6' />
     <nd ref='8' />
     <nd ref='7' />
     <tag k='highway' v='busway' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='10' />
     <nd ref='12' />
     <nd ref='21' />
@@ -133,7 +175,7 @@
     <tag k='highway' v='busway' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='14' />
     <nd ref='17' />
     <nd ref='16' />
@@ -166,14 +208,14 @@
     <tag k='tourist_bus' v='yes' />
     <tag k='wheelchair' v='yes' />
   </way>
-  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='16' />
     <nd ref='15' />
     <tag k='access' v='private' />
     <tag k='highway' v='service' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='18' />
     <nd ref='20' />
     <nd ref='37' />
@@ -182,14 +224,14 @@
     <tag k='moped' v='designated' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='108' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='108' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='22' />
     <nd ref='24' />
     <nd ref='23' />
     <tag k='highway' v='pedestrian' />
     <tag k='name' v='class 1 test' />
   </way>
-  <way id='109' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='109' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='25' />
     <nd ref='29' />
     <nd ref='26' />
@@ -197,7 +239,7 @@
     <tag k='motor_vehicle' v='delivery' />
     <tag k='name' v='class 1 test' />
   </way>
-  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='27' />
     <nd ref='30' />
     <nd ref='28' />
@@ -205,7 +247,7 @@
     <tag k='motor_vehicle' v='delivery' />
     <tag k='name' v='class 1 test' />
   </way>
-  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='31' />
     <nd ref='32' />
     <nd ref='33' />
@@ -213,19 +255,19 @@
     <tag k='motor_vehicle' v='delivery' />
     <tag k='name' v='class 1 test' />
   </way>
-  <way id='112' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='112' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='34' />
     <nd ref='36' />
     <nd ref='35' />
     <tag k='highway' v='residential' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='37' />
     <nd ref='38' />
     <tag k='highway' v='footway' />
   </way>
-  <way id='114' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='114' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='39' />
     <nd ref='40' />
     <nd ref='35' />
@@ -234,12 +276,55 @@
     <tag k='moped' v='designated' />
     <tag k='name' v='class 2 test' />
   </way>
-  <way id='115' timestamp='2014-03-31T22:00:00Z' version='1' >
+  <way id='115' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='41' />
     <nd ref='43' />
     <nd ref='42' />
     <tag k='highway' v='cycleway' />
     <tag k='moped' v='designated' />
     <tag k='name' v='class 2 test' />
+  </way>
+  <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='46' />
+    <nd ref='47' />
+    <nd ref='48' />
+    <nd ref='49' />
+    <nd ref='50' />
+    <nd ref='45' />
+    <tag k='highway' v='primary' />
+    <tag k='name' v='Class 3 test' />
+  </way>
+  <way id='117' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='51' />
+    <nd ref='44' />
+    <nd ref='47' />
+    <tag k='access:conditional' v='no @ Su' />
+    <tag k='highway' v='tertiary' />
+    <tag k='name' v='Class 3 test' />
+  </way>
+  <way id='118' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='52' />
+    <nd ref='55' />
+    <nd ref='56' />
+    <nd ref='59' />
+    <nd ref='60' />
+    <nd ref='53' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='119' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='55' />
+    <nd ref='54' />
+    <nd ref='52' />
+    <tag k='highway' v='footway' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='120' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='59' />
+    <nd ref='58' />
+    <nd ref='56' />
+    <nd ref='57' />
+    <tag k='highway' v='service' />
+    <tag k='name' v='Class 4 test' />
   </way>
 </osm>

--- a/tests/osmosis_highway_access_barrier.osm
+++ b/tests/osmosis_highway_access_barrier.osm
@@ -141,6 +141,35 @@
     <tag k='foot' v='yes' />
     <tag k='note' v='No through-traffic allowed' />
   </node>
+  <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83315968422' lon='5.88210322337'>
+    <tag k='barrier' v='cycle_barrier' />
+  </node>
+  <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83356777062' lon='5.88209908573'>
+    <tag k='barrier' v='cycle_barrier' />
+  </node>
+  <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83367132278' lon='5.88179910677' />
+  <node id='64' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83372118114' lon='5.88238251412'>
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='65' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83111058959' lon='5.87707182736' />
+  <node id='66' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83110008476' lon='5.87958762175'>
+    <tag k='barrier' v='gate' />
+  </node>
+  <node id='67' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8310901337' lon='5.88197079404' />
+  <node id='68' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83618498874' lon='5.87627740036'>
+    <tag k='traffic_calming' v='hump' />
+  </node>
+  <node id='69' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83386435999' lon='5.88222322116' />
+  <node id='70' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83387458731' lon='5.88255837006' />
+  <node id='71' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83377550944' lon='5.88238459018' />
+  <node id='72' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83383559501' lon='5.88230907824' />
+  <node id='73' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83356137467' lon='5.88308385044'>
+    <tag k='barrier' v='cycle_barrier' />
+  </node>
+  <node id='74' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83374035359' lon='5.88293075773' />
+  <node id='75' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8337556946' lon='5.88328866366' />
+  <node id='76' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83346325461' lon='5.88308643802' />
+  <node id='77' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83368633942' lon='5.88308798963' />
   <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='3' />
@@ -287,6 +316,7 @@
   <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='46' />
     <nd ref='47' />
+    <nd ref='68' />
     <nd ref='48' />
     <nd ref='49' />
     <nd ref='50' />
@@ -307,6 +337,7 @@
     <nd ref='55' />
     <nd ref='56' />
     <nd ref='59' />
+    <nd ref='61' />
     <nd ref='60' />
     <nd ref='53' />
     <tag k='highway' v='residential' />
@@ -325,6 +356,66 @@
     <nd ref='56' />
     <nd ref='57' />
     <tag k='highway' v='service' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='121' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='62' />
+    <nd ref='61' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='122' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='63' />
+    <nd ref='62' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='123' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='70' />
+    <nd ref='64' />
+    <nd ref='62' />
+    <tag k='highway' v='cycleway' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='124' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='65' />
+    <nd ref='66' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='125' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='67' />
+    <nd ref='66' />
+    <tag k='highway' v='residential' />
+  </way>
+  <way id='126' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='64' />
+    <nd ref='70' />
+    <nd ref='69' />
+    <nd ref='64' />
+    <tag k='area' v='yes' />
+    <tag k='bicycle' v='yes' />
+    <tag k='highway' v='pedestrian' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='127' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='73' />
+    <nd ref='74' />
+    <nd ref='75' />
+    <nd ref='73' />
+    <tag k='area' v='yes' />
+    <tag k='highway' v='pedestrian' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='128' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='76' />
+    <nd ref='73' />
+    <tag k='highway' v='footway' />
+    <tag k='name' v='Class 4 test' />
+  </way>
+  <way id='129' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='73' />
+    <nd ref='77' />
+    <tag k='highway' v='footway' />
     <tag k='name' v='Class 4 test' />
   </way>
 </osm>


### PR DESCRIPTION
Class 3: detects any barrier on an important (`tertiary_link` or above) road. Such a barrier is likely wrong (either the road is not so important as claimed, or access restrictions (night-time closures or so) are missing, or the barrier is supposed to be on a connecting side road only.
Example: `barrier=kerb` on a primary highway. It should be either `highway=crossing` + `kerb=X` (no `barrier=*`), or the `barrier=kerb` tag should be on the connecting footway (as the kerb is not actually on the primary highway itself).
Example: https://www.openstreetmap.org/node/5798745719

Class 4: ~any barrier on a connection between a residential/unclassified road and a minor road (cycleway, path, service, ...). Very likely such a barrier is actually supposed to be located on the minor road only.~
EDIT, updated after feedback: any crossing with more than 2 minor outgoing ways, having a barrier on it. Very likely the barrier is only supposed to be on one of the ways.
Example: a cycle barrier on a crossing of multiple ways [not end nodes]... I wouldn't even know how it would look like to block cyclists from more than two directions.
Example: https://www.openstreetmap.org/node/1814866994#map=18/57.97252/19.22840&layers=N

<details>

This analyser is basically the SQL implementation of [JOSM's mapcss rule](https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/combinations.mapcss):

```css
/* #20742 - No warning about barrier with inappropriate access tags on highway */
way[highway=~/^(motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link)$/][!access][!vehicle] > node[barrier][barrier!~/entrance|border_control|height_restrictor|toll_booth/][!access][!motor_vehicle][!vehicle] {
  throwWarning: tr("{0} without access tags such as {1}, {2}, or {3}.", "{0.tag}", "{2.key}", "{3.key}", "{4.key}");
  group: tr("suspicious barrier");
}

way[highway=~/^(footway|path|bridleway|cycleway|service)$/] > node[barrier]:connection {
  set barrierSmallRoadConnection;
}

way[highway=~/^(unclassified|residential)$/] >[index = 1] node.barrierSmallRoadConnection,
way[highway=~/^(unclassified|residential)$/] >[index = -1] node.barrierSmallRoadConnection {
  set barrierAllowedAtConnection;
}

/* 20742; warnings for major roads set by other rule, also issue 20742 */
way[highway=~/^(unclassified|residential)$/] > node[barrier][barrier!=bollard][!access][!access:conditional][!vehicle][!vehicle:conditional][!motor_vehicle][!motor_vehicle:conditional].barrierSmallRoadConnection!.barrierAllowedAtConnection {
  throwWarning: tr("Suspicious {0} on a connection of a small highway with a larger highway", "{0.tag}");
  set hasWarningForBarrierOnWay;
  group: tr("suspicious barrier");
}
```
</details>

[results.zip](https://github.com/osm-fr/osmose-backend/files/11072676/results.zip)
