### PR TITLE
Avoid translation of non-translatable strings

### DIFF
--- a/plugins/Structural_UnclosedArea.py
+++ b/plugins/Structural_UnclosedArea.py
@@ -33,8 +33,7 @@ class Structural_UnclosedArea(Plugin):
             fix = T_(
 '''If the object is not a surface, remove the tag `area=yes`, otherwise
 ensure that the way is a loop.'''),
-            example = T_(
-'''![](https://wiki.openstreetmap.org/w/images/c/cc/Osmose-eg-error-1100.png)'''))
+            example = {"en": "![](https://wiki.openstreetmap.org/w/images/c/cc/Osmose-eg-error-1100.png)"})
 
     def way(self, data, tags, nds):
         if "area" not in tags or tags["area"] == "no":


### PR DESCRIPTION
After spotting the one in #2184 there was another one where translating the string doesn't make sense (as it's just a picture without text in the picture)