### PR TITLE
Avoid suggesting `parking=street_side` for too large `amenity=parking`

### DIFF
--- a/analysers/Analyser.py
+++ b/analysers/Analyser.py
@@ -363,19 +363,20 @@ class TestAnalyser(unittest.TestCase):
             if fixes is not None:
                 # input: [ {"+": {k1:v1, k2:v2}, "-": [k1, k1], "~": {k1:v1, k2:v2}} , ...]
                 xml_elems = []
-                for f in e.find('fixes').findall('fix'):
-                    fixactions = {"+": {}, "-": [], "~": {}}
-                    for t in ("node", "way", "relation"):
-                        for fi in f.findall(t):
-                            for fix in fi.findall("tag"):
-                                if fix.attrib["action"] == "delete":
-                                    fixactions["-"].append(fix.attrib["k"])
-                                elif fix.attrib["action"] == "modify":
-                                    fixactions["~"][fix.attrib["k"]] = fix.attrib["v"]
-                                elif fix.attrib["action"] == "create":
-                                    fixactions["+"][fix.attrib["k"]] = fix.attrib["v"]
-                    fixactions = {k:v for k,v in fixactions.items() if len(v)}
-                    xml_elems.append(fixactions)
+                if e.find('fixes') is not None:
+                    for f in e.find('fixes').findall('fix'):
+                        fixactions = {"+": {}, "-": [], "~": {}}
+                        for t in ("node", "way", "relation"):
+                            for fi in f.findall(t):
+                                for fix in fi.findall("tag"):
+                                    if fix.attrib["action"] == "delete":
+                                        fixactions["-"].append(fix.attrib["k"])
+                                    elif fix.attrib["action"] == "modify":
+                                        fixactions["~"][fix.attrib["k"]] = fix.attrib["v"]
+                                    elif fix.attrib["action"] == "create":
+                                        fixactions["+"][fix.attrib["k"]] = fix.attrib["v"]
+                        fixactions = {k:v for k,v in fixactions.items() if len(v)}
+                        xml_elems.append(fixactions)
                 if fixes != xml_elems:
                     continue
             return True

--- a/tests/osmosis_parking_highway.osm
+++ b/tests/osmosis_parking_highway.osm
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='JOSM'>
-  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81153986582' lon='5.81084093495' />
-  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81135523212' lon='5.81079842412' />
-  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81131182761' lon='5.81129161495' />
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81142559988' lon='5.81081705868' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81135808025' lon='5.81079940245' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8113093583' lon='5.81128684668' />
   <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81168178543' lon='5.81124732951' />
   <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81149715231' lon='5.81120481869' />
   <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81145374794' lon='5.81169800951' />
@@ -54,10 +54,20 @@
   <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8116458994' lon='5.81210974804' />
   <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81165393645' lon='5.81218635347' />
   <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81171679763' lon='5.81218449637' />
+  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.811376878' lon='5.81130450291' />
+  <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81134120413' lon='5.81079309111' />
+  <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127368437' lon='5.81077543488' />
+  <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81122496233' lon='5.81126287911' />
+  <node id='59' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81129248216' lon='5.81128053534' />
+  <node id='60' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127635684' lon='5.81053898695' />
+  <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81084809207' lon='5.81043376656' />
+  <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.810780024' lon='5.81115856271' />
+  <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81120828942' lon='5.8112637831' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
     <nd ref='3' />
+    <nd ref='55' />
     <nd ref='1' />
     <tag k='amenity' v='parking' />
   </way>
@@ -215,5 +225,22 @@
     <nd ref='53' />
     <nd ref='54' />
     <tag k='highway' v='service' />
+  </way>
+  <way id='124' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='56' />
+    <nd ref='57' />
+    <nd ref='58' />
+    <nd ref='59' />
+    <nd ref='56' />
+    <tag k='amenity' v='parking' />
+    <tag k='parking' v='sheds' />
+  </way>
+  <way id='125' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='60' />
+    <nd ref='61' />
+    <nd ref='62' />
+    <nd ref='63' />
+    <nd ref='60' />
+    <tag k='amenity' v='parking' />
   </way>
 </osm>


