### PR TITLE
Convert osmosis_polygon_intersects to use table multipolygons

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -245,6 +245,7 @@ ANALYZE {0}.buildings;
             self.relation:"relation", self.relation_full:"relation",
         }
         self.typeMapping = {'N': self.node_full, 'W': self.way_full, 'R': self.relation_full}
+        self.typeMapping_id_only = {'N': self.node, 'W': self.way, 'R': self.relation}
         self.resume_from_timestamp = None
         self.already_issued_objects = None
 
@@ -610,6 +611,9 @@ WHERE
 
     def any_full(self, res):
         self.typeMapping[res[0]](int(res[1:]))
+
+    def any_id(self, res):
+        self.typeMapping_id_only[res[0]](int(res[1:]))
 
     def array_full(self, res):
         for type, id in map(lambda r: (r[0], r[1:]), res):

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -72,11 +72,11 @@ WHERE
 """
 
 sql11 = """
--- Collect all landuse=* and natural=*, closed ways and outer ways of multipolygons
+-- Collect all landuse=* and natural=*, closed ways and multipolygons
 CREATE TEMP TABLE landusage AS
 SELECT
-  id,
-  linestring,
+  'W' || id AS id,
+  ST_Transform(linestring, {proj}) AS linestring_proj,
   ST_MakePolygon(linestring) AS poly,
   CASE
     WHEN tags?'landuse' THEN 'landuse'
@@ -86,8 +86,7 @@ SELECT
     WHEN tags?'landuse' THEN tags->'landuse'
     WHEN tags?'natural' THEN tags->'natural'
   END AS landusevalue,
-  tags,
-  FALSE AS is_multipolygon
+  tags
 FROM
   ways
 WHERE
@@ -98,37 +97,38 @@ WHERE
   ST_Area(ST_MakePolygon(ST_Transform(linestring, {proj}))) >= 20
 UNION ALL
 SELECT
-  ways.id,
-  ways.linestring,
-  -- Better would be to parse inner and outer segments and create an SQL multipolygon
-  -- For now, just use a very small buffer zone around the linestring
-  ST_Buffer(ways.linestring, 0.0000000001, 'quad_segs=1 endcap=flat join=bevel') AS poly,
+  'R' || mp.id AS id,
+  ST_Transform(ST_LineMerge(ST_Collect(ways.linestring)), {proj}) AS linestring_proj, -- usually multilinestring
+  mp.poly,
   CASE
-    WHEN r.tags?'landuse' THEN 'landuse'
-    WHEN r.tags?'natural' THEN 'natural'
+    WHEN mp.tags?'landuse' THEN 'landuse'
+    WHEN mp.tags?'natural' THEN 'natural'
   END AS landusekey,
   CASE
-    WHEN r.tags?'landuse' THEN r.tags->'landuse'
-    WHEN r.tags?'natural' THEN r.tags->'natural'
+    WHEN mp.tags?'landuse' THEN mp.tags->'landuse'
+    WHEN mp.tags?'natural' THEN mp.tags->'natural'
   END AS landusevalue,
-  r.tags,
-  TRUE AS is_multipolygon
+  mp.tags
 FROM
-  relation_members
-  LEFT JOIN relations AS r ON
-    relation_id = r.id
+  multipolygons AS mp
+  JOIN relation_members ON
+    relation_id = mp.id
   JOIN ways ON
-    member_role = 'outer' AND
+    member_role IN ('outer', 'inner') AND
     member_id = ways.id AND
     member_type = 'W'
 WHERE
-  r.tags->'type' = 'multipolygon' AND
-  (r.tags?'natural' OR r.tags?'landuse')
+  mp.is_valid AND
+  (mp.tags?'natural' OR mp.tags?'landuse')
+GROUP BY
+  mp.id,
+  mp.poly,
+  mp.tags
 """
 
 sql12 = """
 CREATE INDEX idx_mobilityway_linestring ON mobility_ways USING GIST(linestring);
-CREATE INDEX idx_landusage_linestring ON landusage USING GIST(linestring);
+CREATE INDEX idx_landusage_poly ON landusage USING GIST(poly);
 """
 
 sql13 = """
@@ -138,26 +138,24 @@ SELECT
   mobility_way_id,
   mobility_way_linestring,
   mobility_way_type,
