### PR TITLE
Limit sql20 to multipolygons and avoid duplicates

### DIFF
--- a/analysers/analyser_osmosis_relation_multipolygon.py
+++ b/analysers/analyser_osmosis_relation_multipolygon.py
@@ -68,7 +68,7 @@ WHERE
 """
 
 sql20 = """
-SELECT
+SELECT DISTINCT
     relations.id,
     ways.id,
     ST_AsText(way_locate(ways.linestring)),
@@ -94,25 +94,27 @@ WHERE
     relations.tags->'type' = 'multipolygon' AND
     ways.tags != ''::hstore AND
     (
-        relations.tags?'landuse' AND
-        ways.tags?'landuse' AND
-        ways.tags->'landuse' != (relations.tags->'landuse')
-    ) OR (
-        relations.tags?'natural' AND
-        relations.tags->'natural' IN ('bay', 'beach', 'fell', 'grassland', 'glacier', 'heath', 'mud', 'sand', 'scree', 'scrub', 'sinkhole', 'water', 'wetland', 'wood') AND
-        ways.tags?'natural' AND
-        ways.tags->'natural' IN ('bay', 'beach', 'fell', 'grassland', 'glacier', 'heath', 'mud', 'sand', 'scree', 'scrub', 'sinkhole', 'water', 'wetland', 'wood') AND
-        ways.tags->'natural' != (relations.tags->'natural')
-    ) OR (
-        relations.tags?'waterway' AND
-        relations.tags->'waterway' IN ('boatyard', 'dock', 'riverbank') AND
-        ways.tags?'waterway' AND
-        ways.tags->'waterway' IN ('boatyard', 'dock', 'riverbank') AND
-        ways.tags->'waterway' != (relations.tags->'waterway')
-    ) OR (
-        relations.tags?'building' AND
-        ways.tags?'building' AND
-        ways.tags->'building' != (relations.tags->'building')
+        (
+            relations.tags?'landuse' AND
+            ways.tags?'landuse' AND
+            ways.tags->'landuse' != (relations.tags->'landuse')
+        ) OR (
+            relations.tags?'natural' AND
+            relations.tags->'natural' IN ('bay', 'beach', 'fell', 'grassland', 'glacier', 'heath', 'mud', 'sand', 'scree', 'scrub', 'sinkhole', 'water', 'wetland', 'wood') AND
+            ways.tags?'natural' AND
+            ways.tags->'natural' IN ('bay', 'beach', 'fell', 'grassland', 'glacier', 'heath', 'mud', 'sand', 'scree', 'scrub', 'sinkhole', 'water', 'wetland', 'wood') AND
+            ways.tags->'natural' != (relations.tags->'natural')
+        ) OR (
+            relations.tags?'waterway' AND
+            relations.tags->'waterway' IN ('boatyard', 'dock', 'riverbank') AND
+            ways.tags?'waterway' AND
+            ways.tags->'waterway' IN ('boatyard', 'dock', 'riverbank') AND
+            ways.tags->'waterway' != (relations.tags->'waterway')
+        ) OR (
+            relations.tags?'building' AND
+            ways.tags?'building' AND
+            ways.tags->'building' != (relations.tags->'building')
+        )
     )
 """
 


### PR DESCRIPTION
See #2090
1. Only run the sql query on multipolygons, not all relations. (E.g. fix missing `(` and `)` )
2. Do not crash frontend on duplicate relation members

For now it only fixes the current analyser. At a later stage we can see if we can make it more generic, e.g. by warning about all tags on outer ways (except selected tags), provided this doesn't cause too many false positives / isn't too difficult to implement.

I also tried a different implementation using table multipolygons, but then the planner chose a much more costly route:
- table relations: cost = 1448.54
- table multipolygons: cost = 61816.26
(Results for japan_chubu)