### PR TITLE
Replace hardcoded rule that internally rewrites `:righthandtraffic` to `[setting('driving_side')='left']` by auto-generation of that code

### DIFF
--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -264,10 +264,10 @@ def pseudo_class_righthandtraffic(t, c):
     Replace pseudo class :righthandtraffic by call to setting()
     """
     if t['pseudo_class'] == 'righthandtraffic':
-        t = {'type': 'booleanExpression', 'operator': '=' if t['not_class'] else '!=', 'operands': [
-            {'type': 'functionExpression', 'name': 'setting', 'params': [{'type': 'primaryExpression', 'derefered': False, 'value': {'type': 'quoted', 'value': 'driving_side'}}]},
-            {'type': 'primaryExpression', 'derefered': False, 'value': {'type': 'quoted', 'value': 'left'}}
-        ]}
+        setting_selector = deepcopy(mock_rules['setting_drivingside_eq_left' if t['not_class'] else 'setting_drivingside_neq_left'])
+        setting_selector = rewrite_tree_rules(rewrite_rules_clean, None, setting_selector, {})
+        setting_selector['selector_index'] = t.get('selector_index')
+        return setting_selector
     return t
 
 rule_declarations_order_map = {

--- a/mapcss/mock_rules/setting_drivingside_eq_left.mapcss
+++ b/mapcss/mock_rules/setting_drivingside_eq_left.mapcss
@@ -1,0 +1,1 @@
+*[setting("driving_side")="left"] {}

--- a/mapcss/mock_rules/setting_drivingside_neq_left.mapcss
+++ b/mapcss/mock_rules/setting_drivingside_neq_left.mapcss
@@ -1,0 +1,1 @@
+*[setting("driving_side")!="left"] {}


### PR DESCRIPTION
Remove hardcoded rule for pseudo class `:righthandtraffic` and replace it by automatically generated code from a mock selector that corresponds to the rule as it is rewritten.
(Similar to https://github.com/osm-fr/osmose-backend/commit/40035a6b0eb43b05d2c895e4c1b2f6baa29eeea7 )

The output for the mapcss files is the same, regenerating doesn't change anything related to this PR

Note that I could have used `*[setting(driving_side)!=left] {}` as mock selector (i.e. without quotes). In that case I wouldn't need to call `rewrite_rules_clean`. However, it feels really strange to me to not use quotes in a function with a string argument ;)

No need to add tests, they're already present: https://github.com/osm-fr/osmose-backend/blob/47d9d27ab23485a21689d97fad6afd4e3580eeb6/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss#L76-L85