### PR TITLE
Add support of requires_tables multipolygons #1818

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -107,6 +107,92 @@ WHERE
 ANALYZE {0}.highway_ends;
 """
 
+    # Multipolygons table is not complete. It does not contain multipolygons across extract border or invalid ones.
+    sql_create_multipolygons = """
+DO $$
+DECLARE
+    mp RECORD;
+BEGIN
+    DROP TABLE IF EXISTS {0}.multipolygons;
+    CREATE UNLOGGED TABLE {0}.multipolygons (
+        id bigint,
+        tags hstore,
+        poly geometry(Geometry, 4326) NOT NULL,
+        poly_proj geometry(Geometry, {1}) NOT NULL,
+        is_valid boolean NOT NULL
+    );
+
+    FOR mp in (
+        SELECT
+            relations.id,
+            relations.tags,
+            ST_LineMerge(ST_Collect(ways.linestring)) AS linestrings
+        FROM
+            relations
+            JOIN relation_members ON
+                relation_members.relation_id = relations.id AND
+                relation_members.member_type = 'W' AND
+                relation_members.member_role IN ('outer', 'inner')
+            JOIN ways ON
+                ways.id = relation_members.member_id
+        WHERE
+            relations.tags->'type' = 'multipolygon'
+        GROUP BY
+            relations.id
+    ) LOOP
+        BEGIN
+            IF ST_BuildArea(mp.linestrings) IS NOT NULL AND NOT ST_IsEmpty(ST_BuildArea(mp.linestrings)) THEN
+                WITH
+                unary AS (
+                    SELECT
+                        id, tags,
+                        (ST_Dump(poly)).geom AS poly
+                    FROM (VALUES (
+                        mp.id,
+                        mp.tags,
+                        ST_BuildArea(mp.linestrings)
+                    )) AS t(id, tags, poly)
+                ),
+                simplified AS (
+                    SELECT
+                        id, tags,
+                        ST_BuildArea(ST_Collect(
+                            ST_ExteriorRing(poly),
+                            (SELECT ST_Union(ST_InteriorRingN(poly, n)) FROM generate_series(1, ST_NumInteriorRings(poly)) AS t(n))
+                        )) AS poly
+                    FROM
+                        unary
+                ),
+                multi AS (
+                    SELECT
+                        id, tags,
+                        ST_CollectionHomogenize(ST_Collect(poly)) AS poly
+                    FROM
+                        simplified
+                    GROUP BY
+                        id, tags
+                )
+                INSERT INTO
+                    {0}.multipolygons
+                SELECT
+                    *,
+                    ST_Transform(poly, {1}) AS poly_proj,
+                    ST_IsValid(poly) AS is_valid
+                FROM multi;
+            END IF;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'multipolygon fails: %', mp.id;
+        END;
+    END LOOP;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE INDEX idx_multipolygons_poly ON {0}.multipolygons USING GIST(poly);
+CREATE INDEX idx_multipolygons_poly_proj ON {0}.multipolygons USING gist(poly_proj);
+CREATE INDEX idx_multipolygons_tags ON {0}.multipolygons USING gist (tags);
+ANALYZE {0}.multipolygons;
+"""
+
     sql_create_buildings = """
 CREATE UNLOGGED TABLE {0}.buildings AS
 SELECT
@@ -268,6 +354,11 @@ ANALYZE {0}.buildings;
                 elif table == 'touched_highway_ends':
                     self.requires_tables_build(["highway_ends"])
                     self.create_view_touched('highway_ends', 'W')
+                elif table == 'multipolygons':
+                    self.giscurs.execute(self.sql_create_multipolygons.format(self.config.db_schema.split(',')[0], self.config.options.get("proj")))
+                elif table == 'touched_multipolygons':
+                    self.requires_tables_build(['multipolygons'])
+                    self.create_view_touched('multipolygons', 'R')
                 elif table == 'buildings':
                     self.giscurs.execute(self.sql_create_buildings.format(self.config.db_schema.split(',')[0], self.config.options.get("proj")))
                 elif table == 'touched_buildings':

--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -133,12 +133,16 @@ BEGIN
                 relation_members.relation_id = relations.id AND
                 relation_members.member_type = 'W' AND
                 relation_members.member_role IN ('outer', 'inner')
-            JOIN ways ON
+            LEFT JOIN ways ON
                 ways.id = relation_members.member_id
         WHERE
             relations.tags->'type' = 'multipolygon'
         GROUP BY
             relations.id
