### PR TITLE
Implement `to_short, to_int, to_long, to_float, to_double` mapcss functions

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -585,18 +585,43 @@ def tag_regex(tags, regex):
 
 #to_short(str)
 #    returns the string argument as a short [since r16110]
+def to_short(string):
+    try:
+        return int(string)
+    except:
+        return None
 
 #to_int(str)
 #    returns the string argument as a int [since r16110]
+def to_int(string):
+    try:
+        return int(string)
+    except:
+        return None
 
 #to_long(str)
 #    returns the string argument as a long [since r16110]
+def to_long(string):
+    try:
+        return int(string)
+    except:
+        return None
 
 #to_float(str)
 #    returns the string argument as a float [since r16110]
+def to_float(string):
+    try:
+        return float(string)
+    except:
+        return None
 
 #to_double(str)
 #    returns the string argument as a double [since r16110]
+def to_double(string):
+    try:
+        return float(string)
+    except:
+        return None
 
 #uniq(str1, str2, str3, ...)
 #    returns a list of strings that only have unique values from an array of strings [since r15323]

--- a/plugins/tests/test_mapcss_parsing_evaluation.py
+++ b/plugins/tests/test_mapcss_parsing_evaluation.py
@@ -727,6 +727,30 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"node x=\"It\\\\'s working\""
                 err.append({'class': 14, 'subclass': 1474979323, 'text': mapcss.tr('test #2236 - {0} {1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{0.value}'))})
 
+        # node[to_int("-3")+to_short("4")*to_long("2")=5]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.to_int('-3')+mapcss.to_short('4')*mapcss.to_long('2') == 5))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertMatch:"node x=y"
+                err.append({'class': 6, 'subclass': 560627145, 'text': {'en': 'test'}})
+
+        # node[to_float("3.14e1")=31.4][to_double("3.1415e1")=31.415]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.to_float('3.14e1') == 31.4) and (mapcss.to_double('3.1415e1') == 31.415))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertMatch:"node x=y"
+                err.append({'class': 6, 'subclass': 931844076, 'text': {'en': 'test'}})
+
         return err
 
     def way(self, data, tags, nds):
@@ -1468,6 +1492,8 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'x': 'd'}), expected={'class': 14, 'subclass': 877576641})
         self.check_not_err(n.node(data, {'x': 'It\'s working'}), expected={'class': 14, 'subclass': 1474979323})
         self.check_err(n.node(data, {'x': 'It\\\\\'s working'}), expected={'class': 14, 'subclass': 1474979323})
+        self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 560627145})
+        self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 931844076})
         self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 15, 'subclass': 1785050832})
         self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 15, 'subclass': 1785050832})
         self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 15, 'subclass': 1785050832})

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -551,3 +551,13 @@ node[x!~/It's\sworking/] {
   assertMatch: "node x=\"It\\\\'s working\"";
   assertNoMatch: "node x=\"It's working\"";
 }
+
+node[to_int("-3") + to_short("4") * to_long("2") = 5] {
+  throwWarning: "test";
+  assertMatch: "node x=y";
+}
+
+node[to_float("3.14e1") = 31.4][to_double("3.1415e1") = 31.415] {
+  throwWarning: "test";
+  assertMatch: "node x=y";
+}


### PR DESCRIPTION
Implement `to_short, to_int, to_long, to_float, to_double` mapcss functions

Thereby I'm neglecting the precision, since Python doesn't really differentiate between short/int/long or float/double.

Note that JOSM throws an exception rather than None (null) for the numeric conversions when they are impossible. E.g. `to_int(3.14)` in JOSM gives `Cannot add MapCSS rule: java.lang.NumberFormatException: For input string: "3.14"`.

Although not in use by rules in Osmose right now, it's for example used in https://josm.openstreetmap.de/wiki/Rules/Runways and I proposed it (without realizing it wasn't implemented) in one of the comments of issue 2200.
