### PR TITLE
Make computation of schema size more robust in case of error on psql request

### DIFF
--- a/modules/OsmOsisManager.py
+++ b/modules/OsmOsisManager.py
@@ -291,7 +291,8 @@ class OsmOsisManager:
     sql = "select sum(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename)))::bigint from pg_tables where schemaname = %s;"
     giscurs.execute(sql, [self.db_schema])
     schema_size = giscurs.fetchone()[0]
-    self.logger.sub().log("Schema size is: {} bytes ({})".format(schema_size, human_readable_size(schema_size)))
+    if schema_size is not None:
+      self.logger.sub().log("Schema size is: {} bytes ({})".format(schema_size, human_readable_size(schema_size)))
 
     if conf.db_persistent:
       pass


### PR DESCRIPTION
We have some errors like this one:
```
2023-06-15 20:39:36 cleaning :
Traceback (most recent call last):
  File "/data/project/osmose/backend/./osmose_run.py", line 600, in <module>
    sys.exit(main(options))
  File "/data/project/osmose/backend/./osmose_run.py", line 514, in main
    err_code |= run(country_conf, logger, analysers, options)
  File "/data/project/osmose/backend/./osmose_run.py", line 410, in run
    clean(conf, logger, options, osmosis_manager)
  File "/data/project/osmose/backend/./osmose_run.py", line 371, in clean
    osmosis_manager.clean_database(conf, options.no_clean or not conf.clean_at_end)
  File "/data/project/osmose/backend/modules/OsmOsisManager.py", line 294, in clean_database
    self.logger.sub().log("Schema size is: {} bytes ({})".format(schema_size, human_readable_size(schema_size)))
  File "/data/project/osmose/backend/modules/OsmOsisManager.py", line 285, in human_readable_size
    if size < 1024.0 or unit == 'PiB':
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```