### PR TITLE
Update TagFix_MultipleTag.py

### DIFF
--- a/plugins/TagFix_MultipleTag.py
+++ b/plugins/TagFix_MultipleTag.py
@@ -90,6 +90,8 @@ For further detail, see [the wiki](https://wiki.openstreetmap.org/wiki/Key:acces
             name_parent.append("removed:" + i)
             name_parent.append("razed:" + i)
             name_parent.append("was:" + i)
+            name_parent.append("ruins:" + i)
+            name_parent.append("destroyed:" + i)
             name_parent.append(i + ":backward")
             name_parent.append(i + ":forward")
         self.name_parent = set(name_parent)


### PR DESCRIPTION
Add [`ruins:`](https://wiki.openstreetmap.org/wiki/Key:ruins:*) and [`destroyed:`](https://wiki.openstreetmap.org/wiki/Key:destroyed:*) lifecycle prefixes to the list of valid prefixes