### PR TITLE
Fixed Improper Method Call: Replaced `NotImplementedError`

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -59,7 +59,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(o - self.to_n())
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __sub__(self, o):
         if self.none:
@@ -67,7 +67,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(self.to_n() - o)
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __rmul__(self, o):
         if self.none:
@@ -75,7 +75,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(o * self.to_n())
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __mul__(self, o):
         if self.none:
@@ -83,7 +83,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(self.to_n() * o)
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __rdiv__(self, o):
         if self.none:
@@ -91,7 +91,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(float(o) / self.to_n())
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __truediv__(self, o):
         if self.none:
@@ -99,7 +99,7 @@ class str_value_(str):
         elif o.__class__ == int:
             return str_value(float(self.to_n()) / o)
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __lt__(self, o):
         if self.none:

--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -85,7 +85,7 @@ class str_value_(str):
         else:
             return NotImplemented
 
-    def __rdiv__(self, o):
+    def __rtruediv__(self, o):
         if self.none:
             return None_value
         elif o.__class__ == int:


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [mapcss_lib.py](https://github.com/osm-fr/osmose-backend/blob/dev/mapcss/mapcss_lib.py#L72), class: str_value_, there is a special method `__rmul__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__rmul__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is here.

### Related Documentation
- [docs.python.org - NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented)
- [docs.python.org - NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError)
- [docs.python.org - Implementing Arithmetic Operators](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations)

Moreover, we noticed that a method called `__rdiv__` was defined in the same file. It is to be noted that this method belongs to Python 2.0 according to the [documentation](https://docs.python.org/2/reference/datamodel.html#object.__rdiv__). The Python 3 equivalent of that method is [`__rtruediv__`](https://docs.python.org/3/reference/datamodel.html#object.__rtruediv__). In that's the case and you're willing, I can rename the `__rdiv__` method to `__rtruediv__`.


## Changes
- Replaced `NotImplementedError` with `NotImplemented`


## Previously Found & Fixed
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/ethereum/web3.py/pull/3080


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
