### PR TITLE
Implement `siunit_length` mapcss function

### DIFF
--- a/plugins/tests/test_mapcss_parsing_evaluation.py
+++ b/plugins/tests/test_mapcss_parsing_evaluation.py
@@ -27,15 +27,16 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
         self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test concat {0}', mapcss.concat(mapcss.tag(tags, 'b'), mapcss.tag(tags, 'c'))))
         self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test regexp_match'})
         self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #2236 - {0} {1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{0.value}')))
-        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
-        self.errors[16] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[17] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
-        self.errors[18] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
-        self.errors[19] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
-        self.errors[20] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[21] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[22] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[23] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
+        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length'))))
+        self.errors[16] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
+        self.errors[17] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[18] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
+        self.errors[19] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
+        self.errors[20] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
+        self.errors[21] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[22] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[23] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[24] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
         self.errors[96] = self.def_class(item = 4, level = 3, tags = [], title = mapcss.tr('I support supports {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
         self.errors[97] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
         self.errors[98] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
@@ -751,6 +752,45 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"node x=y"
                 err.append({'class': 6, 'subclass': 931844076, 'text': {'en': 'test'}})
 
+        # node[tag_length][siunit_length(tag(tag_length))=="1.2"]
+        if ('tag_length' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'tag_length')) and (mapcss.siunit_length(mapcss.tag(tags, 'tag_length')) == '1.2'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test unit conversion {0} -> {1}","{0.value}",siunit_length(tag(tag_length)))
+                # assertMatch:"node tag_length=1.2"
+                err.append({'class': 15, 'subclass': 1907035839, 'text': mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length')))})
+
+        # node[tag_length][siunit_length(tag(tag_length))==tag(b)]
+        if ('tag_length' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'tag_length')) and (mapcss.siunit_length(mapcss.tag(tags, 'tag_length')) == mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test unit conversion {0} -> {1}","{0.value}",siunit_length(tag(tag_length)))
+                # assertMatch:"node tag_length=20'          b=6.096"
+                # assertMatch:"node tag_length=\"  1,3 m \" b=1.3"
+                # assertMatch:"node tag_length=\"10ft 1in\" b=3.0734"
+                # assertMatch:"node tag_length=-1.8km       b=-1800.0"
+                # assertMatch:"node tag_length=-20'2\"      b=-6.1468"
+                # assertMatch:"node tag_length=1.4m         b=1.4"
+                # assertMatch:"node tag_length=1.7km        b=1700.0"
+                # assertMatch:"node tag_length=100in        b=2.54"
+                # assertMatch:"node tag_length=10ft         b=3.048"
+                # assertMatch:"node tag_length=150cm        b=1.5"
+                # assertMatch:"node tag_length=1600.0mm     b=1.6"
+                # assertMatch:"node tag_length=1mi          b=1609.344"
+                # assertMatch:"node tag_length=1nmi         b=1852.0"
+                # assertMatch:"node tag_length=200\"        b=5.08"
+                # assertMatch:"node tag_length=20'2\"       b=6.1468"
+                # assertNoMatch:"node tag_length=Hello      b=0.0"
+                err.append({'class': 15, 'subclass': 208420761, 'text': mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length')))})
+
         return err
 
     def way(self, data, tags, nds):
@@ -771,7 +811,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way x=C00;C1;C22"
                 # assertMatch:"way x=C1"
                 # assertNoMatch:"way x=C12"
-                err.append({'class': 15, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
+                err.append({'class': 16, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
 
         # way:righthandtraffic[x=y][z?]
         if ('x' in keys and 'z' in keys):
@@ -783,7 +823,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{1.tag}","{2.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 16, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
+                err.append({'class': 17, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
 
         # way[x=y][z?]:righthandtraffic
         if ('x' in keys and 'z' in keys):
@@ -795,7 +835,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{0.tag}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 16, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 17, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
         if ('parking' in keys):
@@ -861,7 +901,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # throwWarning:tr("test righthandtraffic")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 17, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
+                err.append({'class': 18, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
 
         # way!:righthandtraffic
         if True:
@@ -874,7 +914,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # throwWarning:tr("test lefthandtraffic")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 18, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
+                err.append({'class': 19, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
 
         # way[count(uniq_list(tag_regex("abc")))==2]
         if True:
@@ -920,7 +960,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way oneway=no"
                 # assertMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 19, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 20, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[oneway?!]
         if ('oneway' in keys):
@@ -935,7 +975,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way oneway=no"
                 # assertNoMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 19, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 20, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -950,7 +990,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=Westminster x=yes"
                 # assertMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 20, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 21, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -965,7 +1005,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way amenity=place_of_worship building=chapel name=Westminster x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 21, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 22, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[inside(FR)][x]
         if ('x' in keys):
@@ -977,7 +1017,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1742 - {0}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y","inside=FR")
-                err.append({'class': 22, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 23, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[a][a=*b]
         if ('a' in keys):
@@ -1059,7 +1099,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way maxspeed=5000"
                 # assertNoMatch:"way maxspeed=default"
                 # assertNoMatch:"way"
-                err.append({'class': 23, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+                err.append({'class': 24, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
 
         # way[tag(a)>tag(b)]
         if True:
@@ -1494,25 +1534,42 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'x': 'It\\\\\'s working'}), expected={'class': 14, 'subclass': 1474979323})
         self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 560627145})
         self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 931844076})
-        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 15, 'subclass': 1785050832})
-        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 15, 'subclass': 1785050832})
-        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 15, 'subclass': 1785050832})
+        self.check_err(n.node(data, {'tag_length': '1.2'}), expected={'class': 15, 'subclass': 1907035839})
+        self.check_err(n.node(data, {'b': '6.096', 'tag_length': '20\''}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.3', 'tag_length': '  1,3 m '}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '3.0734', 'tag_length': '10ft 1in'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '-1800.0', 'tag_length': '-1.8km'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '-6.1468', 'tag_length': '-20\'2"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.4', 'tag_length': '1.4m'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1700.0', 'tag_length': '1.7km'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '2.54', 'tag_length': '100in'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '3.048', 'tag_length': '10ft'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.5', 'tag_length': '150cm'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.6', 'tag_length': '1600.0mm'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1609.344', 'tag_length': '1mi'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1852.0', 'tag_length': '1nmi'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '5.08', 'tag_length': '200"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '6.1468', 'tag_length': '20\'2"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_not_err(n.node(data, {'b': '0.0', 'tag_length': 'Hello'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 16, 'subclass': 1785050832})
+        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 16, 'subclass': 1785050832})
+        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 16, 'subclass': 169712264})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 17, 'subclass': 169712264})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 16, 'subclass': 2074848923})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 17, 'subclass': 2074848923})
         self.check_not_err(n.way(data, {'a': 'b', 'c': 'd'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'a': 'b'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_not_err(n.way(data, {'b': 'a', 'd': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'b': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 17, 'subclass': 529680562})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 17, 'subclass': 529680562})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 877255184})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 19, 'subclass': 877255184})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 877255184})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 19, 'subclass': 877255184})
         self.check_not_err(n.way(data, {'abc': 'def', 'abcdef': 'def'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
@@ -1521,33 +1578,33 @@ class Test(TestPluginMapcss):
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_not_err(n.way(data, {'abc': 'def', 'def': 'def'}, [0]), expected={'class': 6, 'subclass': 57938147})
-        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
+        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
         with with_options(n, {'country': 'FR'}):
-            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 22, 'subclass': 1132689531})
+            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 23, 'subclass': 1132689531})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
-        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {}, [0]), expected={'class': 23, 'subclass': 2063115534})
+        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {}, [0]), expected={'class': 24, 'subclass': 2063115534})
         self.check_not_err(n.way(data, {'a': '0', 'b': '1'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_not_err(n.way(data, {'a': '0', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_err(n.way(data, {'a': '1', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -561,3 +561,27 @@ node[to_float("3.14e1") = 31.4][to_double("3.1415e1") = 31.415] {
   throwWarning: "test";
   assertMatch: "node x=y";
 }
+
+node[tag_length][siunit_length(tag(tag_length)) == "1.2"] {
+  throwWarning: tr("test unit conversion {0} -> {1}", "{0.value}", siunit_length(tag(tag_length)));
+  assertMatch: "node tag_length=1.2";
+}
+node[tag_length][siunit_length(tag(tag_length)) == tag(b)] {
+  throwWarning: tr("test unit conversion {0} -> {1}", "{0.value}", siunit_length(tag(tag_length)));
+  assertMatch: "node tag_length=\"  1,3 m \" b=1.3";
+  assertMatch: "node tag_length=1.4m         b=1.4";
+  assertMatch: "node tag_length=150cm        b=1.5";
+  assertMatch: "node tag_length=1600.0mm     b=1.6";
+  assertMatch: "node tag_length=1.7km        b=1700.0";
+  assertMatch: "node tag_length=-1.8km       b=-1800.0";
+  assertMatch: "node tag_length=10ft         b=3.048";
+  assertMatch: "node tag_length=20'          b=6.096";
+  assertMatch: "node tag_length=100in        b=2.54";
+  assertMatch: "node tag_length=200\"        b=5.08";
+  assertMatch: "node tag_length=1nmi         b=1852.0";
+  assertMatch: "node tag_length=1mi          b=1609.344";
+  assertMatch: "node tag_length=\"10ft 1in\" b=3.0734";
+  assertMatch: "node tag_length=20'2\"       b=6.1468";
+  assertMatch: "node tag_length=-20'2\"      b=-6.1468";
+  assertNoMatch: "node tag_length=Hello      b=0.0";
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geo
 vt2geojson
 tiletanic
 sentry-sdk
+pint
 
 # Tests
 pytest


### PR DESCRIPTION
Implements the new `siunit_length` mapcss function.

Rules using this function were [added in the JOSM mapcss rules today](https://josm.openstreetmap.de/changeset?old_path=%2Fjosm&old=19129&new_path=%2Fjosm&new=19129).
(If desired I can update the mapcss rules in this PR)

I'm using Pint for the unit conversions. Pint would also be useful for #2251 (as suggested by @jocelynj) and probably other places as well (plugin Number.py for example). 