### PR TITLE
Simplify and speed up analyser highway_vs_buildings

### DIFF
--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -74,8 +74,6 @@ SELECT
     tags ?| ARRAY['ford', 'flood_prone'] AS onwater
 FROM
     railways_highways
-WHERE
-    array_length(nodes, 1) <= 100 -- Large ways have too big bbox
 )
 SELECT
     id,


### PR DESCRIPTION
Part 2 of https://github.com/osm-fr/osmose-backend/issues/1852#issuecomment-1541835203

#### The commits
- (commit 1) Use common table `highways` for the highways:
  - Reduces code duplication
  - Speeds up the analyser, most of the time (table below). No longer the factor 3 improvement it used to be in the first tests, probably because sql00 became a lot more complex since. (see old numbers [here](https://github.com/osm-fr/osmose-backend/pull/1820#issuecomment-1524158565))
- (commit 1) Remove twice-whitelisted `highway=elevator`
- (commit 2) Remove 100 nodes limit (see [comments here](https://github.com/osm-fr/osmose-backend/pull/1851/#issuecomment-1553024798) )

#### Regarding commit 1:
- verified that the output was the same
  - (Except `highway=pedestrian` as an area without area tag, as that's now filtered out by is_area)
  - Except some cases where multiple "valid" answers are possible
    - example: sql31 first returned way 317057792, now 317057793, which both connect to the same tree.
    - example: sql40 first had a marker [here](https://www.openstreetmap.org/note/new?lat=36.535489466707&lon=136.891955434029), now [here](https://www.openstreetmap.org/note/new?lat=36.536616623674&lon=136.890345809238), both locations are an overlap between the same ways (found similar occasions for sql51, which is similar)
    - Maybe these cases should have some optimization to ensure the output is constant, but that can be in a later PR (in my opinion). (E.g. some locations also changed between commit 1 and 2)
- speed of *sql00* (not the full analyser, just this query) on osm110:

| extract | before (s) | after (s) | faster? |
| --- | --- | --- | --- |
| japan_chubu | 72.4 | 64.9 | yes |
| japan_chubu (repeat 1) | 74.6 | 65.0 | yes |
| japan_chubu (repeat 2) | 77.6 | 64.7 | yes |
| netherlands_gelderland | 16.0 | 19.7 | no |
| netherlands_gelderland (repeat 1) | 16.8 | 13.3 | yes |
| netherlands_gelderland (repeat 2) | 17.8 | 10.4 | yes |
| netherlands_gelderland (repeat 3) | 16.9 | 13.6 | yes |
| jersey | 0.4 | 0.4 | - |
| sweden_gotland | 1.0 | 0.7 | yes |
| slovenia | 27.6 | 26.6 | yes |
| slovenia (repeat 1) | 18.9 | 17.1 | yes |
| slovenia (repeat 2) | 23.1 | 19.0 | yes |
| usa_iowa | 27.4 | 29.1 | no |
| usa_iowa (repeat 1) | 25.3 | 22.2 | yes |
| usa_iowa (repeat 2) | 23.0 | 21.7 | yes |

(Note: I suspect osm110 was doing something else until about 23:00 today (when I was running the repeats), after that some analyser results became notably faster. If not, I have no clue why some times are so much faster...)

#### Regarding commit 2:
- this added 953 results to the analyser output of japan_chubu, the majority of which were rivers

#### Output files for comparison
[japan_chubu.zip](https://github.com/osm-fr/osmose-backend/files/11511454/japan_chubu.zip)

#### EXPLAIN ANALYZE output for comparison
<details>

Using japan_chubu:

Before commit 1:
```
['Nested Loop  (cost=44329.54..86163.48 rows=697000 width=201) (actual time=1341.473..72147.149 rows=2161665 loops=1)']
['  CTE ways']
['    ->  Bitmap Heap Scan on ways ways_1  (cost=462.41..44329.53 rows=697 width=385) (actual time=1341.432..50376.762 rows=1945045 loops=1)']
["          Recheck Cond: (((tags ? 'highway'::text) AND (tags <> ''::hstore)) OR ((tags ? 'railway'::text) AND (tags <> ''::hstore)))"]
['          Rows Removed by Index Recheck: 1164850']
["          Filter: ((NOT (tags ? 'area:highway'::text)) AND (array_length(nodes, 1) <= 100) AND ((NOT (tags ? 'area'::text)) OR ((tags -> 'area'::text) = 'no'::text)) AND (((tags ? 'highway'::text) AND ((tags -> 'highway'::text) <> ALL ('{planned,proposed,construction,rest_area,razed,no,services,elevator}'::text[]))) OR ((tags ? 'railway'::text) AND ((tags -> 'railway'::text) = ANY ('{rail,tram}'::text[])))) AND (st_npoints(linestring) > 1))"]
['          Rows Removed by Filter: 15548']
['          Heap Blocks: exact=37020 lossy=132513']
['          ->  BitmapOr  (cost=462.41..462.41 rows=12963 width=0) (actual time=1312.397..1312.438 rows=0 loops=1)']
['                ->  Bitmap Index Scan on idx_ways_highway  (cost=0.00..229.03 rows=6482 width=0) (actual time=744.153..744.176 rows=1933163 loops=1)']
["                      Index Cond: (tags ? 'highway'::text)"]
['                ->  Bitmap Index Scan on idx_ways_tags  (cost=0.00..233.03 rows=6482 width=0) (actual time=568.238..568.246 rows=56775 loops=1)']
["                      Index Cond: (tags ? 'railway'::text)"]
['  ->  CTE Scan on ways  (cost=0.00..13.94 rows=697 width=205) (actual time=1341.439..55625.723 rows=1945045 loops=1)']
['  ->  Function Scan on generate_series t  (cost=0.01..10.01 rows=1000 width=4) (actual time=0.002..0.003 rows=1 loops=1945045)']
['Planning Time: 4.645 ms']
['Execution Time: 72442.957 ms']
```

After commit 1: 
```
['Nested Loop  (cost=301220.73..38950979.69 rows=643948000 width=201) (actual time=2.761..64560.995 rows=2161578 loops=1)']
['  CTE railways_highways']
['    ->  Append  (cost=0.00..215897.64 rows=1931843 width=482) (actual time=0.290..10638.409 rows=1951389 loops=1)']
['          ->  Seq Scan on highways  (cost=0.00..163526.24 rows=1931821 width=482) (actual time=0.289..6802.894 rows=1926913 loops=1)']
["                Filter: ((NOT is_construction) AND (NOT is_area) AND (highway <> 'elevator'::text) AND (NOT (tags ? 'area:highway'::text)))"]
['                Rows Removed by Filter: 5760']
['          ->  Bitmap Heap Scan on ways ways_1  (cost=233.04..23393.75 rows=22 width=345) (actual time=1055.235..3545.998 rows=24476 loops=1)']
["                Recheck Cond: ((tags ? 'railway'::text) AND (tags <> ''::hstore))"]
['                Rows Removed by Index Recheck: 29320']
["                Filter: (((tags -> 'railway'::text) = ANY ('{rail,tram}'::text[])) AND ((NOT (tags ? 'area'::text)) OR ((tags -> 'area'::text) = 'no'::text)) AND (st_npoints(linestring) > 1))"]
['                Rows Removed by Filter: 2979']
['                Heap Blocks: exact=19841']
['                ->  Bitmap Index Scan on idx_ways_tags  (cost=0.00..233.03 rows=6482 width=0) (actual time=1050.952..1050.952 rows=56775 loops=1)']
["                      Index Cond: (tags ? 'railway'::text)"]
['  CTE ways']
['    ->  CTE Scan on railways_highways  (cost=0.00..85323.09 rows=643948 width=205) (actual time=2.737..41644.121 rows=1944962 loops=1)']
['          Filter: (array_length(nodes, 1) <= 100)']
['          Rows Removed by Filter: 6427']
['  ->  CTE Scan on ways  (cost=0.00..12878.96 rows=643948 width=205) (actual time=2.740..46616.431 rows=1944962 loops=1)']
['  ->  Function Scan on generate_series t  (cost=0.01..10.01 rows=1000 width=4) (actual time=0.003..0.003 rows=1 loops=1944962)']
['Planning Time: 5.196 ms']
['Execution Time: 64869.297 ms']
```

</details>