### PR TITLE
Tolerate empty role in table multipolygons

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -135,7 +135,7 @@ BEGIN
             JOIN relation_members ON
                 relation_members.relation_id = relations.id AND
                 relation_members.member_type = 'W' AND
-                relation_members.member_role IN ('outer', 'inner')
+                relation_members.member_role IN ('outer', 'inner', '')
             LEFT JOIN ways ON
                 ways.id = relation_members.member_id
         WHERE


### PR DESCRIPTION
Prevent building invalid, partial or incorrect MP in case the outer way has no role (even though this is deprecated, there's still [17035 such ways](https://taginfo.openstreetmap.org/relations/multipolygon#roles) in MP relations worldwide)

Previously such ways were ignored while building table multipolygons (and except for filtering for `inner` and `outer`, the roles are not actively used while constructing table multipolygons, so this could generate strange constructions)