### PR TITLE
Add warning when analyser ran while not in config

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -2026,6 +2026,21 @@ class TestPluginCommon(unittest.TestCase):
         duplicate_polygon_ids = list(map(lambda a: a[0], filter(lambda c: c[1] >= 2, Counter(polygon_ids).items())))
         assert len(duplicate_polygon_ids) == 0, "Duplicate relation IDs: {}".format(sorted(duplicate_polygon_ids))
 
+    def test_analysersExist(self):
+        # Get all analysers ran for at least 1 country
+        c = config.values()
+        analysers_per_country = list(map(lambda cc: list(cc.analyser.keys()), c))
+        all_analysers = {i for country_list in analysers_per_country for i in country_list}
+
+        # Get all files in the directory with analysers
+        analysers_path = os.path.join(os.path.dirname(__file__), "analysers")
+        analyser_files = os.listdir(analysers_path)
+
+        # Verify analyser file corresponding to analyser name exist
+        for a in all_analysers:
+            f = "analyser_" + a + ".py"
+            assert f in analyser_files, "Not found: {0}".format(f)
+
 if __name__ == "__main__":
 
   import json


### PR DESCRIPTION
To make it more easy to spot when I'm running an analyser (with `--analyser=*` as I always do) without adding it to the config properly (see #1825), add a warning message.
(A "normal" test didn't seem like a good idea to me, since sometimes analysers are disabled on purpose, for example merge_street_objects at the moment, but this would pop up as a useful warning that you're running something via `--analyser=*` that wouldn't run normally)

Feel free to reject this idea, it was just a thought to make Osmose more Famlam-proof 😉 