### PR TITLE
Treat `highway=pedestrian` polygons as areas

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -45,7 +45,10 @@ SELECT
     tags->'highway' LIKE '%_link' AS is_link,
     (tags?'junction' AND tags->'junction' = 'roundabout') AS is_roundabout,
     (tags?'oneway' AND tags->'oneway' IN ('yes', 'true', '1', '-1')) AS is_oneway,
-    (tags?'area' AND tags->'area' != 'no') AS is_area,
+    CASE
+      WHEN tags?'area' THEN tags->'area' != 'no'
+      ELSE (is_polygon AND tags->'highway' = 'pedestrian')
+    END AS is_area,
     tags->'highway' IN ('planned', 'proposed', 'construction') AS is_construction,
     CASE tags->'highway'
         WHEN 'motorway' THEN 1


### PR DESCRIPTION
Part 1 of 2 of https://github.com/osm-fr/osmose-backend/issues/1852#issuecomment-1541835203

Treat closed `highway=pedestrian` polygons as areas by default, unless `area=no` is tagged.
This matches the behavior with at least Carto, iD and JOSM. (Note however that there is no documentation for this: the wiki also recommends adding `area`)

Best is to have an area tag present, of course, but it's not always the case.
Currently, worldwide, 229080 closed `highway=pedestrian`, of which 9620 without `area` tag (4%)

Confirmed with the Barcelona extract (which contains a few) that such ways do not get strange detections due to this PR