### PR TITLE
Imporve perf of Analyser osmosis highway vs building.py

### DIFF
--- a/pylama.ini
+++ b/pylama.ini
@@ -1,5 +1,5 @@
 [pylama]
-skip = venv/*,docker/work/.local/*,analysers/disabled/*,mapcss/generated/*,mapcss/mapcss/*,plugins/Josm_*,docker/work/.jupyter/jupyter_notebook_config.py,plugins/tests/test_mapcss_parsing_evalutation.py
+skip = .git/*,venv/*,docker/work/.local/*,analysers/disabled/*,mapcss/generated/*,mapcss/mapcss/*,plugins/Josm_*,docker/work/.jupyter/jupyter_notebook_config.py,plugins/tests/test_mapcss_parsing_evalutation.py
 ignore = E501,E266,E231,E306,E302,E202,E265,E305,E713,E201,E261,E127,E701,E303,C901,E301,E402,E122,E221,E124,E128,E251,E129,E741,E731,E111,E114,E722,E226
 
 [pylama:pyflakes]


### PR DESCRIPTION
Optimize the more time consuming analyzer.

First commit : ensure not duplicate issue reported. Required for the second commit.
Second commit : split the highway to hit less objects on index (especially building).

After the first commit, on tested extract (Gironde) the result is the same.
After second commit there is few more reported issues because multiples intersection on same highway x waterway including one issue intersection and one not issue intersection are not reported. So the split may report previously hidden issues.

Time before commits : 9m42.061s, 9m26.890s, 8m41.663s, 9m48.615s
Time after first commit : 9m48.978s, 9m48.820s, 8m56.001s, 9m50.080s
Time after second commit: 7m15.892s, 7m25.198s, 7m3.211s
