### PR TITLE
Add exception from NSI to TagRemove_Incompatibles.py

### DIFF
--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -93,6 +93,7 @@ class TagRemove_Incompatibles(Plugin):
                 ['shelter', 'highway', 'bus_stop'],
                 ['event_venue', 'leisure', 'garden'],
                 ['gambling', 'leisure', 'adult_gaming_centre'],
+                ['restaurant', 'leisure', 'amusement_arcade'],
             ],
         }.items()
 


### PR DESCRIPTION
Whitelist `amenity=restaurant`+`leisure=amusement_arcade`. The NSI adds both of these tags to places like [Chuck E Cheese](https://github.com/osmlab/name-suggestion-index/blob/a48635629cf96c11d25f38c41440b9f668bed7db/data/brands/amenity/restaurant.json#L1123) and [Dave and Buster's](https://github.com/osmlab/name-suggestion-index/blob/a48635629cf96c11d25f38c41440b9f668bed7db/data/brands/amenity/restaurant.json#L1506), so it is correct usage.