### PR TITLE
New analyser to detect duplicate relation members

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -622,6 +622,10 @@ WHERE
         for type, id in map(lambda r: (r[0], r[1:]), res):
             self.typeMapping[type](int(id))
 
+    def array_id(self, res):
+        for type, id in map(lambda r: (r[0], r[1:]), res):
+            self.typeMapping_id_only[type](int(id))
+
     re_points = re.compile(r"[\(,][^\(,\)]*[\),]")
 
     def get_points(self, text):

--- a/analysers/analyser_osmosis_relation_duplicate_member.py
+++ b/analysers/analyser_osmosis_relation_duplicate_member.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose Project 2023                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Osmosis import Analyser_Osmosis
+
+sql10 = """
+SELECT
+  id,
+  ST_AsText(relation_locate(id)),
+  array_agg(duplicate)
+FROM (
+  SELECT
+    id,
+    member_type || member_id || ' (' || COUNT(*) || ')' AS duplicate
+  FROM
+    {0}relations AS relations
+    JOIN relation_members ON
+        relations.id = relation_id
+  WHERE
+    relations.tags != ''::hstore AND
+    relations.tags?'type' AND
+    relations.tags->'type' IN ('multipolygon', 'site', 'waterway', 'enforcement', 'public_transport', 'building')
+  GROUP BY
+    id,
+    member_id,
+    member_type,
+    member_role
+  HAVING
+    COUNT(*) > 1
+) AS t
+GROUP BY
+  id
+"""
+
+class Analyser_Osmosis_Relation_Duplicate_Member(Analyser_Osmosis):
+
+    def __init__(self, config, logger = None):
+        Analyser_Osmosis.__init__(self, config, logger)
+        self.classs_change[3] = self.def_class(item = 1040, level = 1, tags = ['relation', 'fix:chair', 'geom'],
+            title = T_('Duplicate relation member'),
+            detail = T_(
+'''The relation contains the same member (with the same role) more than once. This is not expected for this type of relations.'''),
+            fix = T_(
+'''Remove the duplicate members until only unique members remain.'''))
+
+        self.callback10 = lambda res: {"class": 3, "data": [self.relation, self.positionAsText], "text": {"en": ', '.join(res[2]).lower()}}
+
+    def analyser_osmosis_full(self):
+        self.run(sql10.format(""), self.callback10)
+
+    def analyser_osmosis_diff(self):
+        self.run(sql10.format("touched_"), self.callback10)
+
+
+
+###########################################################################
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_relation_duplicate_member.osm",
+                                         config.dir_tmp + "/tests/osmosis_relation_duplicate_member.test.xml", {})
+
+    def test_classes(self):
+        with Analyser_Osmosis_Relation_Duplicate_Member(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="3", elems=[("relation", "10001")])
+        self.check_num_err(1)

--- a/doc/3-SQL-basics.md
+++ b/doc/3-SQL-basics.md
@@ -114,6 +114,7 @@ The available value for the `data`, mapping OSM object id are:
 
 From array of (type: N/W/R, ids):
 * `array_full`
+* `array_id`
 
 Without the `_full` suffix, only the id is kept in the Osmose issue, not the tags and other attributes.
 

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -197,6 +197,7 @@ class default_simple(template_config):
         self.analyser["osmosis_polygon_intersects"] = "xxx"
         self.analyser["osmosis_way_angle"] = "xxx"
         self.analyser["osmosis_highway_long_crossing"] = "xxx"
+        self.analyser["osmosis_relation_duplicate_member"] = "xxx"
 
 class default_country_simple(default_simple):
     def __init__(self, part, country, polygon_id=None, analyser_options=None,

--- a/tests/osmosis_relation_duplicate_member.osm
+++ b/tests/osmosis_relation_duplicate_member.osm
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84904121444' lon='5.84167543397' />
+  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84565606741' lon='5.84194492855' />
+  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84571156367' lon='5.84446021135' />
+  <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84589995006' lon='5.84699939213' />
+  <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84592769805' lon='5.85045790597' />
+  <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84914634897' lon='5.84870619117' />
+  <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='1' />
+  </way>
+  <way id='1' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='4' />
+  </way>
+  <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1000' role='outer' />
+    <member type='way' ref='1' role='outer' />
+    <tag k='building' v='yes' />
+    <tag k='name' v='Proper relation' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='10001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1' role='outer' />
+    <member type='way' ref='1000' role='outer' />
+    <member type='way' ref='1' role='outer' />
+    <tag k='building' v='yes' />
+    <tag k='name' v='Duplicate member' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='10002' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='1' role='outer' />
+    <member type='node' ref='1' role='outer' />
+    <tag k='building' v='yes' />
+    <tag k='name' v='Same id, different object' />
+    <tag k='type' v='site' />
+  </relation>
+</osm>


### PR DESCRIPTION
This adds an analyser to detect duplicate relation members, such as in relation 9104912 (see issue 2090).

Not sure if it's the best choice for the item number