### PR TITLE
Fix marine sanitary dump stations

### DIFF
--- a/plugins/TagRemove_Incompatibles.py
+++ b/plugins/TagRemove_Incompatibles.py
@@ -94,6 +94,7 @@ class TagRemove_Incompatibles(Plugin):
                 ['event_venue', 'leisure', 'garden'],
                 ['gambling', 'leisure', 'adult_gaming_centre'],
                 ['restaurant', 'leisure', 'amusement_arcade'],
+                ['sanitary_dump_station', 'waterway', 'sanitary_dump_station'],
             ],
         }.items()
 


### PR DESCRIPTION
The wiki dictates this way of double-tagging marine and 'land-based' sanitary dump stations since 2015: https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dsanitary_dump_station.

Spotted it while going through the user list in # 2044, for example: https://www.openstreetmap.org/node/826260065