### PR TITLE
Add power poles gracethd France merge analyzers, starting on Dordogne opendata

### DIFF
--- a/analysers/Analyser_Merge_power_pole_FR_gracethd.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd.py
@@ -27,11 +27,11 @@ from .Analyser_Merge import Analyser_Merge_Point, SHP, LoadGeomCentroid, Conflat
 class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
     def __init__(self, config, source_url, dataset_name, source, srid, conflationDistance, classs, extract_operator = None, logger = None):
         Analyser_Merge_Point.__init__(self, config, logger)
-        self.def_class_missing_official(item = 8490, id = classs + 1, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+        self.def_class_missing_official(item = 8290, id = classs + 1, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
             title = T_('Power pole not integrated'))
-        self.def_class_possible_merge(item = 8491, id = classs + 3, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+        self.def_class_possible_merge(item = 8291, id = classs + 3, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
             title = T_('Power pole integration suggestion'))
-        self.def_class_update_official(item = 8492, id = classs + 4, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+        self.def_class_update_official(item = 8290, id = classs + 4, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
             title = T_('Power pole update'))
 
         self.init(

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Merge import Analyser_Merge_Point, SHP, LoadGeomCentroid, Conflate, Select, Mapping
+
+
+class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
+    def __init__(self, config, source_url, dataset_name, source, srid, conflationDistance, classs, extract_operator = None, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8490, id = classs + 1, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole not integrated'))
+        self.def_class_possible_merge(item = 8491, id = classs + 3, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole integration suggestion'))
+        self.def_class_update_official(item = 8492, id = classs + 4, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole update'))
+
+        self.init(
+            source_url,
+            dataset_name,
+            SHP(source, srid = srid, zip="*.shp"),
+            LoadGeomCentroid(),
+            Conflate(
+                select = Select(
+                    types = ['nodes'],
+                    tags = {'power': 'pole'}),
+                osmRef = 'ref',
+                conflationDistance = conflationDistance,
+                mapping = Mapping(
+                    static1 = {'power': 'pole'},
+                    static2 = {'source': self.source},
+                    mapping1 = {
+                        'material': lambda res: self.extract_material.get(res['pt_nature']),
+                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else None},
+                text = lambda tags, fields: {} )))
+
+    extract_material = {
+        'PBOI': 'wood',
+        'PBET': 'concrete',
+        'PCMP': 'epoxy',
+        'PMET': 'steel'
+    }

--- a/analysers/analyser_merge_power_pole_FR_gracethd_dordogne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd_dordogne.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge import SourceDataGouv
+
+class Analyser_Merge_power_pole_FR_gracethd_dordogne(Analyser_Merge_power_pole_FR_gracethd):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-de-la-dordogne/',
+            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP de la Dordogne',
+            source=SourceDataGouv(
+                attribution="Syndicat Mixte Périgord Numérique",
+                dataset="659d72fb641c7c0d6fe6cc59",
+                resource="82e49c1f-976f-4be7-ab20-0a58e9badb56"),
+            srid = 2154,
+            conflationDistance=5,
+            classs=1000,
+            extract_operator = {
+                'OR000000000003': 'Enedis'
+            },
+            logger=logger)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -305,7 +305,9 @@ include_aquitaine = [
     'merge_library_FR_aquitaine',
     'merge_winery_FR_aquitaine',
 ]
-france_departement("aquitaine/dordogne", 7375, "FR-24", include=include_aquitaine)
+france_departement("aquitaine/dordogne", 7375, "FR-24", include=include_aquitaine + [
+    'merge_power_pole_FR_gracethd_dordogne'
+])
 france_departement("aquitaine/gironde", 7405, "FR-33", include=include_aquitaine + [
     # Bordeaux
     'merge_recycling_FR_bm',


### PR DESCRIPTION
Earlier this year, some public authorities started publishing opendata about power poles used to support fibre optic roll out.

I'm proposing here a merge analysis based upon graceTHD standard, implemented on Dordogne department.  
Data quality is really good and this area is proposed with 5m as conflation distance.

It is supposed to raise 11 697 warnings and currently conflates with 16 osm existing nodes.
For instance https://osm.org/node/11285907938 accurately matches with `POT-24253-BT-07047` opendata record.

@frodrigo we should adjust classes and item numbers please.