### PR TITLE
Fix (if possible) MP with touching inners, drop otherwise

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -167,7 +167,7 @@ BEGIN
                         id, tags,
                         ST_BuildArea(ST_Collect(
                             ST_ExteriorRing(poly),
-                            (SELECT ST_Union(ST_InteriorRingN(poly, n)) FROM generate_series(1, ST_NumInteriorRings(poly)) AS t(n))
+                            (SELECT ST_Union(ST_MakePolygon(ST_InteriorRingN(poly, n))) FROM generate_series(1, ST_NumInteriorRings(poly)) AS t(n)) -- ST_MakePolygon is needed to union touching inner rings #2169
                         )) AS poly
                     FROM
                         unary

--- a/analysers/analyser_osmosis_building_in_polygon.py
+++ b/analysers/analyser_osmosis_building_in_polygon.py
@@ -124,4 +124,5 @@ class Test(TestAnalyserOsmosis):
         self.root_err = self.load_errors()
         self.check_err(cl="1", elems=[("way", "100"), ("way", "101")])
         self.check_err(cl="1", elems=[("relation", "1000"), ("way", "107")])
-        self.check_num_err(2)
+        self.check_err(cl="1", elems=[("relation", "1001"), ("way", "116")])
+        self.check_num_err(3)

--- a/tests/osmosis_building_in_polygon.osm
+++ b/tests/osmosis_building_in_polygon.osm
@@ -35,6 +35,19 @@
   <node id='39' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8518246492' lon='5.8384224473' />
   <node id='40' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8518368087' lon='5.83866014013' />
   <node id='41' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85195473029' lon='5.83861477038' />
+  <node id='42' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85164195273' lon='5.83953024459' />
+  <node id='43' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85166492752' lon='5.84133415867' />
+  <node id='44' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85210718988' lon='5.84038880851' />
+  <node id='45' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85174342462' lon='5.83993628023' />
+  <node id='46' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85175108287' lon='5.84091262548' />
+  <node id='47' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85174712005' lon='5.84040740831' />
+  <node id='48' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85200571881' lon='5.84044150016' />
+  <node id='49' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85178745952' lon='5.84046319672' />
+  <node id='50' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85179128864' lon='5.84075455054' />
+  <node id='51' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85233884937' lon='5.84040120654' />
+  <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85165459992' lon='5.83961526124' />
+  <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.85166675947' lon='5.83985295407' />
+  <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8517846815' lon='5.83980758432' />
   <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -113,10 +126,56 @@
     <tag k='building' v='barn' />
     <tag k='note' v='Should not warn: not the biggest building' />
   </way>
+  <way id='112' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='51' />
+    <nd ref='42' />
+    <nd ref='43' />
+    <nd ref='51' />
+  </way>
+  <way id='113' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='44' />
+    <nd ref='45' />
+    <nd ref='47' />
+    <nd ref='44' />
+    <tag k='landuse' v='industrial' />
+    <tag k='note' v='Touching inners are allowed in OSM, not in OGC' />
+  </way>
+  <way id='114' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='47' />
+    <nd ref='46' />
+    <nd ref='44' />
+    <nd ref='47' />
+    <tag k='landuse' v='residential' />
+    <tag k='note' v='Touching inners are allowed in OSM, not in OGC' />
+  </way>
+  <way id='115' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='48' />
+    <nd ref='49' />
+    <nd ref='50' />
+    <nd ref='48' />
+    <tag k='building' v='house' />
+    <tag k='note' v='Shouldn&apos;t warn, inside (touching) inners' />
+  </way>
+  <way id='116' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='52' />
+    <nd ref='53' />
+    <nd ref='54' />
+    <nd ref='52' />
+    <tag k='building' v='barn' />
+    <tag k='note' v='Biggest building INSIDE the multipolygon, should warn. Polygon should not be dropped altogether' />
+  </way>
   <relation id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='106' role='inner' />
     <member type='way' ref='105' role='outer' />
     <tag k='landuse' v='vineyard' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+  <relation id='1001' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <member type='way' ref='114' role='inner' />
+    <member type='way' ref='113' role='inner' />
+    <member type='way' ref='112' role='outer' />
+    <tag k='landuse' v='farmland' />
+    <tag k='note' v='Relation with touching inners, here OSM differs from OGC' />
     <tag k='type' v='multipolygon' />
   </relation>
 </osm>


