### PR TITLE
Disable TagFix_Postcode plugin for Egypt

### DIFF
--- a/plugins/TagFix_Postcode.py
+++ b/plugins/TagFix_Postcode.py
@@ -27,6 +27,8 @@ import re
 
 class TagFix_Postcode(Plugin):
 
+    not_for = ("EG") # Egypt is transitioning to a new format. At 2024-04-15 there were still 2.4M entries in OSM in the old format
+
     def parse_format(self, reline, format):
         format = format.replace('optionally ', '')
         if format[-1] == ')':


### PR DESCRIPTION
Egypt Sax analyser fails to update for 2 weeks with `413 Request Entity Too Large` as the postal code check [(class 31901)](https://github.com/osm-fr/osmose-backend/blob/master/plugins/TagFix_Postcode.py#L81) gives an enormous amount of results: [2.4M entries](https://overpass-turbo.eu/s/1JWV) for this specific class.

The origin is this change:
https://en.wikipedia.org/w/index.php?title=List_of_postal_codes&diff=1213919002&oldid=1211651055
This seems to be correct, see for instance: https://epostalmap.com/en/

However, a large amount of data on OSM still uses the old format (which according to that site is being phased out, but not unused).

I suspect we should just disable this check for now?