### PR TITLE
Enable check on ways without `access` tag

### DIFF
--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -247,8 +247,8 @@ FROM
         roundabout.nodes && ways.nodes[2:array_length(ways.nodes,1)-1]
 WHERE
     NOT ways.is_construction AND
-    ways.highway NOT IN ('footway') AND
-    ways.tags->'access' NOT IN ('no', 'psv', 'private') AND
+    ways.highway NOT IN ('footway', 'path', 'busway', 'bus_guideway') AND
+    (NOT ways.tags?'access' OR ways.tags->'access' NOT IN ('no', 'psv', 'private')) AND
     NOT is_area
 """
 
@@ -348,6 +348,6 @@ class Test(TestAnalyserOsmosis):
         self.check_err(cl="2", elems=[("way", "1017")])
         self.check_err(cl="2", elems=[("way", "1018")])
         self.check_err(cl="3", elems=[("way", "1000")])
-        #self.check_err(cl="4", elems=[("way", "1000"), ("way", "1010")]) disabled until fix of #2219
+        self.check_err(cl="4", elems=[("way", "1000"), ("way", "1010")])
 
-        self.check_num_err(9)
+        self.check_num_err(10)


### PR DESCRIPTION
#2219

Previously this check only ran on ways explicitly tagged `access=yes` or similar `access=*`-tagged (`*`!= `psv`/`no`/`private`) highways. This was probably by mistake (nothing to suggest it was intended in [the commit which added it](https://github.com/osm-fr/osmose-backend/commit/27a170ec70ca8cea9732c82e31fb6fc88a02eb9f)). Hence enable for ways without explicit `access` tag.

Furthermore, whitelist `busway` and `bus_guideway` (access=no by default; I can understand they'd be permitted to cross roundabouts sometimes; and consistent with access=psv being allowed). Also whitelist `highway=path` (like `footway`, which is already permitted) as parks may exist within large roundabouts. Example with path: https://www.openstreetmap.org/way/16059651