### PR TITLE
Fix camping pitch in multipolygon camping site

### DIFF
--- a/analysers/analyser_osmosis_camp_pitch_out_of_camp_site.py
+++ b/analysers/analyser_osmosis_camp_pitch_out_of_camp_site.py
@@ -23,22 +23,46 @@
 from modules.OsmoseTranslation import T_
 from .Analyser_Osmosis import Analyser_Osmosis
 
+
+sql01 = """
+CREATE TEMP TABLE camp_sites AS
+SELECT
+    ST_MakePolygon(linestring) AS poly
+FROM
+    ways
+WHERE
+    tags != ''::hstore AND
+    tags?'tourism' AND
+    tags->'tourism' IN ('camp_site', 'caravan_site') AND
+    is_polygon
+UNION ALL
+SELECT
+    poly
+FROM
+    multipolygons
+WHERE
+    tags?'tourism' AND
+    tags->'tourism' IN ('camp_site', 'caravan_site') AND
+    is_valid
+"""
+
+sql02 = """
+CREATE INDEX idx_camp_sites_poly ON camp_sites USING GIST(poly);
+"""
+
 sql10 = """
 SELECT
   pitch.id,
   ST_AsText(way_locate(pitch.linestring))
 FROM
   ways AS pitch
-  LEFT JOIN ways AS site ON
-    site.linestring && pitch.linestring AND
-    site.tags != ''::hstore AND
-    site.tags?'tourism' AND
-    site.tags->'tourism' IN ('camp_site', 'caravan_site')
+  LEFT JOIN camp_sites ON
+    ST_Covers(camp_sites.poly, pitch.linestring)
 WHERE
   pitch.tags != ''::hstore AND
   pitch.tags ?| ARRAY['tourism', 'camp_site'] AND
   (pitch.tags->'tourism' = 'camp_pitch' OR pitch.tags->'camp_site' IN ('camp_pitch', 'pitch')) AND
-  site.id IS NULL
+  camp_sites IS NULL
 """
 
 sql11 = """
@@ -47,25 +71,48 @@ SELECT
   ST_AsText(pitch.geom)
 FROM
   nodes AS pitch
-  LEFT JOIN ways AS site ON
-    site.linestring && pitch.geom AND
-    site.tags != ''::hstore AND
-    site.tags?'tourism' AND
-    site.tags->'tourism' IN ('camp_site', 'caravan_site')
+  LEFT JOIN camp_sites ON
+    ST_Covers(camp_sites.poly, pitch.geom)
 WHERE
   pitch.tags != ''::hstore AND
   pitch.tags ?| ARRAY['tourism', 'camp_site'] AND
   (pitch.tags->'tourism' = 'camp_pitch' OR pitch.tags->'camp_site' IN ('camp_pitch', 'pitch')) AND
-  site.id IS NULL
+  camp_sites IS NULL
 """
 
 class Analyser_Osmosis_Camp_Pitch_Out_Of_Camp_Site(Analyser_Osmosis):
 
+    requires_tables_common = ['multipolygons']
+
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
+        if not "proj" in self.config.options:
+            return
         self.classs[1] = self.def_class(item = 1290, level = 2, tags = ['geom', 'fix:chair'],
           title = T_('Camp pitches outside a camp site'))
 
     def analyser_osmosis_common(self):
+        self.run(sql01)
+        self.run(sql02)
         self.run(sql10, lambda res: {"class":1, "subclass":1, "data":[self.way_full, self.positionAsText]})
         self.run(sql11, lambda res: {"class":1, "subclass":2, "data":[self.node_full, self.positionAsText]})
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_camp_pitch_outside_site.osm",
+                                         config.dir_tmp + "/tests/osmosis_camp_pitch_outside_site.test.xml",
+                                         {"proj": 23032})
+
+    def test(self):
+        with Analyser_Osmosis_Camp_Pitch_Out_Of_Camp_Site(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="1", elems=[("way", "105")])
+        self.check_err(cl="1", elems=[("node", "8")])
+        self.check_num_err(2)

--- a/tests/osmosis_camp_pitch_outside_site.osm
+++ b/tests/osmosis_camp_pitch_outside_site.osm
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8879550452' lon='5.50219983257' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88479461836' lon='5.49959471824' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88501640995' lon='5.50534393606' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88789960103' lon='5.51360843668' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88407378814' lon='5.51405759432' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88401833918' lon='5.52034580131' />
+  <node id='7' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8881768212' lon='5.51863900227' />
+  <node id='8' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88174995384' lon='5.51046802881'>
+    <tag k='tourism' v='camp_pitch' />
+  </node>
+  <node id='9' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88567299679' lon='5.50254039643'>
+    <tag k='tourism' v='camp_pitch' />
+  </node>
+  <node id='10' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88459176824' lon='5.51493714735'>
+    <tag k='tourism' v='camp_pitch' />
+  </node>
+  <node id='11' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88696210604' lon='5.51641939003' />
+  <node id='12' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88672646264' lon='5.51617235332' />
+  <node id='13' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88667101696' lon='5.51718295802' />
+  <node id='14' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88648390112' lon='5.50232704655' />
+  <node id='15' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88624825522' lon='5.50208000985' />
+  <node id='16' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88619280894' lon='5.50309061454' />
+  <node id='17' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88179847413' lon='5.51148986245' />
+  <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88156280366' lon='5.51124282574' />
+  <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.88150735161' lon='5.51225343044' />
+  <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='1' />
+    <tag k='tourism' v='camp_site' />
+  </way>
+  <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+  </way>
+  <way id='102' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='6' />
+    <nd ref='7' />
+    <nd ref='4' />
+  </way>
+  <way id='103' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='11' />
+    <nd ref='12' />
+    <nd ref='13' />
+    <nd ref='11' />
+    <tag k='tourism' v='camp_pitch' />
+  </way>
+  <way id='104' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='14' />
+    <nd ref='15' />
+    <nd ref='16' />
+    <nd ref='14' />
+    <tag k='tourism' v='camp_pitch' />
+  </way>
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='17' />
+    <nd ref='18' />
+    <nd ref='19' />
+    <nd ref='17' />
+    <tag k='tourism' v='camp_pitch' />
+  </way>
+  <relation id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='101' role='outer' />
+    <member type='way' ref='102' role='outer' />
+    <tag k='tourism' v='camp_site' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+</osm>


### PR DESCRIPTION
See #1898

Camp pitches should be in an area, which can be either a closed way or a multipolygon. The latter wasn't supported yet.
This PR also adds tests.

Note that the original issue has been marked as [false positive](https://osmose.openstreetmap.fr/nl/issues/false-positive?source=416810&item=1290&class=1)