### PR TITLE
Fix more than one location on overlapping highways

### DIFF
--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -193,6 +193,7 @@ FROM
         ra1.a_id != ra2.a_id
 WHERE
     ST_Intersects(ra1.connection_sublinestring, ra2.connection_sublinestring) AND
+    ST_NPoints(ST_Intersection(ra1.connection_sublinestring, ra2.connection_sublinestring)) = 1 AND
     NOT ra1.is_oneway
 ORDER BY
     ra1.a_id,

--- a/analysers/analyser_osmosis_roundabout_level.py
+++ b/analysers/analyser_osmosis_roundabout_level.py
@@ -185,7 +185,7 @@ CREATE INDEX roundabout_access_idx ON roundabout_access(ra_id)
 sql22 = """
 SELECT DISTINCT ON (ra1.a_id)
     ra1.a_id,
-    ST_AsText(ST_Intersection(ra1.connection_sublinestring, ra2.connection_sublinestring))
+    ST_AsText(ST_PointOnSurface(ST_Intersection(ra1.connection_sublinestring, ra2.connection_sublinestring))) -- see #2230: intersection can be multipoint or (with illegal overlap) even (multi)linestring
 FROM
     roundabout_access AS ra1
     JOIN roundabout_access AS ra2 ON
@@ -193,7 +193,6 @@ FROM
         ra1.a_id != ra2.a_id
 WHERE
     ST_Intersects(ra1.connection_sublinestring, ra2.connection_sublinestring) AND
-    ST_NPoints(ST_Intersection(ra1.connection_sublinestring, ra2.connection_sublinestring)) = 1 AND
     NOT ra1.is_oneway
 ORDER BY
     ra1.a_id,


### PR DESCRIPTION
Attempts to fix the issue reported by Tomas.

Cause:
- https://www.openstreetmap.org/way/145265140 and https://www.openstreetmap.org/way/1175247716 fully overlap
- This results in `ST_Intersection` to output a non-point geometry (can be linestring for complete overlaps, but also multipoint for ways that cross each-other more than at the connecting node)
- This gives multiple locations in the output:
```xml
<error class="2">
<way id="145265140" version="14" user="">
<tag k="lit" v="yes" />
<tag k="foot" v="private" />
<tag k="name" v="Injektorweg" />
<tag k="access" v="private" />
<tag k="source" v="gps" />
<tag k="highway" v="unclassified" />
<tag k="surface" v="asphalt" />
<tag k="maxspeed" v="5" />
<tag k="lane_markings" v="no" />
</way>
<location lat="53.57444925572931" lon="9.879802518076215" />
<location lat="53.574370900000005" lon="9.879850600000001" />
</error>
```
