### PR TITLE
Vcub is rebranded to Le Vélo

### DIFF
--- a/analysers/analyser_merge_bicycle_rental_FR_bm.py
+++ b/analysers/analyser_merge_bicycle_rental_FR_bm.py
@@ -36,7 +36,7 @@ class Analyser_Merge_Bicycle_Rental_FR_bm(Analyser_Merge_Point):
 
         self.init(
             'https://opendata.bordeaux-metropole.fr/explore/dataset/ci_vcub_p',
-            'Station VCUB en temps réel',
+            'Station Le Vélo en temps réel',
             GeoJSON(SourceOpenDataSoft(
                 attribution="Bordeaux Métropole",
                 url="https://opendata.bordeaux-metropole.fr/explore/dataset/ci_vcub_p",
@@ -51,12 +51,14 @@ class Analyser_Merge_Bicycle_Rental_FR_bm(Analyser_Merge_Point):
                 mapping = Mapping(
                     static1 = {
                         "amenity": "bicycle_rental",
-                        "network": "VCUB",
+                        "bicycle_rental": "docking_station",
+                        "network": "Le Vélo",
+                        "operator": "TBM",
                         "vending": "subscription"},
                     static2 = {"source": self.source},
                     mapping1 = {
                         "ref": "ident",
                         # "capacity": lambda res: int(res["nbplaces"]) + int(res["nbvelos"]),
-                        "description": lambda res: "VCUB+" if res["type"] == "VLS+" else None},
+                    }
                     mapping2 = {
                         "name": "nom"} )))

--- a/analysers/analyser_merge_bicycle_rental_FR_bm.py
+++ b/analysers/analyser_merge_bicycle_rental_FR_bm.py
@@ -59,6 +59,6 @@ class Analyser_Merge_Bicycle_Rental_FR_bm(Analyser_Merge_Point):
                     mapping1 = {
                         "ref": "ident",
                         # "capacity": lambda res: int(res["nbplaces"]) + int(res["nbvelos"]),
-                    }
+                    },
                     mapping2 = {
                         "name": "nom"} )))


### PR DESCRIPTION
Vcub bicycle rental network was recently rebranded to [Le Vélo](https://www.infotbm.com/fr/actualites/le-velo-par-tbm.html).

changes:
- removed the description field since all sation accept standard and electric bikes
- add bicycle_rental=docking_station tag
- add operator TBM

no change:
- capacity still doesn't seems to be accurate