### PR TITLE
Add incompatibles as mapcss rules

### DIFF
--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -179,6 +179,17 @@ node[highway=crossing][crossing][crossing=~/^(no|informal)$/] {
 }
 
 
+node[leisure=picnic_table][tourism=picnic_site],
+area[leisure=picnic_table][tourism=picnic_site] {
+  throwWarning: tr("{0} together with {1}. A picnic site rarely consists of only one single picnic table", "{0.tag}", "{1.tag}");
+  group: tr("Tag conflict");
+  -osmoseItemClassLevel: "4030/40303:2/1";
+  -osmoseTags: list("tag", "fix:chair");
+  -osmoseDetail: tr("The object contains two incompatible tags.");
+  -osmoseTrap: tr("Sometimes the object needs both tags.");
+}
+
+
 /* Workaround for issue #1766 */
 node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable] {
     throwWarning: tr("{0} on suspicious object", "{0.key}");

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -190,6 +190,16 @@ area[leisure=picnic_table][tourism=picnic_site] {
 }
 
 
+way[attraction=roller_coaster][roller_coaster=track] {
+  throwWarning: tr("{0} together with {1}. {0} should be used for the area containing the attraction, {1} for the actual tracks", "{0.tag}", "{1.tag}");
+  group: tr("Tag conflict");
+  -osmoseItemClassLevel: "4030/40303:3/1";
+  -osmoseTags: list("tag", "fix:chair");
+  -osmoseDetail: tr("The object contains two incompatible tags.");
+  -osmoseTrap: tr("Sometimes the object needs both tags.");
+}
+
+
 /* Workaround for issue #1766 */
 node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable] {
     throwWarning: tr("{0} on suspicious object", "{0.key}");

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -166,6 +166,19 @@ node[natural=tree][type][type!=palm] {
 }
 
 
+node[highway=crossing][crossing][crossing=~/^(no|informal)$/] {
+  throwWarning: tr("Conflict between tags: `{1}` must be used without `{0}`", "{0.tag}", "{1.tag}");
+  group: tr("Tag conflict");
+  -osmoseItemClassLevel: "4030/40303:1/1";
+  -osmoseTags: list("tag", "fix:chair");
+  -osmoseDetail: tr("The object contains two incompatible tags.");
+  -osmoseTrap: tr("Sometimes the object needs both tags.");
+  assertMatch: "node crossing=no highway=crossing";
+  assertNoMatch: "node crossing=uncontrolled highway=crossing";
+  fixRemove: "{0.key}";
+}
+
+
 /* Workaround for issue #1766 */
 node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable] {
     throwWarning: tr("{0} on suspicious object", "{0.key}");

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -154,6 +154,18 @@ node[natural=tree][type][type!=palm] {
 }
 
 
+*[bridge=yes][tunnel=yes] {
+  throwWarning: tr("Conflict between tags: `{0}` and `{1}`", "{0.tag}", "{1.tag}");
+  group: tr("Tag conflict");
+  -osmoseItemClassLevel: "4030/40303:0/1";
+  -osmoseTags: list("tag", "fix:chair");
+  -osmoseDetail: tr("The object contains two incompatible tags.");
+  -osmoseTrap: tr("Sometimes the object needs both tags.");
+  assertMatch: "way bridge=yes tunnel=yes";
+  assertNoMatch: "way bridge=yes tunnel=no";
+}
+
+
 /* Workaround for issue #1766 */
 node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable] {
     throwWarning: tr("{0} on suspicious object", "{0.key}");

--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -121,9 +121,6 @@ class TagRemove_Incompatibles(Plugin):
                 if len(conflict) > 1:
                     return {"class": 900, "subclass": 1, "text": T_("Conflict between tags: {0}", (", ".join(sorted(conflict))))}
 
-        if tags.get('highway') == 'crossing' and tags.get('crossing') == 'no':
-            return {"class": 900, "subclass": 3, "text": T_("Conflict between tags: crossing=no must be used without a highway=crossing")}
-
     def way(self, data, tags, nds):
         return self.node(data, tags)
 
@@ -139,7 +136,6 @@ class Test(TestPluginCommon):
         a.init(None)
         for t in [{"aerialway": "yes", "aeroway": "yes"},
                   {"highway": "trunk", "railway": "rail"},
-                  {"crossing": "no", "highway": "crossing"},
                   {"amenity": "fountain", "leisure": "swimming_pool", "natural": "water"},
                  ]:
             self.check_err(a.node(None, t), t)

--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -121,9 +121,6 @@ class TagRemove_Incompatibles(Plugin):
                 if len(conflict) > 1:
                     return {"class": 900, "subclass": 1, "text": T_("Conflict between tags: {0}", (", ".join(sorted(conflict))))}
 
-        if tags.get('bridge') == 'yes' and tags.get('tunnel') == 'yes':
-            return {"class": 900, "subclass": 2, "text": T_("Conflict between tags: 'bridge' and 'tunnel'")}
-
         if tags.get('highway') == 'crossing' and tags.get('crossing') == 'no':
             return {"class": 900, "subclass": 3, "text": T_("Conflict between tags: crossing=no must be used without a highway=crossing")}
 
@@ -142,7 +139,6 @@ class Test(TestPluginCommon):
         a.init(None)
         for t in [{"aerialway": "yes", "aeroway": "yes"},
                   {"highway": "trunk", "railway": "rail"},
-                  {"bridge": "yes", "tunnel": "yes"},
                   {"crossing": "no", "highway": "crossing"},
                   {"amenity": "fountain", "leisure": "swimming_pool", "natural": "water"},
                  ]:
@@ -153,7 +149,6 @@ class Test(TestPluginCommon):
         for t in [{"aerialway": "yes"},
                   {"highway": "residential", "railway": "tram"},
                   {"highway": "bus_stop", "railway": "tram_stop"},
-                  {"bridge": "yes", "tunnel": "no"},
                   {"waterway": "dam", "highway": "road"},
                   {"landuse": "school", "amenity": "school"},
                   {"place": "square", "highway": "pedestrian"},


### PR DESCRIPTION
See #1985

1. Convert existing hardcoded rules in TagRemove_Incompatibles.py to mapcss (allows loading it also in i.e. JOSM)
  a. For `crossing=no`: also add support for `crossing=informal`; only check it for nodes; add fix suggestion
2. Adds a warning for `leisure=picnic_table + tourism=picnic_site` (#1985)
3. Adds a warning for `roller_coaster=track + attraction=roller_coaster` (spin-off from #1960)

Since the 4 rules would conflict with each other if I did them as separate PRs, I did it in one PR, but every commit (except the python file regeneration) can be considered a separate PR.