### PR TITLE
Limit Spanish to Iberian Spain (=the country Spain)

### DIFF
--- a/plugins/Name_UpperCaseNumber.py
+++ b/plugins/Name_UpperCaseNumber.py
@@ -25,7 +25,7 @@ from plugins.Plugin import Plugin
 
 class Name_UpperCaseNumber(Plugin):
 
-    only_for = ["fr", "es", "it", "pt"]
+    only_for = ["fr", "ES", "it", "pt"] # languages fr, it, pt worldwide, Spanish (es) only for Iberian Spain (ES), hence country code
 
     def init(self, logger):
         Plugin.init(self, logger)


### PR DESCRIPTION
See #2254

Limit the check for the Spanish language to Iberian Spain only.
This also matches what [Wikipedia](https://en.wikipedia.org/wiki/Numero_sign#Spanish) says for the symbol in the Spanish language

This patch changes it from:
`languages=fr,es,it,pt`
to 
`languages=fr,it,pt` or `country=ES`

(Untested)
It'll probably require manual clearing of the results for South-America