### PR TITLE
Remove unneeded blacklist

### DIFF
--- a/mapcss/item_map.py
+++ b/mapcss/item_map.py
@@ -369,7 +369,6 @@ item_map = \
                        '{0} value with + sign': 9006002},
              'item': 9006,
              'prefix': 'Josm_',
-             'subclass_blacklist': [1251729862],
              'tags': ['tag', 'value'],
              'url': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/numeric.mapcss?format=txt',
              'url_display': 'https://josm.openstreetmap.de/browser/josm/trunk/resources/data/validator/numeric.mapcss'},


### PR DESCRIPTION
Remove unneeded blacklist that became obsolete as the buggy rule was removed in JOSM.

Didn't update item_map.py fully to avoid hardcoding issue 1934's bug