+        HAVING
+            -- Ensure all ways are downloaded; may be false at extract borders
+            -- If false, calculations like ST_Area would give invalid results
+            bool_and(ways.id IS NOT NULL)
     ) LOOP
         BEGIN
             IF ST_BuildArea(mp.linestrings) IS NOT NULL AND NOT ST_IsEmpty(ST_BuildArea(mp.linestrings)) THEN

--- a/analysers/analyser_osmosis_polygon_small.py
+++ b/analysers/analyser_osmosis_polygon_small.py
@@ -126,4 +126,6 @@ class Test(TestAnalyserOsmosis):
 
         self.root_err = self.load_errors()
         self.check_err(cl="1", elems=[("way", "100")])
-        self.check_num_err(1)
+        self.check_err(cl="3", elems=[("relation", "1000")])
+        self.check_err(cl="3", elems=[("relation", "1001")])
+        self.check_num_err(3)

--- a/analysers/analyser_osmosis_polygon_small.py
+++ b/analysers/analyser_osmosis_polygon_small.py
@@ -26,16 +26,16 @@ from .Analyser_Osmosis import Analyser_Osmosis
 sql10 = """
 SELECT
   id,
-  ST_AsText(way_locate(ways.linestring)),
-  ST_Area(ST_MakePolygon(ST_Transform(ways.linestring, {proj})))
+  ST_AsText(way_locate(linestring)),
+  ST_Area(ST_MakePolygon(ST_Transform(linestring, {proj})))
 FROM
-  {touched}ways AS ways
+  {touched}ways
 WHERE
-  ways.is_polygon AND
-  ways.tags != ''::hstore AND
-  ways.tags?'{key}' AND
-  ways.tags->'{key}' = '{val}' AND
-  ST_Area(ST_MakePolygon(ST_Transform(ways.linestring, {proj}))) < {minarea}
+  is_polygon AND
+  tags != ''::hstore AND
+  tags?'{key}' AND
+  tags->'{key}' = '{val}' AND
+  ST_Area(ST_MakePolygon(ST_Transform(linestring, {proj}))) < {minarea}
 """
 
 

--- a/doc/3-SQL-basics.md
+++ b/doc/3-SQL-basics.md
@@ -166,10 +166,11 @@ FROM
 #### Common Factorized tables
 May analyzers work on same topic. To avoid recomputing intermediate tables many time, and not always on the ways in interpreting OSM tags, some generic tables are available. There are computed only on request, but reused once it is done.
 