### PR DESCRIPTION
**This PR**
- Avoids adding `parking=street_side` as the proposed fix if the perimeter/area ratio is <=0.1
- Fixes the test for `fixes` if no fix is present

**Rationale:**
Currently, Osmose (item 3161, classes 1 and 2 - `Missing access way to parking`) always suggests to fix the issue by adding `parking=street_side`. For some cases, this is clearly wrong, while people may still follow the proposed fix and add it.

By filtering on the perimeter / area ratio, one can filter already on which parkings cannot be street side parkings. A ratio of 0.1 will still allow:
- An infinite row of (4x20m or smaller) cars parked parallel or perpendicular to the street (lets say, cars with XL trailers or small trucks. For context, in NL the maximum allowed length of any road vehicle is 20m, but I think in the USA there's no limit)
- ~70 trucks of 3x22m parked perpendicular to the street (or infinite trucks parallel) 
I would assume that more than 70 trucks in a row (i.e. a street-side parking area over 200m long for trucks only) is a safe cut-off

However, an average parking lot with 2 driveways reaches this after about 15 parallel-parked cars (assumed dimensions: 36x45m)

This would remove the `parking=street_side` suggestion (thus: only the fix suggestion, not the issue itself) for all large parking lots, i.e.:<details>

Japan-Chubu
https://www.openstreetmap.org/way/28678338
https://www.openstreetmap.org/way/28671548
https://www.openstreetmap.org/way/30339726
https://www.openstreetmap.org/way/48036018
etc. (19% of the ways found by this analyser)

USA-iowa
https://www.openstreetmap.org/way/37290504
https://www.openstreetmap.org/way/41889692
https://www.openstreetmap.org/way/104473512
https://www.openstreetmap.org/way/132307608
https://www.openstreetmap.org/way/136920594
https://www.openstreetmap.org/way/136920595
https://www.openstreetmap.org/way/136920596
etc. (10% of the ways found by this analyser)

Sweden-Gotland
https://www.openstreetmap.org/way/9230470
https://www.openstreetmap.org/way/127163852
https://www.openstreetmap.org/way/127191208
https://www.openstreetmap.org/way/127191209
https://www.openstreetmap.org/way/203037123
https://www.openstreetmap.org/way/203245575
etc. (8% of the ways found by this analyser)

Slovenia
https://www.openstreetmap.org/way/73300005
https://www.openstreetmap.org/way/112389857
https://www.openstreetmap.org/way/127296864
https://www.openstreetmap.org/way/143494192
etc. (4% of the ways found by this analyser)

Jersey
https://www.openstreetmap.org/way/213129429
https://www.openstreetmap.org/way/909114029
(4% of the ways found by this analyser - note: only 55 total)

Germany-Saarland
https://www.openstreetmap.org/way/27085086
https://www.openstreetmap.org/way/45851318
https://www.openstreetmap.org/way/45851329
https://www.openstreetmap.org/way/53099565
etc. (3% of the ways found by this analyser)

Belgium-Wallonia-German-community
https://www.openstreetmap.org/way/99228222
https://www.openstreetmap.org/way/114010852
https://www.openstreetmap.org/way/232303724
https://www.openstreetmap.org/way/472521048
https://www.openstreetmap.org/way/723331896
etc. (3% of the ways found by this analyser)

Netherlands-Gelderland
https://www.openstreetmap.org/way/280784092
https://www.openstreetmap.org/way/323273483
https://www.openstreetmap.org/way/480629121
https://www.openstreetmap.org/way/544400653
https://www.openstreetmap.org/way/559509162
etc. (2% of the ways found by this analyser)


(The fraction varies a lot for the different countries, as some countries have many more actual street-side parking lots mapped)
</details>

Side note: 
In order to do this, I had to change `ST_NPoints(pr.linestring) >= 2` to `pr.is_polygon`, but there are only [154 non-closed `amenity=parking` ways worldwide](https://overpass-turbo.eu/s/1twu), so I would call this no big loss.