### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/boundary.yaml
+++ b/.github/workflows/boundary.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup env
       run: |
@@ -21,7 +21,7 @@ jobs:
         sudo chown $USER /data/work/$USER /data/work/$USER/cache
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           flex \
           bison
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup env
       run: |
@@ -42,7 +42,7 @@ jobs:
         cd modules/osm_pbf_parser && make && cd ../../
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -98,7 +98,7 @@ jobs:
           flex \
           bison
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup env
       run: |
@@ -109,7 +109,7 @@ jobs:
         cd modules/osm_pbf_parser && make && cd ../../
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -175,7 +175,7 @@ jobs:
           flex \
           bison
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup env
       run: |
@@ -186,7 +186,7 @@ jobs:
         cd modules/osm_pbf_parser && make && cd ../../
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/poly.yaml
+++ b/.github/workflows/poly.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
This PR update:
- [checkout ](https://github.com/actions/checkout)to v3
- [setup-python](https://github.com/actions/setup-python) to v4

Github remove support to actions using node 12 -> https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/