### PR TITLE
Filter out all invalid polygons - more reliable approach

### DIFF
--- a/analysers/analyser_osmosis_relation_multipolygon.py
+++ b/analysers/analyser_osmosis_relation_multipolygon.py
@@ -189,8 +189,11 @@ WHERE
     ) AND
     ways.linestring IS NOT NULL AND
     NOT ways.is_polygon AND
-    ST_IsValid(ways.linestring) AND -- avoid confusing warnings for invalid ways (checked elsewhere)
-    relation_members.member_id IS NULL
+    relation_members.member_id IS NULL AND
+    -- Avoid confusing warnings for invalid polygons. Any closed way with >3 nodes that doesn't match
+    -- is_polygon (with any of the tags above) must be an invalid polygon (which is checked elsewhere)
+    -- Note: use array_length instead of ST_NPoints as the former includes nodes outside of the extract
+    (NOT ST_IsClosed(ways.linestring) OR array_length(ways.nodes,1) = 3)
 """
 
 class Analyser_Osmosis_Relation_Multipolygon(Analyser_Osmosis):


### PR DESCRIPTION
Fixes the p.s. in https://github.com/osm-fr/osmose-backend/issues/1947#issuecomment-1648568840 : 
> p.s.: also the osm110 output isn't perfect yet, e.g. ways 1118949009, 1118949010, 1118582455 and others should also be removed. [...] cases like https://www.openstreetmap.org/way/1118668190. 

**Rationale of the approach**:
The analyser that warns about invalid polygons, `analyser_osmosis_polygon`, checks the following already (simplified and with comments added):
```
    NOT is_polygon AND -- so either not closed OR not simple OR not a ring OR <=3 points OR not valid
    ST_NumPoints(linestring) > 3 AND -- requirement to make ST_MakePolygon work
    ST_IsClosed(linestring) AND
    NOT ST_IsValid(ST_MakePolygon(linestring))
```

Hence, *any* closed way (with the tags that class 4 of `analyser_osmosis_relation_multipolygon` filters on, such as `building` and `landuse`) with > 3 points that is not valid (e.g. is_polygon is false) *must* be an invalid polygon. Consequently, this analyser (which shouldn't warn on an invalid polygon) can be limited to:
1. not closed ways
2. closed ways with only 2 unique points (e.g. `LINESTRING(1 1, 2 2, 1 1)`)

**Why needed**:

The initial approach (using ST_IsValid) unfortunately worked only partially since the validity of a linestring is much simpler than the validity of a polygon and I checked the former. The ways mentioned in the "p.s." on top of this text fail because they form invalid geometries by being closed (at the extract border) without being a valid polygon, but they are still valid for a linestring. Example in the picture below:
![venezuela way 1118668190](https://github.com/osm-fr/osmose-backend/assets/1315520/03d86d47-2dd9-4088-9c12-6b2198a20675)

**Effect of this PR**
This PR *removes* the following bad ways from the results of Venezuela (border issues):
https://www.openstreetmap.org/way/1118949009
https://www.openstreetmap.org/way/1118949010
https://www.openstreetmap.org/way/1118582455
https://www.openstreetmap.org/way/1118582468
https://www.openstreetmap.org/way/1118582469
https://www.openstreetmap.org/way/1118585659
https://www.openstreetmap.org/way/1118585665
https://www.openstreetmap.org/way/1118594131
https://www.openstreetmap.org/way/1118949011
https://www.openstreetmap.org/way/1118662978
https://www.openstreetmap.org/way/1118668186
https://www.openstreetmap.org/way/1118668190
https://www.openstreetmap.org/way/1118948999
https://www.openstreetmap.org/way/1118949022
https://www.openstreetmap.org/way/1118949024
https://www.openstreetmap.org/way/1118949031
https://www.openstreetmap.org/way/1118952958
https://www.openstreetmap.org/way/1119398017

This PR also *removes* the following results from Japan Chubu (invalid polygons, warned for by another analyser):
https://www.openstreetmap.org/way/430678743
https://www.openstreetmap.org/way/430678746
https://www.openstreetmap.org/way/457376080
https://www.openstreetmap.org/way/477055501
https://www.openstreetmap.org/way/486106365
https://www.openstreetmap.org/way/530912866
https://www.openstreetmap.org/way/943214446
https://www.openstreetmap.org/way/982020573
https://www.openstreetmap.org/way/1084132398
https://www.openstreetmap.org/way/1084326440
(All also warned for by https://osmose.openstreetmap.fr/nl/issues/open?country=japan_chubu&item=1040&source=&class=1&username=&bbox= with a much better message)

It however keeps this valid output (Venezuela):
https://www.openstreetmap.org/way/529095663
https://www.openstreetmap.org/way/1059060678
(and a lot of them in for Japan Chubu)