### PR TITLE
Add `diameter_crown`, `circumference` and `depth`

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -63,7 +63,7 @@ be used if the value is valid.''')
             resource = "https://wiki.openstreetmap.org/wiki/Map_features/Units"
         )
 
-        self.tag_number = ["diameter", "distance", "ele", "height", "length", "width"]
+        self.tag_number = ["diameter", "distance", "ele", "height", "length", "width", "diameter_crown", "circumference", "depth"]
         self.tag_number_integer = ["admin_level", "capital", "heritage", "population", "step_count"] # Only positive integers (no units) allowed
         tag_number_directional = ["maxaxleload", "maxheight", "maxheight:physical", "maxlength", "maxspeed", "maxspeed:advisory", "maxweight", "maxwidth", "minspeed"]
 


### PR DESCRIPTION
Add extra keys of which the value should follow the generic number format, e.g. `[number].[decimals][ optional unit]`.

This doesn't check if the values make sense (so doesn't fix issue 2200), it primarily just validates whether e.g. there's no `,` instead of `.` or so, and the value is actually numerical. The "do the values make sense" question affects a lot more cases worldwide so I'm first trying to include that into JOSM.