### PR TITLE
Fix `<`, `>`, `<=` and `>=` for `[function() > function()]` selectors

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -104,18 +104,18 @@ class str_value_(str):
     def __lt__(self, o):
         if self.none:
             return False
-        elif o.__class__ == int:
+        elif o.__class__ in (int, float):
             return self.to_n() < o
         else:
-            return super(str_value_, self).__lt__(o)
+            return self.to_n() < str_value(o).to_n()
 
     def __le__(self, o):
         if self.none:
             return False
-        elif o.__class__ == int:
+        elif o.__class__ in (int, float):
             return self.to_n() <= o
         else:
-            return super(str_value_, self).__le__(o)
+            return self.to_n() <= str_value(o).to_n()
 
     def __eq__(self, o):
         if self.none:
@@ -138,18 +138,18 @@ class str_value_(str):
     def __gt__(self, o):
         if self.none:
             return False
-        elif o.__class__ == int:
+        elif o.__class__ in (int, float):
             return self.to_n() > o
         else:
-            return super(str_value_, self).__gt__(o)
+            return self.to_n() > str_value(o).to_n()
 
     def __ge__(self, o):
         if self.none:
             return False
-        elif o.__class__ == int:
+        elif o.__class__ in (int, float):
             return self.to_n() >= o
         else:
-            return super(str_value_, self).__ge__(o)
+            return self.to_n() >= str_value(o).to_n()
 
     def __bool__(self):
         if self.none:

--- a/plugins/tests/test_mapcss_parsing_evalutation.py
+++ b/plugins/tests/test_mapcss_parsing_evalutation.py
@@ -19,15 +19,17 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
         self.errors[4] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test commit 373d1ff9bacf8126508bbf3e37467df2bdf17fbd'})
         self.errors[5] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #327'))
         self.errors[6] = self.def_class(item = 0, level = 2, tags = [], title = {'en': 'test'})
