### PR TITLE
Update TagFix_Maxspeed.py

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -42,6 +42,7 @@ class TagFix_Maxspeed(Plugin):
         'be-bru:urban': ['30'],
         'be:motorway': ['120'],
         'be-vlg:rural': ['70'],
+        'bg:motorway': ['140'],
         'by:urban': ['60'],
         'by:motorway': ['110'],
         'ca-on:rural': ['80'],


### PR DESCRIPTION
Max speed on Bulgarian motorways is 140 km/h
There are proposals in law for lowering it to 130 km/h, but they are still not in force.

https://www.mfa.bg/upload/649/09-ZDvP-bg-en.pdf
Art. 21. (1) (page 8)