### PR TITLE
Remove workaround for kOpeningHours bug

### DIFF
--- a/plugins/ConditionalRestrictions.py
+++ b/plugins/ConditionalRestrictions.py
@@ -39,8 +39,6 @@ class ConditionalRestrictions(Plugin):
     self.ReWeekdayMonthOpeningH = re.compile(r'\b[A-Z][a-z]+') # i.e. Mar or Mo
     self.ReMonthDayOpeningH = re.compile(r'\w\w\w[\s-]\d') # i.e. sep 1
     self.ReTimeOpeningH = re.compile(r'\d\D[\d-]|sun[sr][ei][ts]') # i.e. 5:30 or 5h30 or 5h-8h
-    # Workaround https://bugs.kde.org/show_bug.cgi?id=452236
-    self.kOpeningHours452236 = re.compile(r'((?P<yyyy>20\d\d) [A-Z][a-z][a-z] \d\d?\s?-\s?)(?P=yyyy) ([A-Z][a-z][a-z] \d\d?)')
 
     self.getDuplicatesFromList = lambda lst: [x for x in set(lst) if lst.count(x) > 1]
 
@@ -201,7 +199,7 @@ Otherwise, remove the tag without `:conditional`.'''),
         for c in set(allANDsplittedConditions):
           # Validate time-based conditionals
           if self.isLikelyOpeningHourSyntax(c):
-            sanitized = self.sanitize_openinghours(self.kOpeningHours452236.sub(r"\1\3", c))
+            sanitized = self.sanitize_openinghours(c)
             if not sanitized['isValid']:
               if "fix" in sanitized:
                 err.append({"class": 33504, "subclass": 6 + stablehash64(tag + '|' + tag_value + '|' + c), "text": T_("Involves \"{0}\" in \"{1}\". Consider using \"{2}\"", c, tag, sanitized['fix'])})

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ transporthours
 pyproj >= 2.1.0
 Unidecode
 osmium >= 3.1.3
-git+https://invent.kde.org/libraries/kopeninghours.git@v24.01.90
+git+https://invent.kde.org/libraries/kopeninghours.git@v24.04.80
 git+https://github.com/jocelynj/PyEasyArchive.git
 protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geojson
 vt2geojson


### PR DESCRIPTION
The fix for the workaround has been included in v24.04.80
Fixes #2136

Although the workaround caught most issues, it still failed if there was another issue simultaneously.
For example, the fix suggestion for:
`2024 Mar 02-2024 Apr 08 Vr-Zo` (note: using Vr and Zo instead of Fr and Su) suggested:
`2024 Mar 02-Apr 08 Fr-Su` instead of
`2024 Mar 02-2024 Apr 08 Fr-Su`

This was because the workaround essentially just converted `2024 Mar 02-2024 Apr 08 Vr-Zo` to `2024 Mar 02-Apr 08 Vr-Zo` before feeding it to pyKOpeningHours, so that pyKOpeningHours wouldn't detect the (false positive) issue with the years. However, if there was a second issue simultaneously, this also meant that the fix suggestion included the bad year conversion.