-        self.errors[7] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
-        self.errors[8] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[9] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
-        self.errors[10] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
-        self.errors[11] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
-        self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
+        self.errors[7] = self.def_class(item = 0, level = 2, tags = [], title = mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[8] = self.def_class(item = 0, level = 2, tags = [], title = mapcss.tr('test #1882 - {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
+        self.errors[9] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
+        self.errors[10] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[11] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
+        self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
+        self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
+        self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[16] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[17] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
         self.errors[97] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
         self.errors[98] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
         self.errors[99] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
@@ -170,6 +172,189 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertMatch:"node lit=yes"
                 err.append({'class': 6, 'subclass': 612979508, 'text': {'en': 'test'}})
 
+        # node[a][b][tag("a")>tag("b")]
+        if ('a' in keys and 'b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'b')) and (mapcss.tag(tags, 'a') > mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}-{1}","{0.tag}","{1.tag}")
+                # assertNoMatch:"node a=3  b=6"
+                # assertNoMatch:"node a=3  b=6a"
+                # assertNoMatch:"node a=3.0  b=6a"
+                # assertNoMatch:"node a=3a b=6"
+                # assertNoMatch:"node a=3a b=6a"
+                # assertNoMatch:"node a=X  b=Y"
+                # assertMatch:"node b=-5 a=6"
+                # assertMatch:"node b=3  a=12"
+                # assertMatch:"node b=3  a=12.0"
+                # assertMatch:"node b=3  a=6"
+                # assertNoMatch:"node b=3  a=6a"
+                # assertMatch:"node b=3.0  a=12"
+                # assertMatch:"node b=3.0  a=6.0"
+                # assertNoMatch:"node b=3a a=6"
+                # assertNoMatch:"node b=3a a=6a"
+                # assertNoMatch:"node b=X  a=Y"
+                err.append({'class': 7, 'subclass': 766520351, 'text': mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # node[a][b][tag("a")>=tag("b")]
+        if ('a' in keys and 'b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'b')) and (mapcss.tag(tags, 'a') >= mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}-{1}","{0.tag}","{1.tag}")
+                # assertNoMatch:"node a=3  b=6"
+                # assertNoMatch:"node a=3  b=6a"
+                # assertNoMatch:"node a=3.0  b=6a"
+                # assertNoMatch:"node a=3a b=6"
+                # assertNoMatch:"node a=3a b=6a"
+                # assertNoMatch:"node a=X  b=Y"
+                # assertMatch:"node b=-5 a=6"
+                # assertMatch:"node b=3  a=12"
+                # assertMatch:"node b=3  a=12.0"
+                # assertMatch:"node b=3  a=6"
+                # assertNoMatch:"node b=3  a=6a"
+                # assertMatch:"node b=3.0  a=12"
+                # assertMatch:"node b=3.0  a=6.0"
+                # assertNoMatch:"node b=3a a=6"
+                # assertNoMatch:"node b=3a a=6a"
+                # assertNoMatch:"node b=X  a=Y"
+                err.append({'class': 7, 'subclass': 1296744085, 'text': mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # node[a][b][tag("b")<tag("a")]
+        if ('a' in keys and 'b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'b')) and (mapcss.tag(tags, 'b') < mapcss.tag(tags, 'a')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}-{1}","{0.tag}","{1.tag}")
+                # assertNoMatch:"node a=3  b=6"
+                # assertNoMatch:"node a=3  b=6a"
+                # assertNoMatch:"node a=3.0  b=6a"
+                # assertNoMatch:"node a=3a b=6"
+                # assertNoMatch:"node a=3a b=6a"
+                # assertNoMatch:"node a=X  b=Y"
+                # assertMatch:"node b=-5 a=6"
+                # assertMatch:"node b=3  a=12"
+                # assertMatch:"node b=3  a=12.0"
+                # assertMatch:"node b=3  a=6"
+                # assertNoMatch:"node b=3  a=6a"
+                # assertMatch:"node b=3.0  a=12"
+                # assertMatch:"node b=3.0  a=6.0"
+                # assertNoMatch:"node b=3a a=6"
+                # assertNoMatch:"node b=3a a=6a"
+                # assertNoMatch:"node b=X  a=Y"
+                err.append({'class': 7, 'subclass': 660577118, 'text': mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # node[a][b][tag("b")<=tag("a")]
+        if ('a' in keys and 'b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'b')) and (mapcss.tag(tags, 'b') <= mapcss.tag(tags, 'a')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}-{1}","{0.tag}","{1.tag}")
+                # assertNoMatch:"node a=3  b=6"
+                # assertNoMatch:"node a=3  b=6a"
+                # assertNoMatch:"node a=3.0  b=6a"
+                # assertNoMatch:"node a=3a b=6"
+                # assertNoMatch:"node a=3a b=6a"
+                # assertNoMatch:"node a=X  b=Y"
+                # assertMatch:"node b=-5 a=6"
+                # assertMatch:"node b=3  a=12"
+                # assertMatch:"node b=3  a=12.0"
+                # assertMatch:"node b=3  a=6"
+                # assertNoMatch:"node b=3  a=6a"
+                # assertMatch:"node b=3.0  a=12"
+                # assertMatch:"node b=3.0  a=6.0"
+                # assertNoMatch:"node b=3a a=6"
+                # assertNoMatch:"node b=3a a=6a"
+                # assertNoMatch:"node b=X  a=Y"
+                err.append({'class': 7, 'subclass': 1302849761, 'text': mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
+        # node[a>2]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a') > mapcss._value_capture(capture_tags, 0, 2)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}","{0.tag}")
+                # assertNoMatch:"node a=-5"
+                # assertNoMatch:"node a=1"
+                # assertNoMatch:"node a=1.0"
+                # assertMatch:"node a=3"
+                # assertMatch:"node a=3.0"
+                # assertNoMatch:"node a=X"
+                err.append({'class': 8, 'subclass': 1910232765, 'text': mapcss.tr('test #1882 - {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # node[a>2.0]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a') > mapcss._value_capture(capture_tags, 0, 2.0)))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}","{0.tag}")
+                # assertNoMatch:"node a=-5"
+                # assertNoMatch:"node a=1"
+                # assertNoMatch:"node a=1.0"
+                # assertMatch:"node a=3"
+                # assertMatch:"node a=3.0"
+                # assertNoMatch:"node a=X"
+                err.append({'class': 8, 'subclass': 1369591651, 'text': mapcss.tr('test #1882 - {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # node[a][count(split("n",tag("a")))>2]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss.count(mapcss.split('n', mapcss.tag(tags, 'a'))) > 2))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}","{0.tag}")
+                # assertNoMatch:"node a=X"
+                # assertMatch:"node a=ananas"
+                err.append({'class': 8, 'subclass': 130115842, 'text': mapcss.tr('test #1882 - {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # node[a][count(split("n",tag("a")))>2.0]
+        if ('a' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss.count(mapcss.split('n', mapcss.tag(tags, 'a'))) > 2.0))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}","{0.tag}")
+                # assertNoMatch:"node a=X"
+                # assertMatch:"node a=ananas"
+                err.append({'class': 8, 'subclass': 935120167, 'text': mapcss.tr('test #1882 - {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+
+        # node[a][b][count(split("n",tag("a")))>tag(b)]
+        if ('a' in keys and 'b' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'a')) and (mapcss._tag_capture(capture_tags, 1, tags, 'b')) and (mapcss.count(mapcss.split('n', mapcss.tag(tags, 'a'))) > mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwError:tr("test #1882 - {0}-{1}","{0.tag}","{1.tag}")
+                # assertNoMatch:"node a=X b=2"
+                # assertNoMatch:"node a=X b=2.0"
+                # assertMatch:"node a=ananas b=2"
+                # assertMatch:"node a=ananas b=2.0"
+                err.append({'class': 7, 'subclass': 1734018842, 'text': mapcss.tr('test #1882 - {0}-{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+
         return err
 
     def way(self, data, tags, nds):
@@ -190,7 +375,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertMatch:"way x=C00;C1;C22"
                 # assertMatch:"way x=C1"
                 # assertNoMatch:"way x=C12"
-                err.append({'class': 7, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
+                err.append({'class': 9, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
 
         # way:righthandtraffic[x=y][z?]
         if ('x' in keys and 'z' in keys):
@@ -202,7 +387,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{1.tag}","{2.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 8, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
+                err.append({'class': 10, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
 
         # way[x=y][z?]:righthandtraffic
         if ('x' in keys and 'z' in keys):
@@ -214,7 +399,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{0.tag}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 8, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 10, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
         if ('parking' in keys):
@@ -280,7 +465,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # throwWarning:tr("test righthandtraffic")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 9, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
+                err.append({'class': 11, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
 
         # way!:righthandtraffic
         if True:
@@ -293,7 +478,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # throwWarning:tr("test lefthandtraffic")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 10, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
+                err.append({'class': 12, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
 
         # way[count(uniq_list(tag_regex("abc")))==2]
         if True:
@@ -339,7 +524,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way oneway=no"
                 # assertMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 11, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 13, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[oneway?!]
         if ('oneway' in keys):
@@ -354,7 +539,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertMatch:"way oneway=no"
                 # assertNoMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 11, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 13, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -369,7 +554,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=Westminster x=yes"
                 # assertMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 12, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 14, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -384,7 +569,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way amenity=place_of_worship building=chapel name=Westminster x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 13, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 15, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[inside(FR)][x]
         if ('x' in keys):
@@ -396,7 +581,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1742 - {0}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y","inside=FR")
-                err.append({'class': 14, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 16, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[a][a=*b]
         if ('a' in keys):
@@ -478,7 +663,7 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way maxspeed=5000"
                 # assertNoMatch:"way maxspeed=default"
                 # assertNoMatch:"way"
-                err.append({'class': 15, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+                err.append({'class': 17, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
 
         # way[tag(a)>tag(b)]
         if True:
@@ -492,8 +677,6 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"way a=0 b=1"
                 # assertNoMatch:"way a=0 b=yes"
                 # assertMatch:"way a=1 b=0"
-                # assertMatch:"way a=1.5 b=0"
-                # assertNoMatch:"way a=no b=yes"
                 err.append({'class': 6, 'subclass': 384294833, 'text': {'en': 'test'}})
 
         # way[x]
@@ -622,25 +805,109 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'lit': 'yes'}), expected={'class': 6, 'subclass': 130427469})
         self.check_not_err(n.node(data, {'abc': 'def', 'lit': 'yes'}), expected={'class': 6, 'subclass': 612979508})
         self.check_err(n.node(data, {'lit': 'yes'}), expected={'class': 6, 'subclass': 612979508})
-        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 7, 'subclass': 1785050832})
-        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 7, 'subclass': 1785050832})
-        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 7, 'subclass': 1785050832})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6a'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '3.0', 'b': '6a'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6a'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': 'Y'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '6', 'b': '-5'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '12', 'b': '3'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '12.0', 'b': '3'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '6', 'b': '3'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '12', 'b': '3.0'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_err(n.node(data, {'a': '6.0', 'b': '3.0'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '6', 'b': '3a'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3a'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': 'Y', 'b': 'X'}), expected={'class': 7, 'subclass': 766520351})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6a'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '3.0', 'b': '6a'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6a'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': 'Y'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '6', 'b': '-5'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '12', 'b': '3'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '12.0', 'b': '3'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '6', 'b': '3'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '12', 'b': '3.0'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_err(n.node(data, {'a': '6.0', 'b': '3.0'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '6', 'b': '3a'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3a'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': 'Y', 'b': 'X'}), expected={'class': 7, 'subclass': 1296744085})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6a'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '3.0', 'b': '6a'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6a'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': 'Y'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '6', 'b': '-5'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '12', 'b': '3'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '12.0', 'b': '3'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '6', 'b': '3'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '12', 'b': '3.0'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_err(n.node(data, {'a': '6.0', 'b': '3.0'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '6', 'b': '3a'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3a'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': 'Y', 'b': 'X'}), expected={'class': 7, 'subclass': 660577118})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '3', 'b': '6a'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '3.0', 'b': '6a'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '3a', 'b': '6a'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': 'Y'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '6', 'b': '-5'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '12', 'b': '3'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '12.0', 'b': '3'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '6', 'b': '3'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '12', 'b': '3.0'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_err(n.node(data, {'a': '6.0', 'b': '3.0'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '6', 'b': '3a'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '6a', 'b': '3a'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': 'Y', 'b': 'X'}), expected={'class': 7, 'subclass': 1302849761})
+        self.check_not_err(n.node(data, {'a': '-5'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_not_err(n.node(data, {'a': '1'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_not_err(n.node(data, {'a': '1.0'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_err(n.node(data, {'a': '3'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_err(n.node(data, {'a': '3.0'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_not_err(n.node(data, {'a': 'X'}), expected={'class': 8, 'subclass': 1910232765})
+        self.check_not_err(n.node(data, {'a': '-5'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_not_err(n.node(data, {'a': '1'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_not_err(n.node(data, {'a': '1.0'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_err(n.node(data, {'a': '3'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_err(n.node(data, {'a': '3.0'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_not_err(n.node(data, {'a': 'X'}), expected={'class': 8, 'subclass': 1369591651})
+        self.check_not_err(n.node(data, {'a': 'X'}), expected={'class': 8, 'subclass': 130115842})
+        self.check_err(n.node(data, {'a': 'ananas'}), expected={'class': 8, 'subclass': 130115842})
+        self.check_not_err(n.node(data, {'a': 'X'}), expected={'class': 8, 'subclass': 935120167})
+        self.check_err(n.node(data, {'a': 'ananas'}), expected={'class': 8, 'subclass': 935120167})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': '2'}), expected={'class': 7, 'subclass': 1734018842})
+        self.check_not_err(n.node(data, {'a': 'X', 'b': '2.0'}), expected={'class': 7, 'subclass': 1734018842})
+        self.check_err(n.node(data, {'a': 'ananas', 'b': '2'}), expected={'class': 7, 'subclass': 1734018842})
+        self.check_err(n.node(data, {'a': 'ananas', 'b': '2.0'}), expected={'class': 7, 'subclass': 1734018842})
+        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 9, 'subclass': 1785050832})
+        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 9, 'subclass': 1785050832})
+        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 9, 'subclass': 1785050832})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 8, 'subclass': 169712264})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 10, 'subclass': 169712264})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 8, 'subclass': 2074848923})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 10, 'subclass': 2074848923})
         self.check_not_err(n.way(data, {'a': 'b', 'c': 'd'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'a': 'b'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_not_err(n.way(data, {'b': 'a', 'd': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'b': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 9, 'subclass': 529680562})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 11, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 9, 'subclass': 529680562})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 11, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 10, 'subclass': 877255184})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 12, 'subclass': 877255184})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 10, 'subclass': 877255184})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 12, 'subclass': 877255184})
         self.check_not_err(n.way(data, {'abc': 'def', 'abcdef': 'def'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
@@ -649,38 +916,36 @@ class Test(TestPluginMapcss):
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_not_err(n.way(data, {'abc': 'def', 'def': 'def'}, [0]), expected={'class': 6, 'subclass': 57938147})
-        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 11, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 11, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 11, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 11, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 11, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 11, 'subclass': 722694187})
-        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 11, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 11, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 11, 'subclass': 722694187})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 12, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 13, 'subclass': 1140742172})
+        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 13, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 13, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 13, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 13, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 13, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 13, 'subclass': 722694187})
+        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 13, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 13, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 13, 'subclass': 722694187})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 14, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 14, 'subclass': 1095325051})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 14, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 14, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 15, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 15, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 15, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 15, 'subclass': 1140742172})
         with with_options(n, {'country': 'FR'}):
-            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 14, 'subclass': 1132689531})
+            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 16, 'subclass': 1132689531})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
-        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 15, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 15, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 15, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {}, [0]), expected={'class': 15, 'subclass': 2063115534})
+        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 17, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 17, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 17, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {}, [0]), expected={'class': 17, 'subclass': 2063115534})
         self.check_not_err(n.way(data, {'a': '0', 'b': '1'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_not_err(n.way(data, {'a': '0', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_err(n.way(data, {'a': '1', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})
-        self.check_err(n.way(data, {'a': '1.5', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})
-        self.check_not_err(n.way(data, {'a': 'no', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 6, 'subclass': 1961315435})
         self.check_not_err(n.relation(data, {'ABC': 'DEF'}, []), expected={'class': 4, 'subclass': 1371556921})
         self.check_err(n.relation(data, {'abc': 'def'}, []), expected={'class': 4, 'subclass': 1371556921})

--- a/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
@@ -204,10 +204,8 @@ way[maxspeed > 5000] {
 way[tag(a) > tag(b)] {
   throwWarning: "test";
   assertMatch: "way a=1 b=0";
-  assertMatch: "way a=1.5 b=0";
   assertNoMatch: "way a=0 b=1";
   assertNoMatch: "way a=0 b=yes";
-  assertNoMatch: "way a=no b=yes";
 }
 
 way[x] {
@@ -215,4 +213,124 @@ way[x] {
   set b;
   throwWarning: "test";
   assertMatch: "way x=y";
+}
+
+node[a][b][tag("a") > tag("b")] {
+  throwError: tr("test #1882 - {0}-{1}", "{0.tag}", "{1.tag}");
+  assertNoMatch: "node a=3  b=6";
+  assertNoMatch: "node a=X  b=Y";
+  assertNoMatch: "node a=3a b=6a";
+  assertNoMatch: "node a=3a b=6";
+  assertNoMatch: "node a=3  b=6a";
+  assertMatch:   "node b=3  a=6";
+  assertMatch:   "node b=3  a=12.0";
+  assertMatch:   "node b=3  a=12";
+  assertMatch:   "node b=-5 a=6";
+  assertNoMatch: "node b=X  a=Y";
+  assertNoMatch: "node b=3a a=6a";
+  assertNoMatch: "node b=3a a=6";
+  assertNoMatch: "node b=3  a=6a";
+  assertNoMatch: "node a=3.0  b=6a";
+  assertMatch:   "node b=3.0  a=6.0";
+  assertMatch:   "node b=3.0  a=12";
+}
+
+node[a][b][tag("a") >= tag("b")] {
+  throwError: tr("test #1882 - {0}-{1}", "{0.tag}", "{1.tag}");
+  assertNoMatch: "node a=3  b=6";
+  assertNoMatch: "node a=X  b=Y";
+  assertNoMatch: "node a=3a b=6a";
+  assertNoMatch: "node a=3a b=6";
+  assertNoMatch: "node a=3  b=6a";
+  assertMatch:   "node b=3  a=6";
+  assertMatch:   "node b=3  a=12.0";
+  assertMatch:   "node b=3  a=12";
+  assertMatch:   "node b=-5 a=6";
+  assertNoMatch: "node b=X  a=Y";
+  assertNoMatch: "node b=3a a=6a";
+  assertNoMatch: "node b=3a a=6";
+  assertNoMatch: "node b=3  a=6a";
+  assertNoMatch: "node a=3.0  b=6a";
+  assertMatch:   "node b=3.0  a=6.0";
+  assertMatch:   "node b=3.0  a=12";
+}
+
+node[a][b][tag("b") < tag("a")] {
+  throwError: tr("test #1882 - {0}-{1}", "{0.tag}", "{1.tag}");
+  assertNoMatch: "node a=3  b=6";
+  assertNoMatch: "node a=X  b=Y";
+  assertNoMatch: "node a=3a b=6a";
+  assertNoMatch: "node a=3a b=6";
+  assertNoMatch: "node a=3  b=6a";
+  assertMatch:   "node b=3  a=6";
+  assertMatch:   "node b=3  a=12.0";
+  assertMatch:   "node b=3  a=12";
+  assertMatch:   "node b=-5 a=6";
+  assertNoMatch: "node b=X  a=Y";
+  assertNoMatch: "node b=3a a=6a";
+  assertNoMatch: "node b=3a a=6";
+  assertNoMatch: "node b=3  a=6a";
+  assertNoMatch: "node a=3.0  b=6a";
+  assertMatch:   "node b=3.0  a=6.0";
+  assertMatch:   "node b=3.0  a=12";
+}
+
+node[a][b][tag("b") <= tag("a")] {
+  throwError: tr("test #1882 - {0}-{1}", "{0.tag}", "{1.tag}");
+  assertNoMatch: "node a=3  b=6";
+  assertNoMatch: "node a=X  b=Y";
+  assertNoMatch: "node a=3a b=6a";
+  assertNoMatch: "node a=3a b=6";
+  assertNoMatch: "node a=3  b=6a";
+  assertMatch:   "node b=3  a=6";
+  assertMatch:   "node b=3  a=12.0";
+  assertMatch:   "node b=3  a=12";
+  assertMatch:   "node b=-5 a=6";
+  assertNoMatch: "node b=X  a=Y";
+  assertNoMatch: "node b=3a a=6a";
+  assertNoMatch: "node b=3a a=6";
+  assertNoMatch: "node b=3  a=6a";
+  assertNoMatch: "node a=3.0  b=6a";
+  assertMatch:   "node b=3.0  a=6.0";
+  assertMatch:   "node b=3.0  a=12";
+}
+
+node[a > 2] {
+  throwError: tr("test #1882 - {0}", "{0.tag}");
+  assertMatch: "node a=3";
+  assertMatch: "node a=3.0";
+  assertNoMatch: "node a=X";
+  assertNoMatch: "node a=-5";
+  assertNoMatch: "node a=1";
+  assertNoMatch: "node a=1.0";
+}
+
+node[a > 2.0] {
+  throwError: tr("test #1882 - {0}", "{0.tag}");
+  assertMatch: "node a=3";
+  assertMatch: "node a=3.0";
+  assertNoMatch: "node a=X";
+  assertNoMatch: "node a=-5";
+  assertNoMatch: "node a=1";
+  assertNoMatch: "node a=1.0";
+}
+
+node[a][count(split("n", tag("a"))) > 2] {
+  throwError: tr("test #1882 - {0}", "{0.tag}");
+  assertMatch: "node a=ananas";
+  assertNoMatch: "node a=X";
+}
+
+node[a][count(split("n", tag("a"))) > 2.0] {
+  throwError: tr("test #1882 - {0}", "{0.tag}");
+  assertMatch: "node a=ananas";
+  assertNoMatch: "node a=X";
+}
+
+node[a][b][count(split("n", tag("a"))) > tag(b)] {
+  throwError: tr("test #1882 - {0}-{1}", "{0.tag}", "{1.tag}");
+  assertMatch: "node a=ananas b=2";
+  assertMatch: "node a=ananas b=2.0";
+  assertNoMatch: "node a=X b=2";
+  assertNoMatch: "node a=X b=2.0";
 }


### PR DESCRIPTION
Fixes #1882

I added test cases for:
- `*[string_returning_function > string_returning_function]`
- `*[string_returning_function > int/float]`
- `*[int_returning_function > int/float]`
- `*[int_returning_function > string_returning_function]`