### PR TITLE
Whitelist `delivery`

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -79,6 +79,7 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             'communication:mobile_phone',
             'cuisine',
             'operator',
+            'delivery',
             'changing_table:location',
             'furniture',
             'seamark:berth:category',


### PR DESCRIPTION
I spotted the following issue: https://osmose.openstreetmap.fr/nl/issue/73dcb03d-bae1-21af-cbf3-afffcd3e171c

>Similar values Sa 11:00-22:00 and Su 12:00-22:00 in delivery=Mo-Fr 15:00-22:00; Sa 11:00-22:00; Su 12:00-22:00

Apparently it's documented for quite a while already: https://wiki.openstreetmap.org/wiki/Key:delivery
(Although I would personally prefer `opening_hours:delivery=*` over `delivery=*`, but currently it's a weird warning about similar values, hence whitelisting it)