### PR TITLE
Remove 'name' tag from TagFix_MultipleValue.py

### DIFF
--- a/plugins/TagFix_MultipleValue.py
+++ b/plugins/TagFix_MultipleValue.py
@@ -47,7 +47,7 @@ WHERE
     -- Accept multiple values
     'opening_hours', 'description', 'bus_routes', 'phone', 'created_by', 'comment', 'day_off', 'day_on', 'destination', 'fixme', 'FIXME', 'access', 'is_in', 'alt_name', 'boundary', 'fee', 'id', 'marked_trail', 'sport', 'shop', 'school:FR', 'hour_off', 'hour_on', 'old_name', 'operator', 'park_ride', 'antenna', 'brewery', 'collection_times', 'cuisine', 'exit_to', 'towards', 'traffic_sign', 'url', 'brand', 'service', 'material',
     -- No multiple value
-    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name', 'maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
+    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name','maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
     value LIKE '%;%'
 ;
 """

--- a/plugins/TagFix_MultipleValue.py
+++ b/plugins/TagFix_MultipleValue.py
@@ -47,7 +47,7 @@ WHERE
     -- Accept multiple values
     'opening_hours', 'description', 'bus_routes', 'phone', 'created_by', 'comment', 'day_off', 'day_on', 'destination', 'fixme', 'FIXME', 'access', 'is_in', 'alt_name', 'boundary', 'fee', 'id', 'marked_trail', 'sport', 'shop', 'school:FR', 'hour_off', 'hour_on', 'old_name', 'operator', 'park_ride', 'antenna', 'brewery', 'collection_times', 'cuisine', 'exit_to', 'towards', 'traffic_sign', 'url', 'brand', 'service', 'material',
     -- No multiple value
-    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name','maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
+    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
     value LIKE '%;%'
 ;
 """
@@ -79,7 +79,7 @@ values.'''))
             'left:city', 'left:country', 'left:departement', 'left:village',
             'leisure',
             'maxspeed', 'motorcar', 'mtb:scale',
-            'name', 'natural',
+            'natural',
             'oneway',
             'power',
             'railway',

--- a/plugins/TagFix_MultipleValue.py
+++ b/plugins/TagFix_MultipleValue.py
@@ -47,7 +47,7 @@ WHERE
     -- Accept multiple values
     'opening_hours', 'description', 'bus_routes', 'phone', 'created_by', 'comment', 'day_off', 'day_on', 'destination', 'fixme', 'FIXME', 'access', 'is_in', 'alt_name', 'boundary', 'fee', 'id', 'marked_trail', 'sport', 'shop', 'school:FR', 'hour_off', 'hour_on', 'old_name', 'operator', 'park_ride', 'antenna', 'brewery', 'collection_times', 'cuisine', 'exit_to', 'towards', 'traffic_sign', 'url', 'brand', 'service', 'material',
     -- No multiple value
-    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
+    'cycleway', 'highway', 'foot', 'layer', 'landuse', 'foot', 'building', 'left:city', 'left:country', 'left:departement', 'left:village', 'right:city', 'right:country', 'right:departement', 'right:village', 'name', 'maxspeed', 'lanes', 'oneway', 'admin_level', 'natural', 'smoothness', 'surface', 'tracktype', 'type', 'voltage', 'waterway', 'width', 'wikipedia', 'wires', 'wood', 'trail_visibility', 'bicycle', 'est_width', 'motorcar' 'mtb:scale', 'ele', 'power', 'railway', 'addr:housenumber', 'addr:street', 'attraction', 'amenity', 'leisure' ) AND
     value LIKE '%;%'
 ;
 """


### PR DESCRIPTION
Remove 'name' from the tags to check in TagFix_MultipleValue.py, because it's already checked more robustly in Name_Multiple