### PR TITLE
Fix TagWatchFrViPofm after wiki updates

### DIFF
--- a/plugins/TagWatchFrViPofm.py
+++ b/plugins/TagWatchFrViPofm.py
@@ -160,7 +160,7 @@ class Test(TestPluginCommon):
         self.check_err(a.node(None, {"aera": "plop"}))               # No only_for
         self.check_err(a.node(None, {"administrative": "boundary"})) # No only_for
         assert not a.node(None, {"School:FR": "plop"})   # only_for FR
-        assert not a.node(None, {"amenity": "Chapelle"}) # only for fr
+        assert not a.node(None, {"amenity": "Pharmacie"}) # only for fr
         assert not a.node(None, {"amenity": u"Collège"}) # only_for fr
 
 
@@ -175,7 +175,7 @@ class Test(TestPluginCommon):
         self.check_err(a.node(None, {"aera": "plop"}))               # No only_for
         self.check_err(a.node(None, {"administrative": "boundary"})) # No only_for
         self.check_err(a.node(None, {"School:FR": "plop"})) # only_for FR
-        assert not a.node(None, {"amenity": "Chapelle"})    # only for fr
+        assert not a.node(None, {"amenity": "Pharmacie"})    # only for fr
         assert not a.node(None, {"amenity": u"Collège"})    # only_for fr
 
     def test_only_for_fr(self):
@@ -189,5 +189,5 @@ class Test(TestPluginCommon):
         self.check_err(a.node(None, {"aera": "plop"}))               # No only_for
         self.check_err(a.node(None, {"administrative": "boundary"})) # No only_for
         assert not a.node(None, {"School:FR": "plop"})        # only_for FR
-        self.check_err(a.node(None, {"amenity": "Chapelle"})) # only for fr
+        self.check_err(a.node(None, {"amenity": "Pharmacie"})) # only for fr
         self.check_err(a.node(None, {"amenity": u"Collège"})) # only_for fr

--- a/plugins/TagWatchFrViPofm.py
+++ b/plugins/TagWatchFrViPofm.py
@@ -54,8 +54,8 @@ class TagWatchFrViPofm(Plugin):
 
         reline = re.compile(r"^\|([^|]*)\|\|([^|]*)\|\|([^|]*)\|\|([^|]*).*")
 
-        # Obtain the info from https://wiki.openstreetmap.org/index.php?title=Tagging_Mistakes
-        data = urlread(u"https://wiki.openstreetmap.org/index.php?title=Tagging_Mistakes&action=raw", 1)
+        # Obtain the info from https://wiki.openstreetmap.org/index.php?title=Tagging_mistakes
+        data = urlread(u"https://wiki.openstreetmap.org/index.php?title=Tagging_mistakes&action=raw", 1)
         data = data.split("\n")
         for line in data:
             for res in reline.findall(line):
@@ -69,7 +69,7 @@ class TagWatchFrViPofm(Plugin):
                         title = {'en': c0},
                         detail = T_(
 '''Simple and frequent errors, can be updated by anyone on the wiki.'''),
-                        resource = 'https://wiki.openstreetmap.org/wiki/Tagging_Mistakes')
+                        resource = 'https://wiki.openstreetmap.org/wiki/Tagging_mistakes')
                     if u"=" in res[0]:
                         k = res[0].split(u"=")[0].strip()
                         v = res[0].split(u"=")[1].strip()


### PR DESCRIPTION
Renamed earlier today by Tigerfell https://wiki.openstreetmap.org/w/index.php?title=Tagging_mistakes&action=history

Also Chapelle was removed from the wiki ( https://wiki.openstreetmap.org/w/index.php?title=Tagging_mistakes&type=revision&diff=2505513&oldid=2505107 )