### PR TITLE
Allow `entrance=yes` for deadend oneway

### DIFF
--- a/analysers/analyser_osmosis_highway_deadend.py
+++ b/analysers/analyser_osmosis_highway_deadend.py
@@ -154,7 +154,7 @@ WHERE
   tags != ''::hstore AND
   (
     (tags?'amenity'  AND tags->'amenity' IN ('parking_entrance', 'parking', 'ferry_terminal')) OR
-    (tags?'entrance' AND tags->'entrance' IN ('garage', 'emergency')) OR
+    (tags?'entrance' AND tags->'entrance' IN ('garage', 'emergency', 'yes')) OR
     (tags?'aerialway' AND tags->'aerialway' = 'station')
   )
 UNION ALL


### PR DESCRIPTION
Allow `entrance=yes` as a valid end-point for a oneway road. It permits mapping roads where it's unknown what the inside of the building looks like.

Fixes the errors here: https://osmose.openstreetmap.fr/nl/map/#zoom=18&lat=51.837743&lon=5.814744

(I'm not switching to `tags->'entrance' != 'no'` yet, as I highly suspect that most e.g. `entrance=main` (etc) would be bidirectional. If we find cases, we can always make that switch later)