### PR TITLE
Update mapcss

### DIFF
--- a/mapcss/item_map.py
+++ b/mapcss/item_map.py
@@ -365,6 +365,7 @@ item_map = \
                        '{0} value with + sign': 9006002},
              'item': 9006,
              'prefix': 'Josm_',
+             'subclass_blacklist': [1251729862],
              'tags': ['tag', 'value'],
              'url': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/numeric.mapcss?format=txt',
              'url_display': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/numeric.mapcss'},

--- a/plugins/Josm_territories.py
+++ b/plugins/Josm_territories.py
@@ -18,6 +18,7 @@ class Josm_territories(PluginMapCSS):
         self.errors[9009002] = self.def_class(item = 9009, level = 2, tags = ["tag"], title = mapcss.tr('street name contains ss'))
         self.errors[9009003] = self.def_class(item = 9009, level = 2, tags = ["tag"], title = mapcss.tr('street name contains ß'))
 
+        self.re_1596ad87 = re.compile(r'(?i).*spannungstrasse.*')
         self.re_3d3faeb5 = re.compile(r'(?i).*Straße.*')
         self.re_559797c8 = re.compile(r'(?i).*Strasser.*')
         self.re_5b84a257 = re.compile(r'(?i).*Strasse.*')
@@ -30,7 +31,7 @@ class Josm_territories(PluginMapCSS):
 
 
         # *[addr:street=~/(?i).*Strasse.*/][addr:street!~/(?i).*Strasser.*/][inside("DE,AT")]
-        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][inside("DE,AT")]
+        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][name!~/(?i).*spannungstrasse.*/][inside("DE,AT")]
         if ('addr:street' in keys) or ('name' in keys):
             match = False
             if not match:
@@ -39,11 +40,11 @@ class Josm_territories(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_1596ad87, '(?i).*spannungstrasse.*'), mapcss._tag_capture(capture_tags, 2, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("street name contains ss")
-                err.append({'class': 9009002, 'subclass': 821908491, 'text': mapcss.tr('street name contains ss')})
+                err.append({'class': 9009002, 'subclass': 1817721249, 'text': mapcss.tr('street name contains ss')})
 
         # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
         # *[name=~/(?i).*Straße.*/][inside("LI,CH")]
@@ -70,7 +71,7 @@ class Josm_territories(PluginMapCSS):
 
 
         # *[addr:street=~/(?i).*Strasse.*/][addr:street!~/(?i).*Strasser.*/][inside("DE,AT")]
-        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][inside("DE,AT")]
+        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][name!~/(?i).*spannungstrasse.*/][inside("DE,AT")]
         if ('addr:street' in keys) or ('name' in keys):
             match = False
             if not match:
@@ -79,15 +80,16 @@ class Josm_territories(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_1596ad87, '(?i).*spannungstrasse.*'), mapcss._tag_capture(capture_tags, 2, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("street name contains ss")
                 # assertMatch:"way name=Hauptstrasse"
                 # assertNoMatch:"way name=Hauptstraße"
+                # assertNoMatch:"way name=Hochspannungstrasse"
                 # assertNoMatch:"way name=Kapitän-Strasser-Straße"
                 # assertNoMatch:"way name=Peter-Strasser-Platz"
-                err.append({'class': 9009002, 'subclass': 821908491, 'text': mapcss.tr('street name contains ss')})
+                err.append({'class': 9009002, 'subclass': 1817721249, 'text': mapcss.tr('street name contains ss')})
 
         # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
         # *[name=~/(?i).*Straße.*/][inside("LI,CH")]
@@ -116,7 +118,7 @@ class Josm_territories(PluginMapCSS):
 
 
         # *[addr:street=~/(?i).*Strasse.*/][addr:street!~/(?i).*Strasser.*/][inside("DE,AT")]
-        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][inside("DE,AT")]
+        # *[name=~/(?i).*Strasse.*/][name!~/(?i).*Strasser.*/][name!~/(?i).*spannungstrasse.*/][inside("DE,AT")]
         if ('addr:street' in keys) or ('name' in keys):
             match = False
             if not match:
@@ -125,11 +127,11 @@ class Josm_territories(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
+                try: match = ((mapcss.regexp_test(mapcss._value_capture(capture_tags, 0, self.re_5b84a257), mapcss._tag_capture(capture_tags, 0, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 1, self.re_559797c8, '(?i).*Strasser.*'), mapcss._tag_capture(capture_tags, 1, tags, 'name'))) and (not mapcss.regexp_test(mapcss._value_const_capture(capture_tags, 2, self.re_1596ad87, '(?i).*spannungstrasse.*'), mapcss._tag_capture(capture_tags, 2, tags, 'name'))) and (mapcss.inside(self.father.config.options, 'DE,AT')))
                 except mapcss.RuleAbort: pass
             if match:
                 # throwError:tr("street name contains ss")
-                err.append({'class': 9009002, 'subclass': 821908491, 'text': mapcss.tr('street name contains ss')})
+                err.append({'class': 9009002, 'subclass': 1817721249, 'text': mapcss.tr('street name contains ss')})
 
         # *[addr:street=~/(?i).*Straße.*/][inside("LI,CH")]
         # *[name=~/(?i).*Straße.*/][inside("LI,CH")]
@@ -177,9 +179,10 @@ class Test(TestPluginMapcss):
         n.init(None)
         data = {'id': 0, 'lat': 0, 'lon': 0}
 
-        self.check_err(n.way(data, {'name': 'Hauptstrasse'}, [0]), expected={'class': 9009002, 'subclass': 821908491})
-        self.check_not_err(n.way(data, {'name': 'Hauptstraße'}, [0]), expected={'class': 9009002, 'subclass': 821908491})
-        self.check_not_err(n.way(data, {'name': 'Kapitän-Strasser-Straße'}, [0]), expected={'class': 9009002, 'subclass': 821908491})
-        self.check_not_err(n.way(data, {'name': 'Peter-Strasser-Platz'}, [0]), expected={'class': 9009002, 'subclass': 821908491})
+        self.check_err(n.way(data, {'name': 'Hauptstrasse'}, [0]), expected={'class': 9009002, 'subclass': 1817721249})
+        self.check_not_err(n.way(data, {'name': 'Hauptstraße'}, [0]), expected={'class': 9009002, 'subclass': 1817721249})
+        self.check_not_err(n.way(data, {'name': 'Hochspannungstrasse'}, [0]), expected={'class': 9009002, 'subclass': 1817721249})
+        self.check_not_err(n.way(data, {'name': 'Kapitän-Strasser-Straße'}, [0]), expected={'class': 9009002, 'subclass': 1817721249})
+        self.check_not_err(n.way(data, {'name': 'Peter-Strasser-Platz'}, [0]), expected={'class': 9009002, 'subclass': 1817721249})
         self.check_not_err(n.way(data, {'name': 'Hauptstrasse'}, [0]), expected={'class': 9009003, 'subclass': 610086334})
         self.check_err(n.way(data, {'name': 'Hauptstraße'}, [0]), expected={'class': 9009003, 'subclass': 610086334})


### PR DESCRIPTION
Update mapcss in preparation for `area` selector implementation.

Blacklists new rule that is broken in Osmose, see https://github.com/osm-fr/osmose-backend/issues/1766#issuecomment-1572683233