### PR TITLE
Return a value for `println`

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -523,6 +523,7 @@ def URL_decode(string):
 #    prints a string representation of o to the command line, followed by a new line (for debugging) [since 7237]
 def println(o):
     print(o)
+    return o
 
 #JOSM_pref(key, default)
 #    Get value from the JOSM advanced preferences. This way you can offer certain options to the user and make the style customizable. It works with strings, numbers, colors and boolean values.


### PR DESCRIPTION
See https://github.com/osm-fr/osmose-backend/issues/1938

This matches the behavior of JOSM: https://josm.openstreetmap.de/browser/josm/trunk/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java#L1164

Otherwise, the line `trim(replace(URL_decode(get(println(regexp_match(...))))))` would always return None when println is used.
(I suspect println is actually a mistake that should've been removed from the rule, but we better support it correctly rather than produce bad results)  

Before:
```xml
<tag action="create" k="wikipedia:pt" v="" />
```

After
```xml
<tag action="create" k="wikipedia:pt" v="M%C3%A1rio Leopoldo Pereira da C%C3%A2mara" />
```

For the issues here: https://osmose.openstreetmap.fr/nl/map/#item=9011&class=9011006&limit=500&zoom=15&lat=-5.81545&lon=-35.22659&level=2&tags=&fixable=


There's still another issue (the %C3 aren't resolved), but fixing it step by step :)

