### PR TITLE
Brest bike parking: add image URL

### DIFF
--- a/analysers/analyser_merge_bicycle_parking_FR_brest.py
+++ b/analysers/analyser_merge_bicycle_parking_FR_brest.py
@@ -60,6 +60,7 @@ class Analyser_Merge_Bicycle_Parking_FR_Brest(Analyser_Merge_Point):
                         "start_date": "DATE_POSE",
                         "covered": lambda res: self.covered.get(res.get("TYPE_STAT")),
                         "operator": lambda res: "Brest Métropole" if res.get("DOM_PRIVE") == "Public" else None,
+                        "image": lambda res: res.get("LIEN_IMAGE").replace('\\','/') if res.get("LIEN_IMAGE") else None,
                     })))
 
     covered = {


### PR DESCRIPTION
To both facilitate working through the list of "issues" and have the image in OSM. Got the confirmation from the Métropole that the URLs are stable and we're allowed to link them from OSM.

Tested locally with the docker image.