### PR TITLE
Warn if ST_AsText was forgotten

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -651,7 +651,11 @@ WHERE
         if res is None:
             self.logger.warn("NULL location provided")
             return []
-        for loc in self.get_points(res):
+        points = self.get_points(res)
+        if points == []:
+            self.logger.err("Invalid location provided")
+            return []
+        for loc in points:
             self.geom["position"].append(loc)
 
 #    def positionWay(self, res):


### PR DESCRIPTION
It has happened quite often to me that I forgot to add `ST_AsText` (or similar) to the position indicator, resulting in no output for matching elements in the XML files and costing quite some debugging time.

Hopefully adding this little warning is fine?