-The available common tables are (see full definition in Analyser_Osmosis.py):
-* highways: with tags normalization, levels classification and re projected in local country _projection_.
-* highway_ends: the start and ends of all highways ways.
-* buildings: from ways (and not from multipolygon relations), with tags normalization and re-projected in local country _projection_ as _polygons_.
+The available common tables are (see full definition in [Analyser_Osmosis.py](https://github.com/osm-fr/osmose-backend/blob/master/analysers/Analyser_Osmosis.py)):
+* `highways`: with tags normalization, levels classification and re projected in local country _projection_.
+* `highway_ends`: the start and ends of all highways ways.
+* `buildings`: from ways (and not from multipolygon relations), with tags normalization and re-projected in local country _projection_ as _polygons_.
+* `multipolygons`: multipolygon relations with relation id, relation tags, geometry and projected geometry, and whether the multipolygon is valid.
 
 The dependencie on this common tables should be declared in the analyzer class:
 ```python

--- a/osmosis/CreateFunctions.sql
+++ b/osmosis/CreateFunctions.sql
@@ -171,6 +171,13 @@ $$ LANGUAGE plpgsql
    STABLE
    RETURNS NULL ON NULL INPUT;
 
+CREATE OR REPLACE FUNCTION multipolygon_locate(poly geometry) RETURNS geometry AS $$
+DECLARE BEGIN
+    RETURN ST_PointOnSurface(poly);
+END
+$$ LANGUAGE plpgsql
+   IMMUTABLE
+   RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION any_locate(type char(1), aid bigint) RETURNS geometry AS $$
     SELECT CASE $1

--- a/tests/osmosis_polygon_small.osm
+++ b/tests/osmosis_polygon_small.osm
@@ -8,6 +8,37 @@
   <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80085598998' lon='5.74981982866' />
   <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80045350538' lon='5.74986704567' />
   <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80050958423' lon='5.75111704591' />
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8008186065' lon='5.7513633502' />
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80080902447' lon='5.7513630335' />
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80080886473' lon='5.75137567153' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081895308' lon='5.75138055576' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80080808158' lon='5.75138028168' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8008079404' lon='5.75139492531' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8008188119' lon='5.75139519939' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081746313' lon='5.75138616179' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081542161' lon='5.75138242986' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081506656' lon='5.751391042' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081293627' lon='5.75138917604' />
+  <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80081284751' lon='5.75138443936' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80080938579' lon='5.75138687947' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80076349641' lon='5.75134826738' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80066905341' lon='5.75134711909' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80070384822' lon='5.75167667688' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80073935311' lon='5.75140568163' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80067899479' lon='5.75135975023' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80074929447' lon='5.7513620468' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80071875491' lon='5.75146921011' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80068010042' lon='5.75138565571' />
+  <node id='30' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80074215838' lon='5.75143911416' />
+  <node id='31' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80103880092' lon='5.7512553287' />
+  <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80086659312' lon='5.75128333305' />
+  <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80089365628' lon='5.75171851688' />
+  <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80088667498' lon='5.75129819347' />
+  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80087439217' lon='5.7513007915' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80087553718' lon='5.75131494709' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8010147582' lon='5.75139271168' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80100247543' lon='5.75139530971' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.80100362043' lon='5.75140946529' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -26,4 +57,107 @@
     <tag k='natural' v='wood' />
     <tag k='note' v='area: 3875.70m2' />
   </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='9' />
+    <nd ref='10' />
+    <nd ref='11' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='11' />
+    <nd ref='9' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='12' />
+    <nd ref='13' />
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='12' />
+  </way>
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='16' />
+    <nd ref='17' />
+    <nd ref='18' />
+    <nd ref='16' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='19' />
+    <nd ref='20' />
+    <nd ref='21' />
+  </way>
+  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='21' />
+    <nd ref='19' />
+  </way>
+  <way id='108' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='22' />
+    <nd ref='23' />
+    <nd ref='24' />
+    <nd ref='22' />
+  </way>
+  <way id='109' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='25' />
+    <nd ref='26' />
+    <nd ref='27' />
+    <nd ref='25' />
+  </way>
+  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='28' />
+    <nd ref='29' />
+    <nd ref='30' />
+    <nd ref='28' />
+  </way>
+  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='31' />
+    <nd ref='32' />
+    <nd ref='33' />
+    <nd ref='31' />
+  </way>
+  <way id='112' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='34' />
+    <nd ref='35' />
+    <nd ref='36' />
+    <nd ref='34' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='37' />
+    <nd ref='38' />
+    <nd ref='39' />
+    <nd ref='37' />
+  </way>
+  <relation id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='105' role='inner' />
+    <member type='way' ref='106' role='inner' />
+    <member type='way' ref='107' role='inner' />
+    <member type='way' ref='104' role='outer' />
+    <member type='way' ref='102' role='outer' />
+    <member type='way' ref='103' role='outer' />
+    <tag k='landuse' v='farmland' />
+    <tag k='note' v='Complex micro multipolygon' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='1001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='109' role='inner' />
+    <member type='way' ref='108' role='outer' />
+    <member type='way' ref='110' role='inner' />
+    <tag k='landuse' v='farmland' />
+    <tag k='note' v='Outer &gt; treshold, outer - both inner &lt; treshold, (outer- 1 inner above treshold) should warn' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='1002' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='113' role='outer' />
+    <member type='way' ref='112' role='inner' />
+    <member type='way' ref='111' role='outer' />
+    <tag k='landuse' v='forest' />
+    <tag k='note' v='Big polygon with a mini outer part of it. Shouldn&apos;t match. Just conceptually to test mp parsing' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='1003' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='113' role='outer' />
+    <member type='way' ref='999999999' role='outer' />
+    <tag k='landuse' v='forest' />
+    <tag k='note' v='Incomplete polygon, shouldn&apos;t parse as the second &apos;missing&apos; outer could be very large' />
+    <tag k='type' v='multipolygon' />
+  </relation>
 </osm>


### PR DESCRIPTION
Implement a new common required table for multipolygons. See #1818.

Use it in a first analyser as demo analyser_osmosis_polygon_small.

TODO:
- [x] Update the doc
- [x] Add warning, contains only closed and borders inside polygon
- [x] Use `LEFT JOIN` to fail on missing members
- [x] Remove version, user_id, tstamp, changeset_id