### PR TITLE
Remove osmref from gracethd and eclext analyzers

### DIFF
--- a/analysers/Analyser_Merge_power_pole_FR_gracethd.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd.py
@@ -43,7 +43,6 @@ class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
                 select = Select(
                     types = ['nodes'],
                     tags = {'power': 'pole'}),
-                osmRef = 'ref',
                 conflationDistance = conflationDistance,
                 mapping = Mapping(
                     static1 = {'power': 'pole'},

--- a/analysers/Analyser_Merge_street_lamp_FR_eclext.py
+++ b/analysers/Analyser_Merge_street_lamp_FR_eclext.py
@@ -26,7 +26,7 @@ from .Analyser_Merge import Analyser_Merge_Point, CSV, Load_XY, Conflate, Select
 
 
 class Analyser_Merge_street_lamp_FR_eclext (Analyser_Merge_Point):
-    def __init__(self, config, source_url, dataset_name, source, srid, osmRef, classs, logger = None):
+    def __init__(self, config, source_url, dataset_name, source, srid, classs, logger = None):
         Analyser_Merge_Point.__init__(self, config, logger)
         self.def_class_missing_official(item = 8490, id = classs + 1, level = 3, tags = ['merge', 'street_lamp', 'fix:chair', 'fix:survey'],
             title = T_('Street light not integrated'))
@@ -44,7 +44,6 @@ class Analyser_Merge_street_lamp_FR_eclext (Analyser_Merge_Point):
                 select = Select(
                     types = ['nodes'],
                     tags = {'highway': 'street_lamp'}),
-                osmRef = osmRef,
                 conflationDistance = 20,
                 mapping = Mapping(
                     static1 = {'highway': 'street_lamp', 'operator': 'Syane'},

--- a/analysers/analyser_merge_street_lamp_FR_haute-savoie_syane.py
+++ b/analysers/analyser_merge_street_lamp_FR_haute-savoie_syane.py
@@ -34,6 +34,5 @@ class Analyser_Merge_Eclext_FR_Syane(Analyser_Merge_street_lamp_FR_eclext):
                 dataset="6447bfe8709c0b4a2b88355a",
                 resource="011aa541-8510-4caf-8a00-43d7efbe7543"),
             srid = 2154,
-            osmRef='ref',
             classs=1000,
             logger=logger)


### PR DESCRIPTION
Removing ref conflation from two French merge analysers. Useless until we got proper refs on street lamps and power poles.

Is it enough @frodrigo?
https://osmose.openstreetmap.fr/fr/issue/c7812432-6054-d5e4-6df2-146abfbed3ef sounds like to disappear from my test

Happy easter