### PR TITLE
Always select biggest building in osmosis_building_in_polygon

### DIFF
--- a/analysers/analyser_osmosis_building_in_polygon.py
+++ b/analysers/analyser_osmosis_building_in_polygon.py
@@ -71,7 +71,8 @@ WHERE
   buildings.area > 36 AND
   (NOT buildings.tags?'location' OR buildings.tags->'location' != 'underground')
 ORDER BY
-  poly_landuse.type_id
+  poly_landuse.type_id,
+  buildings.area DESC
 """
 
 

--- a/tests/osmosis_building_in_polygon.osm
+++ b/tests/osmosis_building_in_polygon.osm
@@ -20,15 +20,21 @@
   <node id='18' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227362937' lon='5.83801632619' />
   <node id='19' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85227335578' lon='5.83808054832' />
   <node id='20' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8523279728' lon='5.83808115812' />
-  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85281310453' lon='5.83892828569' />
+  <node id='21' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85323987824' lon='5.83938890514' />
   <node id='22' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85242601411' lon='5.83838813655' />
-  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85240171962' lon='5.83938452817' />
-  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85251671342' lon='5.8390200586' />
-  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8524405908' lon='5.8390987211' />
-  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8524405908' lon='5.83896237277' />
+  <node id='23' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85239893021' lon='5.84028318768' />
+  <node id='24' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85307459041' lon='5.83936778113' />
+  <node id='25' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85254937754' lon='5.83984835667' />
+  <node id='26' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85271953063' lon='5.83891269812' />
   <node id='27' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85263251673' lon='5.83880766986' />
   <node id='28' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85250537602' lon='5.83868180987' />
   <node id='29' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85260093404' lon='5.83903054694' />
+  <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85299080819' lon='5.8393608199' />
+  <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85261145189' lon='5.83969951066' />
+  <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85275231618' lon='5.83905148232' />
+  <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8518246492' lon='5.8384224473' />
+  <node id='40' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8518368087' lon='5.83866014013' />
+  <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85195473029' lon='5.83861477038' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -90,6 +96,22 @@
     <nd ref='29' />
     <nd ref='27' />
     <tag k='building' v='yes' />
+  </way>
+  <way id='110' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='36' />
+    <nd ref='37' />
+    <nd ref='38' />
+    <nd ref='36' />
+    <tag k='building' v='houseboat' />
+    <tag k='note' v='Should not warn: inside inner' />
+  </way>
+  <way id='111' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='39' />
+    <nd ref='40' />
+    <nd ref='41' />
+    <nd ref='39' />
+    <tag k='building' v='barn' />
+    <tag k='note' v='Should not warn: not the biggest building' />
   </way>
   <relation id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='106' role='inner' />


### PR DESCRIPTION
This should have two effects:
1. It should avoid the randomness of the building selected (observed in issue 2138)
2. Selecting a prominent building makes more sense than a small building

Also adds a test case for a building inside an MP inner (to ensure that it's not selected). 
I used it to test that 2138 isn't a generic issue with inners, but probably nice to just have the test case anyway

Note: this doesn't fix (any part of) 2138, it just avoids constantly changing false positives