### PR TITLE
Exclude partially downloaded, closed ways from "Should be polygon"-check

### DIFF
--- a/analysers/analyser_osmosis_relation_multipolygon.py
+++ b/analysers/analyser_osmosis_relation_multipolygon.py
@@ -183,12 +183,13 @@ WHERE
         ways.tags?'landuse' OR
         (ways.tags?'natural' AND ways.tags->'natural' in ('wood', 'scrub', 'heath', 'moor', 'grassland', 'fell', 'bare_rock', 'scree', 'shingle', 'sand', 'mud', 'water', 'wetland', 'glacier', 'bay', 'beach', 'hot_spring', 'rock', 'stone', 'sinkhole')) OR
         (ways.tags?'waterway' AND ways.tags->'waterway' in ('boatyard', 'dock', 'riverbank', 'fuel')) OR
-        (ways.tags?'leisure' AND ways.tags->'leisure' in ('adult_gaming_centre', 'amusement_arcade', 'beach_resort', 'bandstand', 'bird_hide', 'common', 'dance', 'dog_park', 'firepit', 'fishing', 'fitness_centre', 'garden', 'golf_course', 'hackerspace', 'horse_riding', 'ice_rink', 'marina', 'miniature_golf', 'nature_reserve', 'park', 'picnic_table', 'pitch', 'playground', 'sports_centre', 'stadium', 'summer_camp', 'swimming_area', 'swimming_pool', 'water_park', 'wildlife_hide', 'user', 'defined')) OR
+        (ways.tags?'leisure' AND ways.tags->'leisure' in ('adult_gaming_centre', 'amusement_arcade', 'beach_resort', 'bandstand', 'bird_hide', 'common', 'dance', 'dog_park', 'firepit', 'fishing', 'fitness_centre', 'garden', 'golf_course', 'hackerspace', 'horse_riding', 'ice_rink', 'marina', 'miniature_golf', 'nature_reserve', 'park', 'picnic_table', 'pitch', 'playground', 'sports_centre', 'stadium', 'summer_camp', 'swimming_area', 'swimming_pool', 'water_park', 'wildlife_hide')) OR
         (ways.tags?'amenity' AND ways.tags->'amenity' in ('bar', 'biergarten', 'cafe', 'fast_food', 'food_court', 'ice_cream', 'pub', 'restaurant', 'college', 'kindergarten', 'library', 'public_bookcase', 'school', 'music_school', 'driving_school', 'language_school', 'university', 'bicycle_repair_station', 'bicycle_rental', 'boat_sharing', 'bus_station', 'car_rental', 'car_sharing', 'car_wash', 'ferry_terminal', 'fuel', 'motorcycle_parking', 'parking', 'parking_space', 'taxi', 'bank', 'baby_hatch', 'clinic', 'dentist', 'doctors', 'hospital', 'nursing_home', 'pharmacy', 'social_facility', 'veterinary', 'blood_donation', 'arts_centre', 'brothel', 'casino', 'cinema', 'community_centre', 'fountain', 'gambling', 'nightclub', 'planetarium', 'social_centre', 'studio', 'swingerclub', 'theatre', 'animal_boarding', 'animal_shelter', 'courthouse', 'coworking_space', 'crematorium', 'crypt', 'dive_centre', 'dojo', 'embassy', 'fire_station', 'firepit', 'game_feeding', 'grave_yard', 'gym', 'hunting_stand', 'internet_cafe', 'kneipp_water_cure', 'marketplace', 'place_of_worship', 'police', 'post_office', 'prison', 'public_building', 'ranger_station', 'recycling', 'rescue_station', 'sauna', 'shelter', 'shower', 'toilets', 'townhall', 'waste_transfer_station')) OR
         ways.tags?'building'
     ) AND
     ways.linestring IS NOT NULL AND
     NOT ways.is_polygon AND
+    ST_IsValid(ways.linestring) AND -- avoid confusing warnings for invalid ways (checked elsewhere)
     relation_members.member_id IS NULL
 """
 


### PR DESCRIPTION
See #1947

This PR excludes partially downloaded, closed ways from the "should be polygon" check. This occurs quite frequently for larger landuses near the extract borders, see the issue for examples.

In addition it removes `leisure=user` and `leisure=defined`, which don't exist in OSM and are very likely just a copy-paste mistake (because the table on the wiki ends with `user defined`)

On top of this, as a positive side effect, the PR also removes the very strange warnings for:
- `building=*` with an `attraction=roller_coaster` tag. 
For example: https://osmose.openstreetmap.fr/nl/map/#zoom=18&lat=51.64769&lon=5.051999&item=1170&level=1&tags=&fixable= . 
It's a strange way of tagging it (which is used for 322 out of 2503 rollercoaster ways), but the warning didn't make sense as it's a polygon. (Note: `attraction=roller_coaster` is whitelisted [in ImportDatabase_Prepare](https://github.com/osm-fr/osmose-backend/blob/dev/osmosis/ImportDatabase_Prepare.sql#L18))
- invalid polygons. These are already warned for by analyser_osmosis_polygon, and that warning is better for such cases than "Should be polygon"