### PR TITLE
Add warning for repeated conditions & avoid duplicate reports

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -97,10 +97,10 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             re.compile('massgis:.+'),
             re.compile('lacounty:.+'),
             re.compile('turn:lanes.*'),
+            re.compile('.+:conditional'), # More thorough check in ConditionalRestrictions plugin
         ))
         self.WhitelistSimilarRegex = set(( # Regexes for keys that can have similar, but not equal values
             re.compile('.+_name'),
-            re.compile('.+:conditional'),
             re.compile('.+:date'),
             re.compile('.+:colour'),
             re.compile('opening_hours(:.+)?'),


### PR DESCRIPTION
This adds a warning when a condition is repeated, overruling (in case of `;`-separated conditions) or at least making redundant (in case of ` AND `-separated conditions) the preceding condition.

In addition it should fix getting a duplicate marker for such cases, in case there's a warning for the condition. (Using some parts of todays earlier commit by Frodrigo)

Also whitelists `*:conditional` from TagFix_DuplicateValue as the new check is more thorough. (TagFix_DuplicateValue wouldn't find it if the values differed, but the conditions were the same)