-  landusage_way_id,
+  landusage_id,
   landusage_poly,
   landusekey,
   landusevalue,
   tag_way,
-  tag_polygon
+  CONCAT(landusekey, '=', landusevalue) AS tag_polygon
 FROM (
   SELECT
     mobility_ways.id AS mobility_way_id,
     mobility_ways.linestring AS mobility_way_linestring,
     mobility_ways.type AS mobility_way_type,
-    landusage.id AS landusage_way_id,
+    landusage.id AS landusage_id,
     landusage.poly AS landusage_poly,
-    landusage.linestring AS landusage_linestring,
+    landusage.linestring_proj AS landusage_linestring_proj,
     landusage.landusekey,
     landusage.landusevalue,
     CONCAT(mobility_ways.type, '=', mobility_ways.tags->mobility_ways.type) AS tag_way,
-    CONCAT(landusage.landusekey, '=', landusage.landusevalue) AS tag_polygon,
-    (ST_Dump(ST_Transform(ST_Intersection(landusage.poly, mobility_ways.linestring), {proj}))).geom AS intersection_part_geom,
-    landusage.is_multipolygon AS skip_intersection_size_check -- due to ST_buffer approach for mp, instead of full parsing of inners/outers
+    (ST_Dump(ST_Transform(ST_Intersection(landusage.poly, mobility_ways.linestring), {proj}))).geom AS intersection_part_geom_proj
   FROM
     mobility_ways
     JOIN landusage ON
@@ -169,35 +167,29 @@ FROM (
           landusage.tags->'layer' = mobility_ways.tags->'layer'
         )
       ) AND
-      landusage.linestring && mobility_ways.linestring AND
+      landusage.poly && mobility_ways.linestring AND
       -- Only find ways where the highway/railway/aeroway actually enters the
       -- polygon. Exclude cases where the polygon is tied to the way without going inside.
       (
-        ST_Crosses(landusage.linestring, mobility_ways.linestring) OR
-        (
-          ST_Contains(landusage.poly, mobility_ways.linestring) AND
-          NOT landusage.is_multipolygon -- due to ST_buffer approach for mp, instead of full parsing of inners/outers
-        )
+        ST_Crosses(landusage.poly, mobility_ways.linestring) OR
+        ST_Contains(landusage.poly, mobility_ways.linestring)
       )
   ) AS t
 WHERE
-  skip_intersection_size_check OR
+  -- Only include significant intersections
+  ST_Length(intersection_part_geom_proj) > 2 AND
   (
-    -- Only include significant intersections
-    ST_Length(intersection_part_geom) > 2 AND
-    (
-      ST_Distance(ST_Centroid(intersection_part_geom), ST_Transform(mobility_way_linestring, {proj})) > 1 OR
-      ST_Distance(ST_Centroid(intersection_part_geom), ST_Transform(landusage_linestring, {proj})) > 1
-    )
+    ST_Distance(ST_Centroid(intersection_part_geom_proj), ST_Transform(mobility_way_linestring, {proj})) > 1 OR
+    ST_Distance(ST_Centroid(intersection_part_geom_proj), landusage_linestring_proj) > 1
   )
 """
 
 sql14 = """
 -- Intersections with railway, aeroway or highway
 SELECT
-  DISTINCT ON (mobility_way_id, landusage_way_id)
+  DISTINCT ON (mobility_way_id, landusage_id)
   mobility_way_id,
-  landusage_way_id,
+  landusage_id,
   ST_AsText(ST_PointOnSurface(ST_Intersection(landusage_poly, mobility_way_linestring))),
   mobility_way_type,
   tag_way,
@@ -219,7 +211,7 @@ WHERE
   )
 ORDER BY
   mobility_way_id,
-  landusage_way_id,
+  landusage_id,
   mobility_way_type,
   tag_way,
   tag_polygon
@@ -261,7 +253,7 @@ However, if the way for transportation is a tunnel or a bridge, add `tunnel=*` o
             title = T_('Bad intersection with aeroway'),
             detail = detailTxt, example = exampleTxt, fix = fixTxt)
 
-    requires_tables_common = ['highways']
+    requires_tables_common = ['highways', 'multipolygons']
 
     def analyser_osmosis_common(self):
         self.run(sql10)
