### PR TITLE
Add parking as allowed deadend in analyser_osmosis_highway_deadend

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -179,7 +179,7 @@ FROM
 WHERE
   tags != ''::hstore AND
   (
-    (tags?'amenity'  AND tags->'amenity' = 'parking_entrance') OR
+    (tags?'amenity'  AND tags->'amenity' IN ('parking_entrance', 'parking')) OR
     (tags?'entrance' AND tags->'entrance' IN ('garage', 'emergency')) OR
     (tags?'aerialway' AND tags->'aerialway' = 'station')
   )


### PR DESCRIPTION
The issue title is "One way inaccessible or missing parking or parking entrance", but only "parking entrance" was allowed. Just "parking" is missing.