### PR TITLE
Check if mapcss functions exist

### DIFF
--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -443,7 +443,7 @@ def checkValidFunction(fn_name, num_params):
     if fn_name[0:7] != "mapcss.":
         return
     if not fn_name[7:] in dir(mapcss_lib):
-        raise NotImplementedError("Undefined function '{0}'. Blacklist or implement to avoid runtime errors".format(fn_name))
+        raise NotImplementedError("Undefined function '{0}'. Blacklist or implement to avoid errors".format(fn_name))
     else:
         sig = signature(getattr(mapcss_lib, fn_name[7:]))
         argcount = len(sig.parameters) # includes optional arguments
@@ -452,7 +452,7 @@ def checkValidFunction(fn_name, num_params):
         if has_vararg:
             argcount = argcount - 1 # *args can be zero-length
         if num_params < argcount - num_optional_arg or (not has_vararg and num_params > argcount):
-            raise NotImplementedError("Undefined function '{0}' with {1} arguments. Blacklist or implement to avoid runtime errors".format(fn_name, num_params))
+            raise NotImplementedError("Undefined function '{0}' with {1} arguments. Blacklist or implement to avoid errors".format(fn_name, num_params))
 
 
 rewrite_rules_clean = [

--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -13,6 +13,8 @@ from .generated.MapCSSParser import MapCSSParser
 from .MapCSSListenerL import MapCSSListenerL
 from typing import Dict, List, Set, Optional
 from copy import deepcopy
+from . import mapcss_lib
+from inspect import signature, Parameter
 
 
 # Clean
@@ -429,7 +431,29 @@ def functionExpression_runtime(t, c):
             "mapcss.round_" if t['name'] == 'round' else
             "mapcss." + t['name']
         )
+
+        if not c.get('flags'):
+            checkValidFunction(t['name'], len(t['params']))
     return t
+
+def checkValidFunction(fn_name, num_params):
+    """
+    Tests if mapcss.* functions actually exist, throws a compile error otherwise
+    """
+    if fn_name[0:7] != "mapcss.":
+        return
+    if not fn_name[7:] in dir(mapcss_lib):
+        raise NotImplementedError("Undefined function '{0}'. Blacklist or implement to avoid runtime errors".format(fn_name))
+    else:
+        sig = signature(getattr(mapcss_lib, fn_name[7:]))
+        argcount = len(sig.parameters) # includes optional arguments
+        has_vararg = any(map(lambda p: p.kind == Parameter.VAR_POSITIONAL, sig.parameters.values()))
+        num_optional_arg = len(set(filter(lambda p: p.default != Parameter.empty, sig.parameters.values())))
+        if has_vararg:
+            argcount = argcount - 1 # *args can be zero-length
+        if num_params < argcount - num_optional_arg or (not has_vararg and num_params > argcount):
+            raise NotImplementedError("Undefined function '{0}' with {1} arguments. Blacklist or implement to avoid runtime errors".format(fn_name, num_params))
+
 
 rewrite_rules_clean = [
     ('valueExpression', valueExpression_remove_null_op),

--- a/plugins/tests/test_mapcss_parsing_evalutation.py
+++ b/plugins/tests/test_mapcss_parsing_evalutation.py
@@ -422,6 +422,18 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertNoMatch:"node z=yes"
                 err.append({'class': 6, 'subclass': 519126950, 'text': {'en': 'test'}})
 
+        # node[x][substring(tag(x),1)=="bcde"][substring(tag(x),1,3)="bc"]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.substring(mapcss.tag(tags, 'x'), 1) == 'bcde') and (mapcss.substring(mapcss.tag(tags, 'x'), 1, 3) == 'bc'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertMatch:"node x=abcde"
+                err.append({'class': 6, 'subclass': 770828321, 'text': {'en': 'test'}})
+
         return err
 
     def way(self, data, tags, nds):
@@ -979,6 +991,9 @@ class test_mapcss_parsing_evalutation(PluginMapCSS):
                 # assertMatch:"relation type=other z=yes"
                 err.append({'class': 10, 'subclass': 758090756, 'text': mapcss.tr('test closed rewrite {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
+        # relation[tag(x)==parent_tag(x)]
+        # Part of rule not implemented
+
         return err
 
 
@@ -1116,6 +1131,7 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'x': 'yes'}), expected={'class': 6, 'subclass': 519126950})
         self.check_err(n.node(data, {'y': 'yes'}), expected={'class': 6, 'subclass': 519126950})
         self.check_not_err(n.node(data, {'z': 'yes'}), expected={'class': 6, 'subclass': 519126950})
+        self.check_err(n.node(data, {'x': 'abcde'}), expected={'class': 6, 'subclass': 770828321})
         self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 12, 'subclass': 1785050832})
         self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 12, 'subclass': 1785050832})
         self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 12, 'subclass': 1785050832})

--- a/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evalutation.validator.mapcss
@@ -410,3 +410,13 @@ node[any(tag("x"), tag("y"))] {
   assertMatch: "node y=yes";
   assertNoMatch: "node z=yes";
 }
+
+relation[tag(x)==parent_tag(x)] { /*parent_tag not implemented, but blacklisted, should be skipped*/
+  throwWarning: "test";
+  assertMatch: "relation a=b c=d";
+}
+
+node[x][substring(tag(x), 1) == "bcde"][substring(tag(x), 1, 3) = "bc"] {
+  throwWarning: "test";
+  assertMatch: "node x=abcde";
+}


### PR DESCRIPTION
Check if mapcss functions exist and have the right number of arguments
Raises a NotImplementedError during compilation, rather than an ArgumentError/TypeError during runtime on the server

Fixes #1925