### PR TITLE
Exclude `highway=trailhead` from `toll`/`fee` check

### DIFF
--- a/plugins/TagFix_MultipleTag2.py
+++ b/plugins/TagFix_MultipleTag2.py
@@ -298,12 +298,12 @@ class TagFix_MultipleTag2(PluginMapCSS):
                 # throwWarning:tr("Suspicious name for a container")
                 err.append({'class': 32302, 'subclass': 0, 'text': mapcss.tr('Suspicious name for a container')})
 
-        # way[highway][fee][!amenity][!leisure]
+        # way[highway][fee][!amenity][!leisure][highway!=trailhead]
         if ('fee' in keys and 'highway' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'fee')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'amenity')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'leisure')))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'highway')) and (mapcss._tag_capture(capture_tags, 1, tags, 'fee')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'amenity')) and (not mapcss._tag_capture(capture_tags, 3, tags, 'leisure')) and (mapcss._tag_capture(capture_tags, 4, tags, 'highway') != mapcss._value_const_capture(capture_tags, 4, 'trailhead', 'trailhead')))
                 except mapcss.RuleAbort: pass
             if match:
                 # group:tr("Watch multiple tags")

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -67,7 +67,7 @@ meta[lang=en] { /* lang=en, unused, only to use tr() to catch string for transla
 }
 
 
-way[highway][fee][!amenity][!leisure] {
+way[highway][fee][!amenity][!leisure][highway!=trailhead] {
     throwWarning: tr("Use tag \"toll\" instead of \"fee\"");
     group: tr("Watch multiple tags");
     assertMatch: "way highway=primary fee=yes";


### PR DESCRIPTION
Exclude `highway=trailhead` from toll/fee check

See #2180 and see https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtrailhead - `fee` is a suggested key and `highway=trailhead` is allowed to be an area

Hopefully it won't cause merge conflicts with the other PR modifying this same mapcss file