### PR TITLE
Add fix message for route highway mismatch

### DIFF
--- a/analysers/analyser_osmosis_relation_route_access.py
+++ b/analysers/analyser_osmosis_relation_route_access.py
@@ -105,7 +105,12 @@ class Analyser_Osmosis_Relation_Route_Access(Analyser_Osmosis):
         }
         for route_type, access in self.map.items():
             self.classs_change[access['class']] = self.def_class(item = 3240, level = 2, tags = ['relation', 'routing'],
-                title = T_('Way access mismatch relation route={0}', route_type))
+                title = T_('Way access mismatch relation route={0}', route_type),
+                fix = T_('''Check if the route should indeed use this highway.
+If not, move the route so that it follows the designated paths.
+This could require shifting the route to separately drawn parallel highways.
+
+If you are sure that the route should follow this way, consider adding `{0}=yes`.''', access['access_tag']))
 
     def callback10(self, clazz):
         return lambda res: {'class':clazz, 'data':[self.way_full, self.relation_full, self.positionAsText] }


### PR DESCRIPTION
This is related to #2043.
It adds a fix suggestion to the `Way access mismatch relation route=*` errors

The question whether `highway=pedestrian` for bicycles should be exempted (e.g. the actual issue that was reported) isn't resolved yet. See (from that issue)
> we could just exclude pedestrian. Out of the 32 countries listed on that wiki, 12 permit cyclists on highway=pedestrian. (Just like cycleway is excluded for foot relations because it differs so much per country)