### PR TITLE
Exclude mini-intersections

### DIFF
--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -217,11 +217,9 @@ WHERE
       mobility_way_type != 'highway'
     )
   )
-GROUP BY
+ORDER BY
   mobility_way_id,
   landusage_way_id,
-  landusage_poly,
-  mobility_way_linestring,
   mobility_way_type,
   tag_way,
   tag_polygon

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -135,41 +135,67 @@ sql13 = """
 -- Collect highway|railway|aeroways either entering or fully inside landuse/natural geometries
 CREATE TEMP TABLE intersecting_geometries AS
 SELECT
-  mobility_ways.id AS mobility_way_id,
-  mobility_ways.linestring AS mobility_way_linestring,
-  mobility_ways.type AS mobility_way_type,
-  landusage.id AS landusage_way_id,
-  landusage.poly AS landusage_poly,
-  landusage.landusekey,
-  landusage.landusevalue,
-  CONCAT(mobility_ways.type, '=', mobility_ways.tags->mobility_ways.type) AS tag_way,
-  CONCAT(landusage.landusekey, '=', landusage.landusevalue) AS tag_polygon
-FROM
-  mobility_ways
-  JOIN landusage ON
-    (
+  mobility_way_id,
+  mobility_way_linestring,
+  mobility_way_type,
+  landusage_way_id,
+  landusage_poly,
+  landusekey,
+  landusevalue,
+  tag_way,
+  tag_polygon
+FROM (
+  SELECT
+    mobility_ways.id AS mobility_way_id,
+    mobility_ways.linestring AS mobility_way_linestring,
+    mobility_ways.type AS mobility_way_type,
+    landusage.id AS landusage_way_id,
+    landusage.poly AS landusage_poly,
+    landusage.linestring AS landusage_linestring,
+    landusage.landusekey,
+    landusage.landusevalue,
+    CONCAT(mobility_ways.type, '=', mobility_ways.tags->mobility_ways.type) AS tag_way,
+    CONCAT(landusage.landusekey, '=', landusage.landusevalue) AS tag_polygon,
+    (ST_Dump(ST_Transform(ST_Intersection(landusage.poly, mobility_ways.linestring), {proj}))).geom AS intersection_part_geom,
+    landusage.is_multipolygon AS skip_intersection_size_check -- due to ST_buffer approach for mp, instead of full parsing of inners/outers
+  FROM
+    mobility_ways
+    JOIN landusage ON
       (
-        NOT landusage.tags?'layer' AND NOT mobility_ways.tags?'layer'
-      ) OR (
-        landusage.tags?'layer' AND mobility_ways.tags?'layer' AND
-        landusage.tags->'layer' = mobility_ways.tags->'layer'
-      )
-    ) AND
-    landusage.linestring && mobility_ways.linestring AND
-    -- Only find ways where the highway/railway/aeroway actually enters the
-    -- polygon. Exclude cases where the polygon is tied to the way without going inside.
-    (
-      ST_Crosses(landusage.linestring, mobility_ways.linestring) OR
+        (
+          NOT landusage.tags?'layer' AND NOT mobility_ways.tags?'layer'
+        ) OR (
+          landusage.tags?'layer' AND mobility_ways.tags?'layer' AND
+          landusage.tags->'layer' = mobility_ways.tags->'layer'
+        )
+      ) AND
+      landusage.linestring && mobility_ways.linestring AND
+      -- Only find ways where the highway/railway/aeroway actually enters the
+      -- polygon. Exclude cases where the polygon is tied to the way without going inside.
       (
-        ST_Contains(landusage.poly, mobility_ways.linestring) AND
-        NOT landusage.is_multipolygon -- due to ST_buffer approach for mp, instead of full parsing of inners/outers
+        ST_Crosses(landusage.linestring, mobility_ways.linestring) OR
+        (
+          ST_Contains(landusage.poly, mobility_ways.linestring) AND
+          NOT landusage.is_multipolygon -- due to ST_buffer approach for mp, instead of full parsing of inners/outers
+        )
       )
+  ) AS t
+WHERE
+  skip_intersection_size_check OR
+  (
+    -- Only include significant intersections
+    ST_Length(intersection_part_geom) > 2 AND
+    (
+      ST_Distance(ST_Centroid(intersection_part_geom), ST_Transform(mobility_way_linestring, {proj})) > 1 OR
+      ST_Distance(ST_Centroid(intersection_part_geom), ST_Transform(landusage_linestring, {proj})) > 1
     )
+  )
 """
 
 sql14 = """
 -- Intersections with railway, aeroway or highway
 SELECT
+  DISTINCT ON (mobility_way_id, landusage_way_id)
   mobility_way_id,
   landusage_way_id,
   ST_AsText(ST_PointOnSurface(ST_Intersection(landusage_poly, mobility_way_linestring))),
@@ -191,6 +217,14 @@ WHERE
       mobility_way_type != 'highway'
     )
   )
+GROUP BY
+  mobility_way_id,
+  landusage_way_id,
+  landusage_poly,
+  mobility_way_linestring,
+  mobility_way_type,
+  tag_way,
+  tag_polygon
 """
 
 class Analyser_Osmosis_Polygon_Intersects(Analyser_Osmosis):
