### PR TITLE
Fix missing space

### DIFF
--- a/analysers/analyser_osmosis_highway_vs_building.py
+++ b/analysers/analyser_osmosis_highway_vs_building.py
@@ -457,7 +457,7 @@ class Analyser_Osmosis_Highway_VS_Building(Analyser_Osmosis):
 '''Move a feature if it's in the wrong place. Connect the features if appropriate or update the tags if not.'''),
             trap = T_(
 '''A feature may be missing a tag, such as `tunnel=*`, `bridge=*`, `covered=*` or `ford=*`.
-If a road or railway intersects a building, consider adding the`layer=*` tag to it.
+If a road or railway intersects a building, consider adding the `layer=*` tag to it.
 Warning: information sources can be contradictory in time or with spatial offset.'''),
             example = T_(
 '''![](https://wiki.openstreetmap.org/w/images/d/dc/Osmose-eg-error-1070.png)


### PR DESCRIPTION
Add a missing space. (My bad, introduced in https://github.com/osm-fr/osmose-backend/commit/0a51489621af1433162522d5b91fe9ddbbfe20b2 )

This string was not translated in any language yet (with the translations in the `dev` branch). Hence, I guess we can just simply replace it by one with a space.

@jocelynj Since there's a lot of translation activity in the HU strings: could you please double-check that it's not recently translated, when you're synchronizing the translations with Transifex?