### PR TITLE
Remove false positives for incorrect tag check

### DIFF
--- a/plugins/TagFix_Access.py
+++ b/plugins/TagFix_Access.py
@@ -38,9 +38,9 @@ class TagFix_Access(Plugin):
                        "hazmat:water", "hgv", "horse", "hov", "inline_skates", "light_rail", "minibus", "mofa", "moped", "motor_vehicle", "motorboat", "motorcar", "motorcycle", "motorhome", "psv",
                        "share_taxi", "ship", "ski:nordic", "ski", "small_electric_vehicle", "snowmobile", "speed_pedelec", "subway", "swimming", "tank", "taxi", "tourist_bus", "trailer", "train", "tram", "vehicle"]
     self.accessValuesGeneral = ["yes", "no", "private", "permissive", "permit", "destination", "delivery", "customers", "designated", "use_sidepath", "agricultural", "forestry", "discouraged"]
-    self.accessValuesSpecial = {"bicycle": ["dismount"],
+    self.accessValuesSpecial = {"bicycle": ["optional_sidepath", "dismount"],
                                 "canoe": ["put_in", "portage"],
-                                "dog": ["leashed", "unleashed"],
+                                "dog": ["leashed", "unleashed", "outside"],
                                 "horse": ["dismount"],
                                 "mofa": ["dismount"],
                                 "moped": ["dismount"],

--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -95,7 +95,7 @@ However, this should probably still conform to the typical format used for value
         self.allow_closed = { "area": ( "yes", "no", ),
                             "backrest": ( "yes", "no", ),
                             "conveying": ( "yes", "forward", "backward", "no", "reversible", ),
-                            "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", ),
+                            "crossing": ( "traffic_signals", "uncontrolled", "unmarked", "no", "marked", "zebra", "informal", ),
                             "lane_markings": ( "yes", "no", ),
                             "narrow": ( "yes", "no", ),
                             "oneway": ( "yes", "no", "1", "-1", "reversible", "alternating"),


### PR DESCRIPTION
I found three documented tags that I believe are false positives as they are documented in the wiki. Especially `bicycle=optional_sidepath` and `crossing=informal` have a rather large occurrence.