### PR TITLE
Fix rollercoasters

### DIFF
--- a/osmosis/ImportDatabase_Prepare.sql
+++ b/osmosis/ImportDatabase_Prepare.sql
@@ -15,7 +15,7 @@ BEGIN
       ST_IsValid(NEW.linestring) AND
       ST_IsSimple(NEW.linestring) AND
       ST_IsValid(ST_MakePolygon(NEW.linestring)) AND
-      NOT (NEW.tags?'attraction' AND NEW.tags->'attraction' = 'roller_coaster');
+      NOT (NEW.tags?'roller_coaster' AND NEW.tags->'roller_coaster' = 'track');
   END IF;
   RETURN NEW;
 END;


### PR DESCRIPTION
While diving into #1951 I noticed that the roller coaster exception in ImportDatabase_Prepare is wrong. 

`attraction=roller_coaster` refers to the *area* where the entire roller coaster is located (see [wiki](https://wiki.openstreetmap.org/wiki/Tag:attraction%3Droller_coaster)). Consequently, it must be a polygon (or a node).

For the track, the tag [`roller_coaster=track`](https://wiki.openstreetmap.org/wiki/Tag:roller_coaster%3Dtrack) has to be used. The wiki's both explicitly state that this tag should *not* be combined with `attraction=roller_coaster`. The track is of course not a polygon, even if it's a closed loop.

note that this exception was [added almost 12 years ago](https://github.com/osm-fr/osmose-backend/commit/122ed9ee18c5761bbcb8b008bc61e219028d38ba), when roller_coaster=track didn't exist yet.