### PR TITLE
Add Brest, FR bicycle parking

### DIFF
--- a/analysers/analyser_merge_bicycle_parking_FR_brest.py
+++ b/analysers/analyser_merge_bicycle_parking_FR_brest.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights XioNoX 2024                                                ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Merge import Analyser_Merge_Point, SourceDataGouv, SHP, LoadGeomCentroid, Conflate, Select, Mapping
+
+class Analyser_Merge_Bicycle_Parking_FR_Brest(Analyser_Merge_Point):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8150, id = 1, level = 3, tags = ['merge', 'public equipment', 'bicycle', 'fix:survey', 'fix:picture'],
+            title = T_('Bicycle parking not integrated'))
+        self.def_class_possible_merge(item = 8151, id = 3, level = 3, tags = ['merge'],
+            title = T_('Bicycle parking integration suggestion'))
+        self.def_class_update_official(item = 8412, id = 4, level = 3, tags = ['merge'],
+            title = T_('Bicycle parking update'))
+        self.init(
+            "https://www.data.gouv.fr/fr/datasets/stationnement-velos-1/",
+            "Localisation des stationnements vélos connus sur le territoire de Brest métropole",
+            SHP(
+                SourceDataGouv(
+                    attribution="data.gouv.fr:Brest Métropole",
+                    dataset="64809542ee39c6b7774817bb",
+                    resource="16da3c74-e885-4563-94ef-a9b59d600d8e"),
+                zip="DEP_ACT_StationnementVelo.shp"),
+            LoadGeomCentroid(select = {"ETAT": 'Existant'}),
+            Conflate(
+                select = Select(
+                    types = ["nodes", "ways"],
+                    tags = {"amenity": "bicycle_parking"}),
+                conflationDistance = 10,
+                mapping = Mapping(
+                    static1 = {"amenity": "bicycle_parking"},
+                    static2 = {"source": self.source},
+                    mapping1 = {
+                        "capacity": "NB_PLACES",
+                        "bicycle_parking": lambda res: self.bicycle_parking.get(res.get("TYPE_STAT")),
+                    },
+                    mapping2 = {
+                        "access": lambda res: "yes" if res.get("ACCES_PUBL") == "OUI" else None,
+                        "locked": lambda res: "yes" if res.get("CTRLACCES") == "KorriGo" else None,
+                        "start_date": "DATE_POSE",
+                        "covered": lambda res: self.covered.get(res.get("TYPE_STAT")),
+                        "operator": lambda res: "Brest Métropole" if res.get("DOM_PRIVE") == "Public" else None,
+                    })))
+
+    covered = {
+        None: None,
+        'Abri tram': 'yes',
+        'Arceau': 'no',
+        'Arceau abri': "yes",
+        'Autre': None,
+        'Box': 'yes',
+        'Rack provisoire': 'no',
+        'Ratelier': 'no',
+        'Ratelier couvert': 'yes',
+    }
+    bicycle_parking = {
+        None: None,
+        'Abri tram': 'shed',
+        'Arceau': 'stands',
+        'Arceau abri': 'stands',
+        'Autre': None,
+        'Box': None,
+        'Rack provisoire': None,
+        'Ratelier': 'wall_loops',
+        'Ratelier couvert': 'wall_loops',
+    }

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -352,6 +352,7 @@ france_departement("bretagne/ille_et_vilaine", 7465, "FR-35", include=[
 ])
 france_departement("bretagne/finistere", 102430, "FR-29", include=[
     'merge_public_transport_FR_bibus',
+    'merge_bicycle_parking_FR_brest',
 ])
 france_departement("bretagne/morbihan", 7447, "FR-56", include=[
     'merge_defibrillators_FR_lorient',


### PR DESCRIPTION
Hi,

This PR compares the OSM bicycle parking with the Metropole's open data.

The Metropole's data is also visible on https://geo.brest-metropole.fr/portal/home/item.html?id=6b920107ce114196b5ac658071aa6f4d
And here are the fields' descriptions : https://public.brest-metropole.fr/VIPDU61/aspx/HTDU502.aspx?TYPE=FICHE&ID=DEP_ACT_StationnementVelo

Running it locally showed 80 points to check : https://cocarto.com/fr/share/sXuffNphf-hnZsuo
All the ones I looked at seem legitimate. Some are slightly wrong location from the city's data, some are slightly wrong location from the OSM data, most are just missing bike parking that need to be added to OSM.

A few questions, first, here I'm adding a new field `ref:FR:BM` which matches the `IDENT_UNIQ` from the city. But that `IDENT_UNIQ` is not always present in their database, and is never on the equipment. Is it worth adding ?

Secondly, the city did a mass import a year ago : https://forum.openstreetmap.fr/t/import-des-arceaux-a-velo-de-brest-metropole-non-presents-dans-osm/11072/4
Unfortunately they didn't add their internal ref to OSM, but in their own DB they added a `OSM_ID` field.

For example : 
```json
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    -4.404130765233779,
                    48.41070444663655
                ]
            },
            "properties": {
                "class": 81,
                "subclass": "3460837473469635718",
                "text": {},
                "ids": [
                    0,
                    "POINT(-4.404130765233779 48.41070444663655)",
                    {
                        "access": "yes",
                        "source": "data.gouv.fr:Brest M\u00e9tropole - 2024-01",
                        "amenity": "bicycle_parking",
                        "covered": "no",
                        "capacity": "6",
                        "operator": "Brest M\u00e9tropole",
                        "bicycle_parking": "stands"
                    },
                    {
                        "ETAT": "Existant",
                        "PRIO": "0",
                        "LIBRU": "RUE JEAN MERMOZ",
                        "RTS_X": "0E-8",
                        "RTS_Y": "0E-8",
                        "TEXTE": "270",
                        "X_L93": "152886.42940000",
                        "Y_L93": "6837975.45040000",
                        "Y_LAT": "48.41104056",
                        "ARRETE": "NON",
                        "OSM_ID": "10275591475",
                        "X_LONG": "-4.40416606",
                        "ADRESSE": "Cimeti\u00e8re RK",
                        "NOPHOTO": "0",
                        "ogc_fid": "177",
                        "DATE_ARR": "None",
                        "FICHE_RA": "0",
                        "NOARRETE": "0",
                        "ORIG_DEM": "Autre",
                        "OSM_DIST": "4.03642775",
                        "RTS_DIST": "0E-8",
                        "CTRLACCES": "Non",
                        "DATE_POSE": "None",
                        "DOM_PRIVE": "Public",
                        "NB_PLACES": "6",
                        "TYPE_STAT": "Arceau",
                        "ACCES_PUBL": "OUI",
                        "ETAT_MATER": "Bon",
                        "FOURNISSEU": "Actus",
                        "IDENT_UNIQ": "0",
                        "NBPL_STAVP": "1",
                        "NB_ARC_EXI": "0",
                        "NB_SUPPORT": "3",
                        "OBSERVATIO": "None",
                        "RTS_MATRIC": "None",
                        "RTS_NOMTYP": "None",
                        "SIGNALISAT": "None",
                        "SIGNAL_SOU": "None",
                        "TYPE_ARCEA": "Classique",
                        "VAL_ARRETE": "None"
                    },
                    "01010000206A08000000128340ACA902412C90A080AC155A41"
                ],
                "types": [
                    "node",
                    null
                ],
                "fix": {
                    "+": {
                        "access": "yes",
                        "source": "data.gouv.fr:Brest M\u00e9tropole - 2024-01",
                        "amenity": "bicycle_parking",
                        "covered": "no",
                        "capacity": "6",
                        "operator": "Brest M\u00e9tropole",
                        "bicycle_parking": "stands"
                    }
                }
            }
        },
```

Matches this bike parking : https://www.openstreetmap.org/node/10275591475
The one from OpenData is a few meters away : https://www.openstreetmap.org/search?query=48.41104056%2C%20-4.40416606#map=19/48.41104/-4.40417&layers=C
With the city's picture : https://geo.brest-metropole.fr/arcgis/rest/services/public/GPB_DEP/MapServer/1710001/16001/attachments/14081
Questions are : 
* with `conflationDistance` of 20, why Osmose considers it as missing ?
* Is it possible to use the OpenData `OSM_ID` field to conflate them ?

Bonus question, how should I tag this kind of parking https://www.altinnova.com/produits/stationnement-velos/altao-mobile/ ?

Thanks a lot !

The full json output is visible there for 30 days : https://transfert.free.fr/7hm1qLY
