### PR TITLE
Reuse is_oneway instead of recalculating

### DIFF
--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -162,7 +162,7 @@ SELECT
         WHEN ways.nodes[1] = ANY (roundabout.nodes) THEN ARRAY[ways.nodes[2], ways.nodes[3], ways.nodes[4]]
         WHEN ways.nodes[array_length(ways.nodes,1)] = ANY (roundabout.nodes) THEN ARRAY[ways.nodes[array_length(ways.nodes,1)], ways.nodes[array_length(ways.nodes,1)-1], ways.nodes[array_length(ways.nodes,1)-2]]
     END AS n_ids,
-    (ways.tags?'oneway' AND ways.tags->'oneway' IN ('yes', 'true', '-1', '1')) AS oneway
+    ways.is_oneway
 FROM
     roundabout
     JOIN highways AS ways ON
@@ -190,7 +190,7 @@ FROM
         ra1.a_id != ra2.a_id
 WHERE
     ra1.n_ids && ra2.n_ids AND
-    NOT ra1.oneway
+    NOT ra1.is_oneway
 GROUP BY
     ra1.a_id,
     COALESCE(ra1.n_ids[2], ra1.n_ids[1])

--- a/tests/osmosis_highway_deadend.osm
+++ b/tests/osmosis_highway_deadend.osm
@@ -172,13 +172,16 @@
   <node id='161' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85082280825' lon='5.83932035437' />
   <node id='162' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85114753837' lon='5.83916742319' />
   <node id='163' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85114753837' lon='5.83923114451' />
-  <node id='164' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85135092517' lon='5.83901345193' >
+  <node id='164' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85135092517' lon='5.83901345193'>
     <tag k='amenity' v='ferry_terminal' />
   </node>
   <node id='165' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85160938691' lon='5.83921729982' />
-  <node id='166' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85160938691' lon='5.83877205312' >
+  <node id='166' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85160938691' lon='5.83877205312'>
     <tag k='amenity' v='ferry_terminal' />
   </node>
+  <node id='167' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8494018404' lon='5.83792167126' />
+  <node id='168' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84951205558' lon='5.83804274178' />
+  <node id='169' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.84939593601' lon='5.83815744017' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -784,23 +787,40 @@
     <nd ref='162' />
     <tag k='amenity' v='bicycle_parking' />
   </way>
-  <way id='1089' timestamp='2014-03-31T22:00:00Z' visible='true' version='1'>
+  <way id='1089' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='164' />
     <nd ref='165' />
     <tag k='highway' v='trunk_link' />
     <tag k='name' v='Class 2 and 3 good' />
     <tag k='oneway' v='yes' />
   </way>
-  <way id='1090' timestamp='2014-03-31T22:00:00Z' visible='true' version='1'>
+  <way id='1090' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='165' />
     <nd ref='166' />
     <tag k='highway' v='trunk_link' />
     <tag k='name' v='Class 2 and 3 good' />
     <tag k='oneway' v='yes' />
   </way>
-  <way id='1091' timestamp='2014-03-31T22:00:00Z' visible='true' version='1'>
+  <way id='1091' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='166' />
     <nd ref='164' />
     <tag k='route' v='ferry' />
+  </way>
+  <way id='1092' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='167' />
+    <nd ref='168' />
+    <tag k='highway' v='motorway' />
+    <tag k='oneway' v='alternating' />
+  </way>
+  <way id='1093' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='169' />
+    <nd ref='168' />
+    <tag k='highway' v='trunk' />
+    <tag k='oneway' v='alternating' />
+  </way>
+  <way id='1094' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='169' />
+    <nd ref='167' />
+    <tag k='highway' v='trunk' />
   </way>
 </osm>


### PR DESCRIPTION
This PR:
1. Re-uses the `is_oneway` property of table `highways`, rather than calculating it again
2. Adds a test case for `oneway=alternating`, in case the `is_oneway` check ever gets rewritten. (To ensure that an easy to miss bug like described in https://github.com/osm-fr/osmose-backend/pull/2158#issuecomment-1986826894 will never actually slip in)