### PR TITLE
Allow buildings with amenity=parking

### DIFF
--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -214,7 +214,8 @@ FROM
         ST_Dimension(ST_Intersection(building.polygon_proj, highway.linestring_proj)) >= 1 -- The cross is more than a point
 WHERE
     building.wall AND
-    NOT building.layer
+    NOT building.layer AND
+    (NOT building.tags?'amenity' OR building.tags->'amenity'!='parking')
 ORDER BY
     highway.id,
     building.id


### PR DESCRIPTION
See #1874

Allow mapping the ground floor level of parking garages by allowing buildings that are also tagged as `amenity=parking`.
Alternative approaches could be:
1. Filtering on `building=parking` (but this would fail if it's a multi-purpose building, which may be tagged as `building=retail;parking` or simply `building=yes`)
2. Filtering on `parking=multi-story` (but this already requires `amenity=parking`)
3. Requiring `covered=yes` on the highway (but this would also affect many other building/highway crossings that should be fixed)
4. Filtering on the presence of a `level`-key on the highway (suggestive of a multi-level situation), but this isn't a mandatory key. Also it would require a rewrite of all sql queries that use `highway.level` (as `highway.level` isn't the same as `highway.tags?'level'`: it's set to `'0'` if omitted and `tags` isn't in the `highway` table)