### PR TITLE
add unsigned_ref to highway_without_ref tags

### DIFF
--- a/analysers/analyser_osmosis_highway_without_ref.py
+++ b/analysers/analyser_osmosis_highway_without_ref.py
@@ -34,10 +34,10 @@ FROM
     relation_members.member_id = ways.id
   LEFT JOIN relations ON
     relations.id = relation_members.relation_id AND
-    relations.tags ?| ARRAY['noref', 'ref', 'nat_ref', 'int_ref']
+    relations.tags ?| ARRAY['noref', 'ref', 'nat_ref', 'int_ref', 'unsigned_ref']
 WHERE
   ways.highway = 'motorway' AND
-  NOT ways.tags ?| ARRAY['noref', 'ref', 'nat_ref', 'int_ref'] AND
+  NOT ways.tags ?| ARRAY['noref', 'ref', 'nat_ref', 'int_ref', 'unsigned_ref'] AND
   relations.id IS NULL
 """
 


### PR DESCRIPTION
While uncommon, it is possible for a motorway to only have an `unsigned_ref` https://wiki.openstreetmap.org/wiki/Key:unsigned_ref, see https://www.openstreetmap.org/relation/1648091 and https://www.openstreetmap.org/relation/282102 for examples