### PR TITLE
Add `tidal_channel` as a valid waterway where streams can end

### DIFF
--- a/analysers/analyser_osmosis_waterway.py
+++ b/analysers/analyser_osmosis_waterway.py
@@ -55,7 +55,6 @@ sql20 = """
 CREATE TEMP TABLE water_ends AS
 SELECT
     id,
-    nodes[array_length(nodes,1)] AS start,
     nodes[array_length(nodes,1)] AS end,
     tags->'waterway' AS waterway,
     linestring
@@ -86,7 +85,7 @@ FROM
         ways.id = way_nodes.way_id AND
         ways.tags != ''::hstore AND
         ways.tags?'waterway' AND
-        ways.tags->'waterway' IN ('stream', 'river', 'canal', 'drain', 'ditch')
+        ways.tags->'waterway' IN ('stream', 'river', 'canal', 'drain', 'ditch', 'tidal_channel')
 """
 
 sql23 = """


### PR DESCRIPTION
Per the wiki, the `tidal_channel` exists outside of the coastline. Hence, table `coastline_sinkhole` will not contain the end point of a stream connected to such a channel.

Fixing it this way looked easier than adding it to `coastline_sinkhole`.

Also removes an unused (and probably wrongly defined) column.

See #2086