### PR TITLE
Enable multipolygon intersection checks

### DIFF
--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -77,7 +77,7 @@ sql11 = """
 -- Collect all landuse=* and natural=*, closed ways and multipolygons
 CREATE TEMP TABLE landusage AS
 SELECT
-  'W' || id AS id,
+  'W' || id AS tid,
   ST_MakePolygon(linestring) AS poly_full,
   ST_Subdivide(ST_Buffer(ST_Transform(ST_MakePolygon(linestring), {proj}), -2.0), 1000) AS poly_proj_buffer_fragment,
   CASE
@@ -93,7 +93,7 @@ WHERE
   (tags?'natural' OR tags?'landuse')
 UNION ALL
 SELECT
-  'R' || id AS id,
+  'R' || id AS tid,
   poly AS poly_full,
   ST_Subdivide(ST_Buffer(poly_proj, -2.0), 1000) AS poly_proj_buffer_fragment,
   CASE
@@ -120,7 +120,7 @@ SELECT
   mobility_ways.id AS mobility_way_id,
   mobility_ways.linestring AS mobility_way_linestring,
   mobility_ways.type AS mobility_way_type,
-  landusage.id AS landusage_id,
+  landusage.tid AS landusage_tid,
   landusage.poly_full AS landusage_poly,
   landusage.landusekey,
   landusage.tags->landusage.landusekey AS landusevalue,
@@ -150,9 +150,9 @@ FROM
 sql14 = """
 -- Intersections with railway, aeroway or highway
 SELECT
-  DISTINCT ON (mobility_way_id, landusage_id)
+  DISTINCT ON (mobility_way_id, landusage_tid)
   mobility_way_id,
-  landusage_id,
+  landusage_tid,
   ST_AsText(ST_PointOnSurface(ST_Intersection(landusage_poly, mobility_way_linestring))),
   mobility_way_type,
   tag_way,
@@ -167,14 +167,14 @@ WHERE
     landusekey = 'natural' AND
     landusevalue IN ('bay', 'cliff', 'scrub', 'shrubbery', 'sinkhole', 'tree_group', 'wetland', 'wood') OR
     (
-      -- Special case as highway=* vs. natural=water is already included in item 1070 class 4/5
+      -- Special case as highway=* vs. natural=water _ways_ are already included in item 1070 class 4
       landusevalue = 'water' AND
-      mobility_way_type != 'highway'
+      (mobility_way_type != 'highway' OR SUBSTRING(landusage_tid,1,1) = 'R')
     )
   )
 ORDER BY
   mobility_way_id,
-  landusage_id,
+  landusage_tid,
   mobility_way_type,
   tag_way,
   tag_polygon
@@ -258,9 +258,10 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1027"), ("way", "1023")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1036"), ("way", "1035")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1049"), ("relation", "10002")])
+        self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1067"), ("relation", "10001")])
         self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1050"), ("relation", "10001")])
         self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1063"), ("relation", "10001")])
         self.check_err(cl=str(a.classIndex["aeroway"]), elems=[("way", "1064"), ("relation", "10001")])
         self.check_err(cl=str(a.classIndex["railway"]), elems=[("way", "1055"), ("relation", "10003")])
         self.check_err(cl=str(a.classIndex["highway"]), elems=[("way", "1062"), ("way", "1059")])
-        self.check_num_err(16)
+        self.check_num_err(17)

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -169,7 +169,7 @@ WHERE
     (
       -- Special case as highway=* vs. natural=water _ways_ are already included in item 1070 class 4
       landusevalue = 'water' AND
-      (mobility_way_type != 'highway' OR substring(landusage_tid,1,1) = 'R')
+      (mobility_way_type != 'highway' OR substring(landusage_tid, 1, 1) = 'R')
     )
   )
 ORDER BY

--- a/analysers/analyser_osmosis_polygon_intersects.py
+++ b/analysers/analyser_osmosis_polygon_intersects.py
@@ -169,7 +169,7 @@ WHERE
     (
       -- Special case as highway=* vs. natural=water _ways_ are already included in item 1070 class 4
       landusevalue = 'water' AND
-      (mobility_way_type != 'highway' OR SUBSTRING(landusage_tid,1,1) = 'R')
+      (mobility_way_type != 'highway' OR substring(landusage_tid,1,1) = 'R')
     )
   )
 ORDER BY

--- a/tests/osmosis_polygon_intersects.osm
+++ b/tests/osmosis_polygon_intersects.osm
@@ -138,6 +138,8 @@
   <node id='175' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82188764589' lon='5.92684902751' />
   <node id='176' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81909375438' lon='5.92556846439' />
   <node id='177' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82106700151' lon='5.92696119385' />
+  <node id='178' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82586172981' lon='5.92318385657' />
+  <node id='179' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.82545353166' lon='5.9285813642' />
   <way id='1000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='1' />
     <nd ref='2' />
@@ -472,6 +474,11 @@
     <nd ref='176' />
     <tag k='aeroway' v='runway' />
     <tag k='note' v='mini-intersection' />
+  </way>
+  <way id='1067' timestamp='2014-03-31T22:00:00Z' version='1'>
+    <nd ref='178' />
+    <nd ref='179' />
+    <tag k='highway' v='trunk' />
   </way>
   <relation id='10000' timestamp='2014-03-31T22:00:00Z' version='1'>
     <member type='way' ref='1045' role='inner' />


### PR DESCRIPTION
See the Matrix chat earlier this week.

`natural=water` *ways* intersecting highways are dealt with in `osmosis_highway_vs_building`, which doesn't support multipolygons. It is a special case there. On the other hand, `osmosis_polygon_intersects` deals with all polygons *except* `natural=water`, for highways. (It already deals with railways etc intersecting `natural=water`). However, `osmosis_polygon_intersects` is restricted to important highways (to avoid spamming) and takes a small buffer where intersections are permitted.

Therefore, porting the check directly to osmosis_polygon_intersects without losing existing results would be very difficult (and expensive) as natural=water vs. highways would become an exception nearly everywhere in the code: all other polygons should remain checked vs. important highways (& railways etc) only, and with the 2m buffer.

Rather than adding multipolygon support to `osmosis_highway_vs_building` (which is already a 'heavy' analyser), make the special case more specific so that multipolygon support is added for the cases that would also be found by osmosis_polygon_intersects. That way the results remain unchanged AND multipolygon support is added.

For the user it probably won't be noticed: both analysers report to item 1070