@@ -270,7 +262,7 @@ However, if the way for transportation is a tunnel or a bridge, add `tunnel=*` o
         self.run(sql13.format(proj=self.config.options["proj"]))
         self.run(sql14, lambda res: {
             "class": self.classIndex[res[3]],
-            "data": [self.way, self.way, self.positionAsText],
+            "data": [self.way, self.any_id, self.positionAsText],
             "text": T_("`{0}` intersects `{1}`", res[4], res[5])
         })
 
@@ -302,9 +294,10 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1058"), ("way", "1023")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1027"), ("way", "1023")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1036"), ("way", "1035")])
-        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1049"), ("way", "1042")])
-        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1049"), ("way", "1043")])
-        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1050"), ("way", "1047")])
-        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1055"), ("way", "1052")])
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1049"), ("relation", "10002")])
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1050"), ("relation", "10001")])
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1063"), ("relation", "10001")])
+        self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1064"), ("relation", "10001")])
+        self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1055"), ("relation", "10003")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1062"), ("way", "1059")])
-        self.check_num_err(15)
+        self.check_num_err(16)

--- a/doc/3-SQL-basics.md
+++ b/doc/3-SQL-basics.md
@@ -110,6 +110,7 @@ The available value for the `data`, mapping OSM object id are:
 * `relation`
 * `relation_full`
 * `any_full` (N/W/R + id)
+* `any_id` (N/W/R + id)
 
 From array of (type: N/W/R, ids):
 * `array_full`

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -133,6 +133,11 @@
   <node id='170' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85473263308' lon='5.94986392287' />
   <node id='171' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.86305597816' lon='5.94939459778' />
   <node id='172' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85940211083' lon='5.94713689084' />
+  <node id='173' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82243018532' lon='5.92452682867' />
+  <node id='174' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82087367465' lon='5.92317387773' />
+  <node id='175' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82188764589' lon='5.92684902751' />
+  <node id='176' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81909375438' lon='5.92556846439' />
+  <node id='177' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82106700151' lon='5.92696119385' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -435,8 +440,8 @@
     <nd ref='163' />
     <nd ref='171' />
     <nd ref='172' />
-    <tag k='railway' v='rail' />
     <tag k='note' v='many very shallow intersections' />
+    <tag k='railway' v='rail' />
   </way>
   <way id='1062' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='170' />
@@ -445,6 +450,28 @@
     <nd ref='169' />
     <tag k='highway' v='motorway' />
     <tag k='note' v='small + 2x big intersection' />
+  </way>
+  <way id='1063' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='173' />
+    <nd ref='136' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='1064' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='174' />
+    <nd ref='173' />
+    <tag k='aeroway' v='runway' />
+  </way>
+  <way id='1065' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='175' />
+    <nd ref='177' />
+    <tag k='aeroway' v='runway' />
+    <tag k='note' v='mini-intersection' />
+  </way>
+  <way id='1066' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='130' />
+    <nd ref='176' />
+    <tag k='aeroway' v='runway' />
+    <tag k='note' v='mini-intersection' />
   </way>
   <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='1045' role='inner' />


### PR DESCRIPTION
- Converts the multipolygon workaround in polygon_intersects to full multipolygon support
- Adds `any_id` as the 'non-_full' equivalent of `any_full`
  - (suggestions for better names? I didn't want to overwrite the python `any` function. If the name is fine, I'll update the doc)
- Updates the tests to use the relation id, and adds two small tests

The results seem fine. The increase (detections inside multipolygons) or decrease (small incursions of outer ways are now filtered) of detections:
| extract | before | after | after switch to buffer |
| --- | --- | --- | --- |
| belgium_wallonia_german_community | 36 | 57 | 57 |
| jersey  | 3 | 3 | 3 |
| switzerland_basel_stadt  | 14 | 14 | 14 |
| sweden_gotland  | 1 | 1 | 1 |
| netherlands_gelderland  | 127 | 125 | 87 |
| usa_iowa  | 128 | 124 | 124 |
| slovenia  | 378 | 343 | 292 |
| germany_saarland  | 248 | 316 | 314 |
| japan_chubu  | 6569 | 10379 | 10333 |
| venezuela | 118 | 124 | 122 |