### PR TITLE
Add analyser: mismatching parking access

### DIFF
--- a/tests/osmosis_parking_highway.osm
+++ b/tests/osmosis_parking_highway.osm
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81153986582' lon='5.81084093495' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81135523212' lon='5.81079842412' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81131182761' lon='5.81129161495' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81168178543' lon='5.81124732951' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81149715231' lon='5.81120481869' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81145374794' lon='5.81169800951' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81141417791' lon='5.81155637276' />
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81123901715' lon='5.8115201376' />
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81137789736' lon='5.8120151994' />
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81114254958' lon='5.81156089628' />
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81137663995' lon='5.81160943991' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81135316945' lon='5.81192981054' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81155279889' lon='5.81249961015' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81137270389' lon='5.81246588097' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81151637803' lon='5.81300837473' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81149140158' lon='5.81255606118' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81150007945' lon='5.81280029064' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81128486764' lon='5.81252237435' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81117956352' lon='5.81242084389' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81115397423' lon='5.81299237163' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81094412543' lon='5.81296779113' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81096971484' lon='5.81239626339' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81088047491' lon='5.81249570562' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81113387164' lon='5.81252939244' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81111825133' lon='5.81290556197' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81103560677' lon='5.81251632899' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81102279379' lon='5.81287748961' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81169446344' lon='5.81253781415' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81166148764' lon='5.81253781415' />
+  <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81164586752' lon='5.81294205602' />
+  <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81120273647' lon='5.81197896425' />
+  <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127637074' lon='5.81158864692' />
+  <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81125265703' lon='5.81191567956' />
+  <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='1' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='4' />
+    <tag k='amenity' v='parking' />
+    <tag k='park_ride' v='yes' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='7' />
+    <nd ref='8' />
+    <nd ref='31' />
+    <nd ref='9' />
+    <nd ref='7' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='10' />
+    <nd ref='32' />
+    <nd ref='11' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='11' />
+    <nd ref='12' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='parking_aisle' />
+  </way>
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='13' />
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='13' />
+    <tag k='access' v='private' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='16' />
+    <nd ref='17' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='parking_aisle' />
+  </way>
+  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='18' />
+    <nd ref='16' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='108' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='19' />
+    <nd ref='20' />
+    <nd ref='21' />
+    <nd ref='22' />
+    <nd ref='19' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='109' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='23' />
+    <nd ref='26' />
+    <nd ref='24' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='26' />
+    <nd ref='27' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='parking_aisle' />
+  </way>
+  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='24' />
+    <nd ref='25' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='parking_aisle' />
+  </way>
+  <way id='112' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='28' />
+    <nd ref='29' />
+    <nd ref='30' />
+    <nd ref='28' />
+    <tag k='amenity' v='parking' />
+    <tag k='parking' v='street_side' />
+  </way>
+  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='32' />
+    <nd ref='33' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+    <tag k='service' v='parking_aisle' />
+  </way>
+</osm>

--- a/tests/osmosis_parking_highway.osm
+++ b/tests/osmosis_parking_highway.osm
@@ -33,6 +33,27 @@
   <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81120273647' lon='5.81197896425' />
   <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127637074' lon='5.81158864692' />
   <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81125265703' lon='5.81191567956' />
+  <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81089098504' lon='5.81286280125' />
+  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81094724532' lon='5.81242823953' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81108272897' lon='5.81232238476' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8110850253' lon='5.81221652998' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81117802654' lon='5.81225552911' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81101498719' lon='5.8122425294' />
+  <node id='40' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81102072803' lon='5.81215524564' />
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81096102334' lon='5.81220538737' />
+  <node id='42' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81161202981' lon='5.81195096449' />
+  <node id='43' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8115500296' lon='5.81194539318' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81154773329' lon='5.8121125323' />
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81157069634' lon='5.8119751068' />
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81152362207' lon='5.8119751068' />
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81152362208' lon='5.81215338853' />
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81172684594' lon='5.81208838813' />
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81167632738' lon='5.81208467393' />
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81166943848' lon='5.81229266928' />
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8116972791' lon='5.81210742667' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8116458994' lon='5.81210974804' />
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81165393645' lon='5.81218635347' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81171679763' lon='5.81218449637' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -132,5 +153,67 @@
     <tag k='access' v='private' />
     <tag k='highway' v='service' />
     <tag k='service' v='parking_aisle' />
+  </way>
+  <way id='114' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='34' />
+    <nd ref='27' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='115' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='36' />
+    <nd ref='37' />
+    <tag k='access' v='yes' />
+    <tag k='highway' v='track' />
+  </way>
+  <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='38' />
+    <nd ref='39' />
+    <nd ref='40' />
+    <nd ref='38' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='117' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='41' />
+    <nd ref='37' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='118' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='42' />
+    <nd ref='43' />
+    <nd ref='44' />
+    <nd ref='42' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='119' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='45' />
+    <nd ref='46' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='120' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='44' />
+    <nd ref='47' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='121' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='48' />
+    <nd ref='49' />
+    <nd ref='50' />
+    <nd ref='48' />
+    <tag k='amenity' v='parking' />
+  </way>
+  <way id='122' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='51' />
+    <nd ref='52' />
+    <tag k='access' v='private' />
+    <tag k='highway' v='service' />
+  </way>
+  <way id='123' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='53' />
+    <nd ref='54' />
+    <tag k='highway' v='service' />
   </way>
 </osm>


### PR DESCRIPTION
- Detects parkings with public access (`access=yes, permissive, ...` or `access` not set), where all ways leading to it have limited access (such as `private`)
- Adds tests
- ~(Also adds the `&&` intersection check to the existing sql)~

I got the idea after spotting my own mistake here:
https://www.openstreetmap.org/way/1127681810

The road towards the parking is access=private, but the parking itself is set as if it's a public (and free) one, making it stand out when I search for a free parking spot.

Some [results attached](https://github.com/osm-fr/osmose-backend/files/11133361/parking.zip)
