### PR TITLE
Remove mofa/moped, which are defaults on bollards

### DIFF
--- a/analysers/analyser_osmosis_highway_area_access.py
+++ b/analysers/analyser_osmosis_highway_area_access.py
@@ -69,7 +69,7 @@ WHERE
   barrier.tags != ''::hstore AND
   -- barrier.tags?'barrier' AND -- commented to avoid planner to try to use idx_nodes_tags, build bad plan with it. Very slow
   barrier.tags->'barrier' = '{barriertype}' AND
-  -- Default of bollard is access=no / bicycle=foot=yes; default of bus_trap is motor_vehicle=no / psv=foot=bicycle=yes.
+  -- Default of bollard is access=no / bicycle=mofa=moped=foot=yes; default of bus_trap is motor_vehicle=no / psv=foot=bicycle=yes.
   -- Hence, the below three lines should cover all cases as long as we don't test for any non-motor_vehicle or vehicles under psv
   (NOT barrier.tags?'access' OR barrier.tags->'access' = 'no') AND
   (NOT barrier.tags?'vehicle' OR barrier.tags->'vehicle' = 'no') AND
@@ -216,7 +216,7 @@ In the bottom example, cars will also have to drive over the kerb. Usually, kerb
     def analyser_osmosis_common(self):
         self.run(sql20.format(barriertype='bollard'))
         self.run(sql20.format(barriertype='bus_trap'))
-        for vehicle in ['motorcycle', 'mofa', 'moped', 'emergency', 'motorcar']:
+        for vehicle in ['motorcycle', 'emergency', 'motorcar']:
             self.run(sql21.format(barriertype='bollard', vehicle=vehicle), lambda res: {
                 "class":2, "data":[self.way_full, self.node_full, self.positionAsText],
                 "text": T_("Inconsistent {0} access: '{1}' on highway, not set on barrier", vehicle, res[3])})

--- a/tests/osmosis_highway_access_barrier.osm
+++ b/tests/osmosis_highway_access_barrier.osm
@@ -43,7 +43,7 @@
   <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82774909991' lon='5.86388771947' />
   <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82768028797' lon='5.85845427317'>
     <tag k='barrier' v='bollard' />
-    <tag k='note' v='I should have a moped tag' />
+    <tag k='note' v='I should have a motorcycle tag' />
   </node>
   <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.83177615107' lon='5.86408732208'>
     <tag k='barrier' v='bus_trap' />
@@ -84,7 +84,7 @@
   </node>
   <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82771274187' lon='5.86101685819'>
     <tag k='barrier' v='bollard' />
-    <tag k='note' v='I should have a moped tag' />
+    <tag k='note' v='I should have a motorcycle tag' />
   </node>
   <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82845094135' lon='5.86096548758' />
   <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82982934447' lon='5.85966842454' />
@@ -250,7 +250,7 @@
     <nd ref='37' />
     <nd ref='19' />
     <tag k='highway' v='cycleway' />
-    <tag k='moped' v='designated' />
+    <tag k='motorcycle' v='designated' />
     <tag k='name' v='class 2 test' />
   </way>
   <way id='108' timestamp='2014-03-31T22:00:00Z' version='1'>
@@ -302,7 +302,7 @@
     <nd ref='35' />
     <tag k='access' v='destination' />
     <tag k='highway' v='residential' />
-    <tag k='moped' v='designated' />
+    <tag k='motorcycle' v='designated' />
     <tag k='name' v='class 2 test' />
   </way>
   <way id='115' timestamp='2014-03-31T22:00:00Z' version='1'>
@@ -310,7 +310,7 @@
     <nd ref='43' />
     <nd ref='42' />
     <tag k='highway' v='cycleway' />
-    <tag k='moped' v='designated' />
+    <tag k='motorcycle' v='designated' />
     <tag k='name' v='class 2 test' />
   </way>
   <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>


### PR DESCRIPTION
See #1846 - `mofa=yes` and `moped=yes` have been added as defaults for `barrier=bollard`, so requesting people to tag these values explicitly isn't necessary anymore.