### PR TITLE
merge: skip timestamp computation when no sub analyser

### DIFF
--- a/analysers/Analyser_Merge_Dynamic.py
+++ b/analysers/Analyser_Merge_Dynamic.py
@@ -46,8 +46,9 @@ class Analyser_Merge_Dynamic(Analyser):
                 #     analyser_obj.analyser_change()
 
     def timestamp(self):
-        with self.analysers[0](self.config, self.error_file,  self.logger) as analyser_obj:
-            return analyser_obj.timestamp()
+        if self.analysers:
+            with self.analysers[0](self.config, self.error_file,  self.logger) as analyser_obj:
+                return analyser_obj.timestamp()
 
 
 class SubAnalyser_Merge_Dynamic(Analyser_Merge_Point):


### PR DESCRIPTION
Fail safe when no merge sub-analyser configured.

It is the case of merge_traffic_signs for bir_tawil, probably because missing datasource to define sub-analyser.