### PR TITLE
Fix looped drivethroughs

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -235,6 +235,7 @@ WHERE
   drivethroughs.tags?'service' AND
   drivethroughs.tags->'service' = 'drive-through' AND
   NOT drivethroughs.is_oneway AND
+  drivethroughs.nodes[1] != drivethroughs.nodes[array_length(drivethroughs.nodes,1)] AND
   other_highways.id IS NULL
 """
 

--- a/tests/osmosis_highway_deadend.osm
+++ b/tests/osmosis_highway_deadend.osm
@@ -83,6 +83,8 @@
   <node id='77' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85536371943' lon='5.82689960204' />
   <node id='78' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8552634216' lon='5.82729637275' />
   <node id='79' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85536226544' lon='5.82729731998' />
+  <node id='80' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85556437347' lon='5.82683739266' />
+  <node id='81' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85556585241' lon='5.82696669393' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -341,5 +343,14 @@
     <nd ref='56' />
     <nd ref='60' />
     <tag k='highway' v='tertiary' />
+  </way>
+  <way id='1036' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='80' />
+    <nd ref='70' />
+    <nd ref='81' />
+    <nd ref='80' />
+    <tag k='highway' v='service' />
+    <tag k='name' v='Class 5 good' />
+    <tag k='service' v='drive-through' />
   </way>
 </osm>


### PR DESCRIPTION
If a drivethrough is a loop (and not a floating way without connections - which would be detected by a different analyser), then there must be a way out already. This way out is not necessarily connected to the same way as the first=final node of the loop. Hence, exclude such cases.
Also adds a test case.

Resolves #1946
Fixes https://www.openstreetmap.org/way/965343808, https://www.openstreetmap.org/way/196851026, https://www.openstreetmap.org/way/1186289900

p.s.: I can also use is_polygon if preferred? (Downside: it's more sensitive to invalid geometries).