### PR TITLE
Exclude pedestrian from tree-too-close

### DIFF
--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -243,7 +243,7 @@ FROM
     JOIN {1}highway AS highway ON
         highway.level = '0' AND
         highway.layer = '0' AND
-        highway.highway NOT IN ('footway', 'path', 'track') AND
+        highway.highway NOT IN ('footway', 'path', 'track', 'pedestrian') AND
         tree.geom && highway.linestring AND
         ST_Intersects(ST_Buffer(tree.geom::geography, 0.25)::geometry, highway.linestring)
 ORDER BY


### PR DESCRIPTION
Fixes #1852 

Allow trees very close to the edge of `highway=pedestrian`.

Alternative would be something like:
```sql
(highway.highway != 'pedestrian' OR nodes[1] != nodes[array_length(nodes, 1)]) AND
```
(or adding `is_polygon` in table highway)