### PR TITLE
Don't warn about polygons for (self-intersecting) ways that are no polygons

### DIFF
--- a/analysers/analyser_osmosis_polygon.py
+++ b/analysers/analyser_osmosis_polygon.py
@@ -32,7 +32,8 @@ FROM
     {0}ways
 WHERE
     NOT is_polygon AND
-    NOT (tags?'attraction' AND tags->'attraction' = 'roller_coaster') AND
+    NOT (tags?'roller_coaster' AND tags->'roller_coaster' = 'track') AND -- permit self-intersecting ways
+    NOT (tags?'highway' AND tags->'highway' = 'raceway') AND -- permit self-intersecting ways
     nodes[1] = nodes[array_length(nodes,1)] AND
     ST_NumPoints(linestring) > 3 AND
     ST_IsClosed(linestring) AND


### PR DESCRIPTION
Fixes #1935 and the second part of #1995
For `attraction=roller_coaster` (area surrounding the rollercoaster) vs `roller_coaster=track` (the track itself), see #1960

Note: personally I think that self-intersecting ways can better be split in fragments that do not overlap, especially for rollercoasters where they cross at different heights (and should thus have `layer` tags). This PR is mostly based upon https://github.com/osm-fr/osmose-backend/issues/1935#issuecomment-1616660825 : it's not a polygon, so the warning doesn't make sense.