### PR TITLE
Update kOpeningHours 

### DIFF
--- a/plugins/TagFix_Opening_Hours.py
+++ b/plugins/TagFix_Opening_Hours.py
@@ -88,7 +88,7 @@ class Test(TestPluginCommon):
 
         # These are OK, no suggestion
         assert not a.node(None, {'opening_hours': 'Mo-Fr 10:00-19:00'})
-        assert not a.node(None, {'opening_hours': 'Mo-Tu,Th-Fr 09:30-12:00; We 15:00-17:00; 2020 Dec 24,31 off; Sa,Su off; PH off'})
+        assert not a.node(None, {'opening_hours': 'Mo-Tu,Th-Fr 09:30-12:00; We 15:00-17:00; Dec 24,31 off; Sa,Su off; PH off'})
         assert not a.node(None, {'opening_hours': 'Mo off, Tu-Th 09:00-18:00; Fr 09:00-19:00; Sa 08:00-18:00; Su off'})
 
         # Check 00:00 and 24:00 are both OK

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium >= 3.1.3
-git+https://invent.kde.org/libraries/kopeninghours.git@v23.03.80
+git+https://invent.kde.org/libraries/kopeninghours.git@v24.01.90
 git+https://github.com/jocelynj/PyEasyArchive.git
 protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geojson
 vt2geojson


### PR DESCRIPTION
Update (py)kOpeningHours to the latest version.

(Likely only?) relevant change for us is https://invent.kde.org/libraries/kopeninghours/-/commit/906078795f0d7b594166f575e334f4b0bd8771ee