### PR TITLE
Allow highway=path to indoor features

### DIFF
--- a/analysers/analyser_osmosis_indoor.py
+++ b/analysers/analyser_osmosis_indoor.py
@@ -113,7 +113,7 @@ FROM
         highways.id = highway_ends.id
 WHERE
     indoor_surfaces.indoor IN ('room', 'corridor', 'area') AND
-    highways.highway IN ('steps', 'footway', 'pedestrian')
+    highways.highway IN ('steps', 'footway', 'pedestrian', 'path')
 """
 
 # TODO : check that all surfaces have at least one connected_highway_level that matches it own surface_level


### PR DESCRIPTION
See #1813 
Although usually `highway=footway` seems more appropriate, it doesn't seem wrong to have `highway=path` (the wiki of highway=path also indicates there's a lot of debate on when something is truely a footway)

Additionally, the warning message (`This indoor feature is not reachable`) is very confusing for such situations, as an indoor feature connected by a path is actually connected.

Hence lets tolerate `highway=path`