### PR TITLE
Add multipolygon support to building_in_polygon

### DIFF
--- a/tests/osmosis_building_in_polygon.osm
+++ b/tests/osmosis_building_in_polygon.osm
@@ -20,6 +20,15 @@
   <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227362937' lon='5.83801632619' />
   <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227335578' lon='5.83808054832' />
   <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8523279728' lon='5.83808115812' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85281310453' lon='5.83892828569' />
+  <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85242601411' lon='5.83838813655' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85240171962' lon='5.83938452817' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85251671342' lon='5.8390200586' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8524405908' lon='5.8390987211' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8524405908' lon='5.83896237277' />
+  <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85263251673' lon='5.83880766986' />
+  <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85250537602' lon='5.83868180987' />
+  <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85260093404' lon='5.83903054694' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -62,4 +71,30 @@
     <nd ref='17' />
     <tag k='building' v='stable' />
   </way>
+  <way id='105' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='21' />
+    <nd ref='22' />
+    <nd ref='23' />
+    <nd ref='21' />
+  </way>
+  <way id='106' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='24' />
+    <nd ref='25' />
+    <nd ref='26' />
+    <nd ref='24' />
+    <tag k='natural' v='water' />
+  </way>
+  <way id='107' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='27' />
+    <nd ref='28' />
+    <nd ref='29' />
+    <nd ref='27' />
+    <tag k='building' v='yes' />
+  </way>
+  <relation id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='106' role='inner' />
+    <member type='way' ref='105' role='outer' />
+    <tag k='landuse' v='vineyard' />
+    <tag k='type' v='multipolygon' />
+  </relation>
 </osm>


### PR DESCRIPTION
This PR adds multipolygon support to analyser osmosis_building_in_polygon. Also adds a test case for a multipolygon.

No need to create an index: it uses the index on buildings.polygon_proj.
Surprisingly the new implementation is actually faster, despite including the multipolygons: 
- from 9 seconds on netherlands_gelderland to 6
- from 111 seconds on japan_chubu to 84 
(Exact numbers vary from run to run, but usually the trend is like that)


<details>

On extract japan_chubu:
*sql10:*
```
['Result  (cost=6201.28..398482.13 rows=5256 width=126) (actual time=59.451..2312.283 rows=310719 loops=1)']
['  ->  Append  (cost=6201.28..398416.43 rows=5256 width=154) (actual time=59.445..2220.063 rows=310719 loops=1)']
['        ->  Subquery Scan on "*SELECT* 1"  (cost=6201.28..397227.48 rows=5230 width=125) (actual time=59.445..2176.953 rows=310287 loops=1)']
['              ->  Bitmap Heap Scan on ways  (cost=6201.28..397175.18 rows=5230 width=125) (actual time=59.442..2127.636 rows=310287 loops=1)']
["                    Recheck Cond: ((tags <> ''::hstore) AND (tags ? 'landuse'::text))"]
["                    Filter: (is_polygon AND ((tags -> 'landuse'::text) = ANY ('{farmland,vineyard,orchard,plant_nursery}'::text[])))"]
['                    Rows Removed by Filter: 83351']
['                    Heap Blocks: exact=60593']
['                    ->  Bitmap Index Scan on idx_ways_landuse  (cost=0.00..6199.97 rows=396109 width=0) (actual time=37.232..37.233 rows=393638 loops=1)']
['        ->  Subquery Scan on "*SELECT* 2"  (cost=23.50..1162.67 rows=26 width=6083) (actual time=1.039..9.615 rows=432 loops=1)']
['              ->  Bitmap Heap Scan on multipolygons  (cost=23.50..1162.41 rows=26 width=6083) (actual time=1.038..9.540 rows=432 loops=1)']
["                    Recheck Cond: (tags ? 'landuse'::text)"]
['                    Rows Removed by Index Recheck: 49']
["                    Filter: (is_valid AND ((tags -> 'landuse'::text) = ANY ('{farmland,vineyard,orchard,plant_nursery}'::text[])))"]
['                    Rows Removed by Filter: 905']
['                    Heap Blocks: exact=835']
['                    ->  Bitmap Index Scan on idx_multipolygons_tags  (cost=0.00..23.50 rows=1313 width=0) (actual time=0.650..0.650 rows=1386 loops=1)']
["                          Index Cond: (tags ? 'landuse'::text)"]
['Planning Time: 2.133 ms']
['Execution Time: 2349.115 ms']
```

*sql11:*
```
['Unique  (cost=60956370724.44..60965700446.06 rows=200 width=136) (actual time=76317.408..76322.937 rows=6642 loops=1)']
['  ->  Sort  (cost=60956370724.44..60961035585.25 rows=1865944324 width=136) (actual time=76317.406..76319.077 rows=32342 loops=1)']
['        Sort Key: poly_landuse.type_id']
['        Sort Method: quicksort  Memory: 5317kB']
['        ->  Nested Loop  (cost=0.41..60505041856.24 rows=1865944324 width=136) (actual time=2.659..76266.583 rows=32342 loops=1)']
['              ->  Seq Scan on poly_landuse  (cost=0.00..15564.45 rows=613145 width=96) (actual time=0.033..346.386 rows=310719 loops=1)']
['              ->  Index Scan using idx_buildings_polygon_proj on buildings  (cost=0.41..94104.30 rows=304 width=325) (actual time=0.239..0.243 rows=0 loops=310719)']
['                    Index Cond: (polygon_proj @ poly_landuse.poly_proj)']
["                    Filter: ((area > '36'::double precision) AND ((NOT (tags ? 'location'::text)) OR ((tags -> 'location'::text) <> 'underground'::text)) AND st_contains(poly_landuse.poly_proj, polygon_proj))"]
['                    Rows Removed by Filter: 1']
['Planning Time: 0.588 ms']
['Execution Time: 76324.978 ms']
```
</details>