### PR TITLE
Exclude the node shared with the roundabout

### DIFF
--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -160,7 +160,7 @@ SELECT
     ways.id AS a_id,
     CASE
         WHEN ways.nodes[1] = ANY (roundabout.nodes) THEN ARRAY[ways.nodes[2], ways.nodes[3], ways.nodes[4]]
-        WHEN ways.nodes[array_length(ways.nodes,1)] = ANY (roundabout.nodes) THEN ARRAY[ways.nodes[array_length(ways.nodes,1)], ways.nodes[array_length(ways.nodes,1)-1], ways.nodes[array_length(ways.nodes,1)-2]]
+        WHEN ways.nodes[array_length(ways.nodes,1)] = ANY (roundabout.nodes) THEN ARRAY[ways.nodes[array_length(ways.nodes,1)-1], ways.nodes[array_length(ways.nodes,1)-2], ways.nodes[array_length(ways.nodes,1)-3]]
     END AS n_ids,
     ways.is_oneway
 FROM


### PR DESCRIPTION
See #2213 - fixes incorrectly reported "should be oneway" cases if ways joined at the roundabout.

The current behavior included the node on the roundabout itself for ways where the final node was the roundabout way.
Consequently, completely unrelated ways that only intersected at the roundabout were detected, thus giving a false warning about a required oneway tag.

It was already correct for ways in the reverse direction (e.g. line 162 in the code)

Asides from the way in the issue, it also fixes other very similar cases, like
https://www.openstreetmap.org/way/384256584
https://www.openstreetmap.org/way/141816760
https://www.openstreetmap.org/way/88823059

(And it adds cases where the intersection occurs at the now newly included node)

---

@frodrigo I find it odd that also the node is given as output geometry to the user (e.g. node 1630563193 in https://osmose.openstreetmap.fr/en/issue/e9e0aaaa-cf24-029f-2aff-a605b863c71e). I think it should only report the way, not? The node seems completely random.

---

As a future improvement, we should probably check for intersections in a certain way length, rather than at the first 3 nodes after the roundabout. Using the first 3 nodes makes it highly dependent on the level of mapping accuracy. If very accurate, 3 nodes may miss the intersection; if very poorly mapped, it may find cases where the ways are completely unrelated but simply join by coincident at some point.