### PR TITLE
Add keys that default to `area=yes` or require `area=yes`

### DIFF
--- a/plugins/TagFix_Area.py
+++ b/plugins/TagFix_Area.py
@@ -27,8 +27,8 @@ class TagFix_Area(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
-        self.area_yes_good = set(('aerialway', 'aeroway', 'amenity', 'barrier', 'highway', 'historic', 'leisure', 'man_made', 'military', 'playground', 'power', 'public_transport', 'sport', 'tourism', 'traffic_calming', 'waterway'))
-        self.area_yes_default = set(('area:highway', 'boundary', 'building', 'cemetery', 'craft', 'geological', 'indoor', 'landuse', 'natural', 'office', 'place', 'shop'))
+        self.area_yes_good = set(('aerialway', 'aeroway', 'amenity', 'barrier', 'highway', 'historic', 'leisure', 'man_made', 'military', 'piste:type', 'playground', 'power', 'public_transport', 'sport', 'tourism', 'traffic_calming', 'waterway'))
+        self.area_yes_default = set(('area:highway', 'boundary', 'building', 'building:part', 'cemetery', 'club', 'craft', 'geological', 'healthcare', 'health_facility:type', 'indoor', 'landuse', 'natural', 'office', 'place', 'shop'))
         self.errors[32002] = self.def_class(item = 3200, level = 3, tags = ['tag', 'fix:chair'],
             title = T_('Untagged area object'),
             detail = T_('The object is missing any tag which defines what kind of feature it is. This is unexpected for something tagged with `area=yes`.'),


### PR DESCRIPTION
Add more "main" keys (=keys that can exist without other main keys) that:
- Require an `area=yes` key sometimes according to their wiki ([`piste:type`](https://wiki.openstreetmap.org/wiki/Key:piste:type))
- Default to `area=yes` (if used on a way) so should not get a misleading "Untagged area object" warning ([`building:part`](https://wiki.openstreetmap.org/wiki/Key:building:part), [`club`](https://wiki.openstreetmap.org/wiki/Key:club), [`healthcare`](https://wiki.openstreetmap.org/wiki/Key:healthcare), [`health_facility:type`](https://wiki.openstreetmap.org/wiki/Key:health_facility:type))