### PR TITLE
Upgrade openjdk from version 11 to 17

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-bullseye
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.9
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
@@ -17,7 +17,7 @@ RUN apt-get update && \
         libprotobuf-dev \
         locales \
         make \
-        openjdk-11-jre-headless \
+        openjdk-17-jre-headless \
         pkg-config \
         postgis \
         postgresql-client \


### PR DESCRIPTION
Docker build fails with `Package 'openjdk-11-jre-headless' has no installation candidate` due to the python:3.9 tag being updated to debian bookworm and bookworm no longer supporting openjdk-11.