@@ -274,4 +308,5 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1049"), ("way", "1043")])
         self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1050"), ("way", "1047")])
         self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1055"), ("way", "1052")])
-        self.check_num_err(14)
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1062"), ("way", "1059")])
+        self.check_num_err(15)

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -207,7 +207,7 @@ FROM
 WHERE
   (
     landusekey = 'landuse' AND
-    landusevalue NOT IN ('civic_admin', 'commercial', 'construction', 'education', 'grass', 'harbour', 'industrial', 'military', 'port', 'proposed', 'railway', 'religious', 'residential', 'retail', 'winter_sports')
+    landusevalue NOT IN ('civic_admin', 'commercial', 'construction', 'education', 'grass', 'harbour', 'industrial', 'military', 'port', 'proposed', 'quarry', 'railway', 'religious', 'residential', 'retail', 'winter_sports')
   ) OR (
     landusekey = 'natural' AND
     landusevalue IN ('bay', 'cliff', 'scrub', 'shrubbery', 'sinkhole', 'tree_group', 'wetland', 'wood') OR

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -118,6 +118,21 @@
   <node id='155' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82735410949' lon='5.93945301264' />
   <node id='156' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82900157915' lon='5.8820351702' />
   <node id='157' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82801107079' lon='5.8846363293' />
+  <node id='158' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.86325415449' lon='5.94951099447' />
+  <node id='159' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85482861434' lon='5.94430396071' />
+  <node id='160' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8519525888' lon='5.95650321883' />
+  <node id='161' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85462725272' lon='5.94522112268' />
+  <node id='162' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85180850371' lon='5.95664434869' />
+  <node id='163' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.86335610317' lon='5.94952434142' />
+  <node id='164' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85759956032' lon='5.95301346689' />
+  <node id='165' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.86047233074' lon='5.95122267254' />
+  <node id='166' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85469567' lon='5.9547965556' />
+  <node id='167' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85386091171' lon='5.94437696956' />
+  <node id='168' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85483260746' lon='5.94430388623' />
+  <node id='169' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85509278473' lon='5.94660197761' />
+  <node id='170' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85473263308' lon='5.94986392287' />
+  <node id='171' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.86305597816' lon='5.94939459778' />
+  <node id='172' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85940211083' lon='5.94713689084' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -398,6 +413,38 @@
     <nd ref='156' />
     <nd ref='157' />
     <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1059' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='158' />
+    <nd ref='159' />
+    <nd ref='160' />
+    <nd ref='158' />
+    <tag k='landuse' v='forest' />
+    <tag k='name' v='Small intersection woods' />
+  </way>
+  <way id='1060' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='167' />
+    <nd ref='161' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='1061' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='162' />
+    <nd ref='166' />
+    <nd ref='164' />
+    <nd ref='165' />
+    <nd ref='163' />
+    <nd ref='171' />
+    <nd ref='172' />
+    <tag k='railway' v='rail' />
+    <tag k='note' v='many very shallow intersections' />
+  </way>
+  <way id='1062' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='170' />
+    <nd ref='167' />
+    <nd ref='168' />
+    <nd ref='169' />
+    <tag k='highway' v='motorway' />
+    <tag k='note' v='small + 2x big intersection' />
   </way>
   <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='1045' role='inner' />


### PR DESCRIPTION
Fixes #1836

(Note for reviewing: many lines are just indention changes, so switching off showing whitespace changes is recommended) 

For some bigger extracts:
usa_iowa: 157->130 results
slovenia: 543->388 results
netherlands_gelderland: 222->127 results
japan_chubu: 7025->6479 results
germany_saarland: 268->248 results

No significant differences in runtime.

Also whitelists `landuse=quarry`, which often contains railways