### PR TITLE
Fix single-quoted strings

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -445,7 +445,10 @@ def JOSM_search(string):
 #    translate from English to the current language (only for strings in the JOSM user interface) [since 6506]
 def tr(string, *args):
     if string is not None:
-        return T_(string, *args)
+        # Treat '' as ' so JOSM translations work in Osmose too.
+        # A ' is a special character in JOSM, see https://josm.openstreetmap.de/wiki/Translations
+        t = T_(string, *args)
+        return {k: t[k].replace("''", "'") for k in t.keys()}
 
 #regexp_test(regexp, string)
 #    test if string matches pattern regexp [since 5699]


### PR DESCRIPTION
In JOSM `'` is a special character, so to print an actual `'` in JOSM, you have to use `''`. Hence, the JOSM translations contain `''` where `'` is the desired output. In Osmose, the character is not special, so it was previously (wrongly) printed as a double `''`.

In order to not get strange translations, such as:
> unusual value of width: use '' for foot and " for inches, no spaces

instead of:

> unusual value of width: use ' for foot and " for inches, no spaces

, we have to convert `''` to `'`. 

Fixes #1934
Attached the output of usa_iowa before and after this change to see the effect: [tr.zip](https://github.com/osm-fr/osmose-backend/files/12383866/tr.zip)

p.s.: please note that this does not affect the strings in mapcss/item_map.py. Since they're just an internal mapping, they can be double-quoted; keeps the code much simpler.
p.p.s.: the `''` to `'` conversion is only needed for `tr(...)` strings. If `tr(...)` is omitted (meaning a string literal, without translations or placeholders) `''` is not converted to `'` 
