### PR TITLE
Support `waterway=stream_end`

### DIFF
--- a/analysers/analyser_osmosis_waterway.py
+++ b/analysers/analyser_osmosis_waterway.py
@@ -115,8 +115,10 @@ FROM
     JOIN nodes ON
         nodes.id = ww.end AND
         nodes.tags != ''::hstore AND
-        nodes.tags?'natural' AND
-        nodes.tags->'natural' IN ('sinkhole')
+        (
+            (nodes.tags?'natural' AND nodes.tags->'natural' IN ('sinkhole')) OR
+            (nodes.tags?'waterway' AND nodes.tags->'waterway' IN ('stream_end'))
+        )
 """
 
 sql24 = """


### PR DESCRIPTION
Issue #2032

Note: I don't know why the previous entry was listed as `IN ('sinkhole')` instead of `= 'sinkhole'` (probably just for ease of adding items later), but for consistency I added this one the same way.

Confirmed with osm110 that the stream_end results are gone now ([results](https://github.com/osm-fr/osmose-backend/files/12719958/waterway.zip) for italy_abruzzo)

p.s. maybe we should also add [`waterway=soakhole`](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dsoakhole) at some point, but the wiki of that tag suggests its poor quality import (and taginfo doesn't show any notable increase in usage)