### PR TITLE
Whitelist names in NSI from plugin Name_Script

### DIFF
--- a/plugins/Name_Script.py
+++ b/plugins/Name_Script.py
@@ -27,6 +27,7 @@ from modules.languages import language2scripts, gen_regex
 from modules import confusables
 from modules.py3 import ilen
 from modules.Stablehash import stablehash64
+from plugins.modules.name_suggestion_index import whitelist_from_nsi
 
 
 class Name_Script(Plugin):
@@ -117,6 +118,10 @@ appropriate.'''),
 
         self.names = [u"name", u"name_1", u"name_2", u"alt_name", u"loc_name", u"old_name", u"official_name", u"short_name"]
 
+        self.whitelist_names = set()
+        if country:
+            self.whitelist_names = whitelist_from_nsi(country.lower())
+
     def node(self, data, tags):
         err = []
         for key, value in tags.items():
@@ -157,7 +162,7 @@ appropriate.'''),
                 break
 
             if self.default:
-                if key in self.names:
+                if key in self.names and value not in self.whitelist_names:
                     s = self.non_letter.sub(u" ", value)
                     s = self.alone_char.sub(u"", s)
                     s = self.roman_number.sub(u"", s)
@@ -226,6 +231,7 @@ class Test(TestPluginCommon):
 
         assert not a.node(None, {u"name": u"test ь"})
         assert not a.node(None, {u"name": u"Sacré-Cœur"})
+        assert not a.node(None, {u"name": u"Søstrene Grene"}) # in NSI
 
         self.check_err(a.node(None, {u"name:uk": u"Sacré-Cœur"}))
 

--- a/plugins/TagFix_Brand.py
+++ b/plugins/TagFix_Brand.py
@@ -22,9 +22,7 @@
 from modules.OsmoseTranslation import T_
 from plugins.Plugin import TestPluginCommon
 from plugins.Plugin import Plugin
-from modules.downloader import urlread
-import json
-
+from plugins.modules.name_suggestion_index import download_nsi
 
 class TagFix_Brand(Plugin):
 
@@ -52,15 +50,9 @@ If not, see if you can improve the [name-suggestion-index project](https://githu
             return False
         self.country_code = self.father.config.options.get("country").split("-")[0].lower()
 
-        nsi = self._download_nsi()
+        nsi = download_nsi()
         self.brands_from_nsi = self._parse_category_from_nsi(nsi, "brands/", "brand")
         self.operators_from_nsi = self._parse_category_from_nsi(nsi, "operators/", "operator")
-
-    def _download_nsi(self):
-        nsi_url = "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/nsi.json"
-        json_str = urlread(nsi_url, 30)
-        results = json.loads(json_str)
-        return results['nsi']
 
     def _parse_category_from_nsi(self, nsi, nsiprefix, key):
         additional_presets = {}

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -1,0 +1,59 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Frédéric Rodrigo 2016                                      ##
+## Copyrights Noémie Lehuby 2020                                         ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+
+# This module file contains functions to read out the data from the
+# name suggestion index (NSI) for Osmose - https://nsi.guide/
+
+from modules.downloader import urlread
+import json
+
+
+# Downloads and returns the parsed NSI database
+def download_nsi():
+    nsi_url = "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/nsi.json"
+    json_str = urlread(nsi_url, 30)
+    results = json.loads(json_str)
+    return results['nsi']
+
+# Gets all valid (shop, amenity, ...) names that exist within a certain country
+# country: the lowercase 2-letter country code of the country of interest
+# nsi: the parsed NSI database obtained from download_nsi()
+# nsiprefix: 'brands/', 'operators/', 'flags/' or 'transit/'
+def whitelist_from_nsi(country, nsi = download_nsi(), nsiprefix = 'brands/'):
+    whitelist = set()
+    for tag, details in nsi.items():
+        if tag.startswith(nsiprefix) and "items" in details:
+            for preset in details["items"]:
+                if "locationSet" in preset:
+                    if ("include" in preset["locationSet"] and
+                            country not in preset["locationSet"]["include"] and
+                            "001" not in preset["locationSet"]["include"]): # 001 = worldwide
+                        continue
+                    if "exclude" in preset["locationSet"] and country in preset["locationSet"]["exclude"]:
+                        continue
+                if "name" in preset["tags"]:
+                    for name in preset["tags"]["name"].split():
+                        whitelist.add(name)
+                for name in preset["displayName"].split():
+                    whitelist.add(name)
+    return whitelist


### PR DESCRIPTION
See #1830

This PR
- Moves common functions to a common file in subfolder /modules/
  - The filter for uppercase names was of course left in the Name_Uppercase plugin
  - Copyright I copied from both existing files to the new file
- Uses the NSI to whitelist names (only the non-localized variant, e.g. `name` but not `name:nl`) that contain "uncommon" characters

Note: failing test is unrelated to this PR