### PR TITLE
Warn about invalid months/days

### DIFF
--- a/plugins/Date.py
+++ b/plugins/Date.py
@@ -41,9 +41,6 @@ class Date(Plugin):
             "mhs:inscription_date", # Heritage
         ]
         self.default_date = datetime.datetime(9999, 12, 1)
-        self.Year = re.compile(u"^[12][0-9][0-9][0-9]$")
-        self.Day1 = re.compile(u"^[12][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$")
-        self.Day2 = re.compile(u"^[0-9][0-9]/[0-9][0-9]/[12][0-9][0-9][0-9]$")
         self.Aprox = re.compile(u"^(?:early|mid|late|before|after|spring|summer|autumn|winter) [^ ]+")
 
     def convert2date(self, string):
@@ -64,10 +61,6 @@ class Date(Plugin):
             return len(string) > 1 and self.check(string[:-1])
         if string[-3:] == ' BC' or string[-3:] == ' AD':
             return len(string) > 3 and self.check(string[:-3])
-        if len(string) == 4 and self.Year.match(string):
-            return True
-        if len(string) == 10 and (self.Day1.match(string) or self.Day2.match(string)):
-            return True
         if string[0] == 'C':
             try:
                 int(string[1:])
@@ -106,12 +99,12 @@ class Test(TestPluginCommon):
     def test(self):
         a = Date(None)
         a.init(None)
-        for d in ["~1855", "~1940s", "~C13", "C18", "1970s", "1914", "1914..1918", "2008-08-08..2008-08-24", "late 1920s", "after 1500", "summer 1998", "480 BC", "2012-10", "2002-11", "2014", "2010.."]:
+        for d in ["~1855", "~1940s", "~C13", "C18", "1970s", "1914", "1914..1918", "2008-08-08..2008-08-24", "late 1920s", "after 1500", "summer 1998", "480 BC", "2012-10", "2002-11", "2014", "2010..", "2022-04-08"]:
             assert not a.node(None, {"date":d}), ("date={0}".format(d))
 
         assert not a.node(None, {"date":"yes", "amenity":"clock"}), ("date=yes")
 
-        for d in ["yes", "XVI", "p", "0000", "9999", "Ca9", "1914..9999", "2014..Ca09", "7000", "~"]:
+        for d in ["yes", "XVI", "p", "0000", "9999", "Ca9", "1914..9999", "2014..Ca09", "7000", "~", "2022-88", "2022-12-99", "2022-99-12"]:
             self.check_err(a.node(None, {"date":d}), ("date={0}".format(d)))
             self.check_err(a.way(None, {"date":d}, None), ("date={0}".format(d)))
             self.check_err(a.relation(None, {"date":d}, None), ("date={0}".format(d)))


### PR DESCRIPTION
Follow-up of #2070
Instead of fixing the regexes, just let `dateutil` take care of it. `dateutil` already took care of the `yyyy-mm` scenario.

See https://github.com/osm-fr/osmose-backend/pull/2070#issuecomment-1811439988

Some examples of newly detected items:
`2017-12-00`	(should be: `2017-12`)
`2023-09-31`	(september has only 30 days)
`2021-22-05`	(there is no 22th month, probably `2021-05-22` is meant)
`1999-00-00`	(should be `1999`)