### PR TITLE
Fix missing motorway detections.

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -191,11 +191,10 @@ FROM
 WHERE
   -- Non-oneway highways are valid input nodes for oneways
   (NOT is_oneway AND NOT is_roundabout) OR
-  -- Force motorways as valid input nodes
   -- Raceways are commonly isolated from the main network
   -- Escape (emergency stop) ways are supposed to be not used / dead-ended
   -- Footway can lead to anything (attraction entrances, ...) so exclude them even if oneway
-  highway IN ('motorway', 'raceway', 'escape', 'footway') OR
+  highway IN ('raceway', 'escape', 'footway') OR
   -- Construction roads are usually temporary, the connections are likely access=no or similar
   is_construction
 UNION ALL
@@ -541,6 +540,7 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl="3", elems=[("node", "9"), ("way", "1003")])
         self.check_err(cl="3", elems=[("node", "14"), ("way", "1005")])
         self.check_err(cl="3", elems=[("node", "15"), ("way", "1006")]) # way 1006 or 1007 are both fine
+        self.check_err(cl="3", elems=[("node", "55"), ("way", "1024")])
         self.check_err(cl="3", elems=[("node", "65"), ("way", "1028")])
         self.check_err(cl="3", elems=[("node", "82"), ("way", "1036")]) # way 1036 or 1037 are both fine
         self.check_err(cl="3", elems=[("node", "84"), ("way", "1038")]) # way 1038 or 1040 are both fine
@@ -559,4 +559,4 @@ class Test(TestAnalyserOsmosis):
 
         self.check_err(cl="5", elems=[("node", "73"), ("way", "1031")])
 
-        self.check_num_err(22)
+        self.check_num_err(23)

--- a/tests/osmosis_highway_deadend.osm
+++ b/tests/osmosis_highway_deadend.osm
@@ -350,7 +350,7 @@
     <nd ref='62' />
     <nd ref='56' />
     <tag k='highway' v='motorway' />
-    <tag k='name' v='Class 3 good, class 2 bad' />
+    <tag k='name' v='Class 2 and 3 bad' />
   </way>
   <way id='1025' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='57' />


### PR DESCRIPTION
https://github.com/osm-fr/osmose-backend/pull/2158 "added motorways to oneways"  should've detected the motorway input node 55 in `\tests\osmosis_highway_deadend.osm` but the inclusion of all motorway nodes as valid inputs means it wasn't. 

https://github.com/osm-fr/osmose-backend/issues/231 should also be resolved by https://github.com/osm-fr/osmose-backend/pull/2158 so the workaround is no longer needed.