### PR TITLE
Fix French graceTHD analyser for power poles and add Brittany and Jura

### DIFF
--- a/analysers/Analyser_Merge_power_pole_FR_gracethd.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd.py
@@ -49,7 +49,8 @@ class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['pt_nature']),
-                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else None},
+                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else extract_operator.get(res['pt_prop']) if res['pt_prop'] and extract_operator.get(res['pt_prop']) else None,
+                        'height': lambda res: res['pt_a_haut'] if res['pt_a_haut'] and float(res['pt_a_haut']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
 
     extract_material = {

--- a/analysers/analyser_merge_power_pole_FR_gracethd_bretagne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd_bretagne.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge import SourceDataGouv
+
+class Analyser_Merge_power_pole_FR_gracethd_bretagne(Analyser_Merge_power_pole_FR_gracethd):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/recensement-poteaux-enedis-reutilises-dans-le-cadre-du-deploiement-ftth-du-projet-bretagne-tres-haut-debit/',
+            dataset_name='Recensement poteaux ENEDIS réutilisés dans le cadre du déploiement FTTH du projet Bretagne Très Haut Débit',
+            source=SourceDataGouv(
+                attribution="Mégalis Bretagne",
+                dataset="6613a43e5b40aaa8022d3787",
+                resource="b00051b6-69e5-42c3-8229-f6b556561d83"),
+            srid = 2154,
+            conflationDistance=5,
+            classs=1000,
+            extract_operator = {
+                'ORMB0000000003': 'Enedis'
+            },
+            logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd_jura.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd_jura.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge import SourceDataGouv
+
+class Analyser_Merge_power_pole_FR_gracethd_jura(Analyser_Merge_power_pole_FR_gracethd):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-du-jura/',
+            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP du Jura',
+            source=SourceDataGouv(
+                attribution="SIDEC Jura",
+                dataset="66158cdd04686348037417af",
+                resource="3f427bbd-f2bb-49dc-9457-c0aad16b1529"),
+            srid = 2154,
+            conflationDistance=5,
+            classs=1000,
+            extract_operator = {
+                'OR00000003': 'Enedis'
+            },
+            logger=logger)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -344,19 +344,23 @@ france_departement("bourgogne/saone_et_loire", 7397, "FR-71", include=[
 ])
 france_departement("bourgogne/yonne", 7392, "FR-89")
 
-france_departement("bretagne/cotes_d_armor", 7398, "FR-22")
-france_departement("bretagne/ille_et_vilaine", 7465, "FR-35", include=[
+include_bretagne = [
+    # Bretagne
+    'merge_power_pole_FR_gracethd_bretagne'
+]
+france_departement("bretagne/cotes_d_armor", 7398, "FR-22", include=include_bretagne)
+france_departement("bretagne/ille_et_vilaine", 7465, "FR-35", include=include_bretagne + [
     # Rennes
     'merge_public_equipment_FR_rennes_toilets',
     'merge_public_transport_FR_star',
     'merge_defibrillators_FR_montfort',
     'merge_defibrillators_FR_saintmalo',
 ])
-france_departement("bretagne/finistere", 102430, "FR-29", include=[
+france_departement("bretagne/finistere", 102430, "FR-29", include=include_bretagne + [
     'merge_public_transport_FR_bibus',
     'merge_bicycle_parking_FR_brest',
 ])
-france_departement("bretagne/morbihan", 7447, "FR-56", include=[
+france_departement("bretagne/morbihan", 7447, "FR-56", include=include_bretagne + [
     'merge_defibrillators_FR_lorient',
 ])
 
@@ -378,6 +382,7 @@ france_departement("corse/haute_corse", 76931, "FR-2B")
 france_departement("franche_comte/doubs", 7462, "FR-25")
 france_departement("franche_comte/jura", 7460, "FR-39", include=[
     'merge_hydrants_FR_SDIS_39',
+     'merge_power_pole_FR_gracethd_jura'
 ])
 france_departement("franche_comte/haute_saone", 7423, "FR-70")
 france_departement("franche_comte/territoire_de_belfort", 7410, "FR-90")

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -382,7 +382,7 @@ france_departement("corse/haute_corse", 76931, "FR-2B")
 france_departement("franche_comte/doubs", 7462, "FR-25")
 france_departement("franche_comte/jura", 7460, "FR-39", include=[
     'merge_hydrants_FR_SDIS_39',
-     'merge_power_pole_FR_gracethd_jura'
+    'merge_power_pole_FR_gracethd_jura'
 ])
 france_departement("franche_comte/haute_saone", 7423, "FR-70")
 france_departement("franche_comte/territoire_de_belfort", 7410, "FR-90")


### PR DESCRIPTION
Two fixes for common French GraceTHD analyzer:
* Add `height` field out of GraceTHD `pt_a_haut` when defined and > 6 meters
* Default GraceTHD's `pt_gest` with `pt_prop` as public authority sometimes confuses owners and operators (and GraceTHD summarizes them with common identifiers).

Two supplementary regions were recently added on data.gouv:
* Brittany (24 000 poles)
* Jura (20 000 poles)