### PR DESCRIPTION
See #2138

Touching inners were dropped silently from the multipolygon geometry. Per the [wiki](https://wiki.openstreetmap.org/wiki/Relation:multipolygon#Touching_inner_rings), touching inners are valid in OSM (unlike OGC) and should just be considered as a single inner.

The reason for this 'silent dropping' of touching inners is that `ST_Union` doesn't join two touching closed ways unmodified, but rather converts it into three 'open' ways:
`ST_AsText(ST_Union(ARRAY[ST_GeomFromText('LINESTRING(1 0, 1 1, 0 0, 1 0)'), ST_GeomFromText('LINESTRING(1 0, 1 -1, 0 0, 1 0)')]))`
gives `MULTILINESTRING((1 0,1 1,0 0),(0 0,1 0),(1 0,1 -1,0 0))`
This cannot be resolved by `ST_BuildArea` anymore, so it drops it.

This can be resolved by first converting the rings to polygons already:
`ST_AsText(ST_Union(ARRAY[ST_MakePolygon(ST_GeomFromText('LINESTRING(1 0, 1 1, 0 0, 1 0)')), ST_MakePolygon(ST_GeomFromText('LINESTRING(1 0, 1 -1, 0 0, 1 0)'))]))`
gives `POLYGON((1 -1,0 0,1 1,1 0,1 -1))`

(`ST_BuildArea` accepts either closed ways and polygons for inners)

---

Results noticed during testing:
1. No new false positives in the changed entries - tested with osmosis_building_in_polygon, osmosis_polygon_intersects and osmosis_polygon_small on belgium_wallonia_german_community, france_centre_loiret, germany_saarland, japan_chubu, jersey, monaco, netherlands_gelderland, san_marino, slovenia, sweden_gotland, switzerland_basel_stadt, usa_iowa, venezuela)
2. Several false positives fixed, examples: [location 1](https://osmose.openstreetmap.fr/nl/map/#country=usa_iowa&item=1310&zoom=18&lat=41.526394&lon=-94.57104&level=3), [location 2](https://osmose.openstreetmap.fr/nl/map/#country=usa_iowa&item=1310&zoom=18&lat=41.753589&lon=-95.30946&level=3), [location 3](https://osmose.openstreetmap.fr/nl/map/#zoom=17&lat=36.717704&lon=138.48832&item=1070&level=1%2C2%2C3&class=12), [location 4](https://osmose.openstreetmap.fr/nl/map/#country=france_centre_loiret&item=1070&source=&class=15&username=&bbox=&zoom=18&lat=47.950698&lon=3.030552&level=2&tags=&fixable=) (and many more)
3. (Unexpected to me) better detection of invalid relations when `outer`s touch `inner`s, examples: [r14165680](https://www.openstreetmap.org/relation/14165680), [r14175064](https://www.openstreetmap.org/relation/14175064), so less false positives in general due to invalid relations being detected better. (My guess is that in those cases ST_BuildArea cannot generate an alternative valid structure anymore and thus must default to something that doesn't pass the ST_IsValid checks later on)

---

Unfortunately it's not perfect: in some rare cases, the inners are already dropped at `ST_BuildArea(mp.linestrings)`. Fixing it here is much more risky (we don't want to convert invalid MP to valid MP by accident) and this is pretty rare it seems, so instead the better solution seems to me to drop these cases (just like other MP that St_BuildArea on the linestrings cannot process). Cases found so far:
- https://www.openstreetmap.org/relation/10791091 
- https://www.openstreetmap.org/relation/9466424
- https://www.openstreetmap.org/relation/14164343
- https://www.openstreetmap.org/relation/14364124
- https://www.openstreetmap.org/relation/1288370
- https://www.openstreetmap.org/relation/5888956
- https://www.openstreetmap.org/relation/13559903
- https://www.openstreetmap.org/relation/13482010
- https://www.openstreetmap.org/relation/13384968
- https://www.openstreetmap.org/relation/12247611
- https://www.openstreetmap.org/relation/11073268
- https://www.openstreetmap.org/relation/11073166
- https://www.openstreetmap.org/relation/11069546
- https://www.openstreetmap.org/relation/3315160

Note, for the simpler cases of the above I noticed that it was always happening when the first=last nodes of the closed inner ways were in the overlapping area. Didn't check the complicated cases. Just listing them for future reference if needed.