### PR TITLE
Implement `siunit_length(str)` mapcss function

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -2,6 +2,7 @@
 from urllib.parse import unquote
 import re
 from modules.OsmoseTranslation import T_
+from plugins.modules.units import convertToUnit
 
 # Utils
 
@@ -631,6 +632,21 @@ def to_double(string):
 def uniq_list(l):
     return set(l)
 
+# siunit_length(str)
+#    convert length units to meter (fault tolerant, ignoring white space)
+def siunit_length(string):
+    if not string:
+        return None_value
+    string = string.replace(',', '.', 1).replace(' ', '')
+    try:
+        val = convertToUnit(string, 'm')
+        if val is None:
+            return None_value
+        if not 'e' in str(val): # Not sure how to deal with 10^x numbers, but they're rare. Just leave them as is
+            val = round(val, 5) # Round to avoid Python float precision limitation giving numbers with decimals 0000001 or 999998 or so
+        return str_value(val)
+    except:
+        return None_value
 
 # Other functions
 

--- a/plugins/modules/units.py
+++ b/plugins/modules/units.py
@@ -1,0 +1,110 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose project 2024                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+
+# This module file contains functions to read and convert numbers with units
+
+import re
+
+_ftin_re = re.compile("^(-?)(?:(\\d+(?:\\.\\d+)?)(ft|')) ?(?:(\\d+(?:\\.\\d+)?)(in|\"))$") # Regex for combined feet/inch measures
+_numunit_re = re.compile(r"^(-?\d+(?:\.\d+)?) ?(\D.*)?$") # Regex for any number followed by an optional unit
+_si_prefixes = {
+    "n": 1E-9, "u": 1E-6, "µ": 1E-6, "m": 0.001, "c": 0.01, "d": 0.1, "da": 10, "h": 100, "k": 1000, "M": 1E6, "G": 1E9, "T": 1E12,
+    "nano": 1E-9, "micro": 1E-6, "milli": 0.001, "centi": 0.01, "deci": 0.1, "deca": 10, "hecto": 100, "kilo": 1000, "mega": 1E6, "giga": 1E9, "tera": 1E12,
+}
+
+
+# Converts strings that contain a number with a unit to a dict of {"value": float, "unit": string}
+# Input:
+#   string: the string to parse, e.g. "22.4 km"
+#   defaultUnit: the unit if not specified (default: None)
+# Returns:
+#   None if conversion isn't possible
+#   Otherwise a dict with keys:
+#       value [float] - the number in the string
+#       unit [string or None] - the unit
+# For a string with multiple numbers/units, it converts it to a float of the largest unit (e.g. 3'4" becomes 3.33 ft)
+def parseNumberUnitString(string, defaultUnit = None):
+    if not string or not isinstance(string, str):
+        return None
+    string = string.strip()
+
+    # Combined units: feet and inch
+    m = re.fullmatch(_ftin_re, string)
+    if m:
+        return {
+            "value": float(m.group(1) + m.group(2)) + float(m.group(1) + m.group(4))/12,
+            "unit": "ft"
+        }
+    # Regular numbers with optional unit
+    m = re.fullmatch(_numunit_re, string)
+    if m:
+        return {
+            "value": float(m.group(1)),
+            "unit": m.group(2) or defaultUnit
+        }
+    # Not a numerical value
+    return None
+
+
+# Converts a number in arbitrary units to the default unit
+# Input:
+#   x: either a string with a number + optional unit to parse, or a dict with value:[float] and unit:[string] keys
+#   convertTo: the unit to convert the x-input to (the abbreviation)
+#   If x is a string without unit, it assumes the default unit equals the unit of convertTo
+# Returns:
+#   None if the input was None or the string couldn't be parsed into a number + optional unit
+#   The value [float] converted to convertTo units otherwise
+# Throws:
+#   If conversion wasn't possible
+def convertToUnit(x, convertTo):
+    if not isinstance(x, dict):
+        # String input, extract value and unit
+        x = parseNumberUnitString(x, convertTo)
+    if not x:
+        return None
+    if x["unit"] == convertTo:
+        return x["value"]
+
+    # Length based conversions
+    if convertTo == "m": # default for range, height, length
+        if x["unit"] in ('ft', "'", 'foot', 'feet'):
+            return x["value"] * 0.3048
+        if x["unit"] in ('in', '"', 'inch', 'inches'):
+            return x["value"] * 0.0254
+        if x["unit"] == 'nmi':
+            return x["value"] * 1852
+        if x["unit"] in ('mi', 'mile', 'miles'):
+            return x["value"] * 1609.344
+        if x["unit"].replace('meters', 'meter', 1).endswith('meter'):
+            return convertToUnit({"value": x["value"], "unit": x["unit"].rstrip("s")[0:-4]}, 'm')
+        if x["unit"].endswith('m'):
+            prefix = x["unit"][0:-1]
+            if prefix in _si_prefixes:
+                return x["value"] * _si_prefixes[prefix]
+    if convertTo == "mm": # default for length (small scale)
+        return convertToUnit(x, 'm') / _si_prefixes['milli']
+    if convertTo == "km": # default for distance over land
+        return convertToUnit(x, 'm') / _si_prefixes['kilo']
+    if convertTo == "nmi": # default for distance over water
+        return convertToUnit(x, 'm') / 1852
+
+    raise NotImplementedError("Unknown conversion: {0} to {1}".format(str(x), convertTo))

--- a/plugins/tests/test_mapcss_parsing_evaluation.py
+++ b/plugins/tests/test_mapcss_parsing_evaluation.py
@@ -27,15 +27,16 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
         self.errors[12] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test concat {0}', mapcss.concat(mapcss.tag(tags, 'b'), mapcss.tag(tags, 'c'))))
         self.errors[13] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test regexp_match'})
         self.errors[14] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #2236 - {0} {1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{0.value}')))
-        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
-        self.errors[16] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[17] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
-        self.errors[18] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
-        self.errors[19] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
-        self.errors[20] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[21] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[22] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
-        self.errors[23] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
+        self.errors[15] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length'))))
+        self.errors[16] = self.def_class(item = 0, level = 3, tags = [], title = {'en': 'test #1610'})
+        self.errors[17] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[18] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test righthandtraffic'))
+        self.errors[19] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test lefthandtraffic'))
+        self.errors[20] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
+        self.errors[21] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[22] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}')))
+        self.errors[23] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}')))
+        self.errors[24] = self.def_class(item = 0, level = 3, tags = [], title = mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}')))
         self.errors[96] = self.def_class(item = 4, level = 3, tags = [], title = mapcss.tr('I support supports {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}')))
         self.errors[97] = self.def_class(item = 4, level = 1, tags = mapcss.list_('osmose_rules'), title = mapcss.tr('test'), trap = mapcss.tr('Don\'t do this!'), detail = mapcss.tr('More {0}.', '`info`'), example = {"en": 'Look at me, I haven\'t lost my apostrophe'}, fix = {"en": 'This may fix it.'}, resource = 'https://wiki.openstreetmap.org/wiki/Useful_Page')
         self.errors[98] = self.def_class(item = 4030, level = 2, tags = mapcss.list_('fix:survey'), title = {'en': 'test #1740'})
@@ -751,6 +752,63 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"node x=y"
                 err.append({'class': 6, 'subclass': 931844076, 'text': {'en': 'test'}})
 
+        # node[tag_length][siunit_length(tag(tag_length))=="1.2"]
+        if ('tag_length' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'tag_length')) and (mapcss.siunit_length(mapcss.tag(tags, 'tag_length')) == '1.2'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test unit conversion {0} -> {1}","{0.value}",siunit_length(tag(tag_length)))
+                # assertMatch:"node tag_length=1.2"
+                err.append({'class': 15, 'subclass': 1907035839, 'text': mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length')))})
+
+        # node[tag_length][siunit_length(tag(tag_length))==tag(b)]
+        if ('tag_length' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'tag_length')) and (mapcss.siunit_length(mapcss.tag(tags, 'tag_length')) == mapcss.tag(tags, 'b')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:tr("test unit conversion {0} -> {1}","{0.value}",siunit_length(tag(tag_length)))
+                # assertMatch:"node tag_length=20'          b=6.096"
+                # assertMatch:"node tag_length=\"  1,3 m \" b=1.3"
+                # assertMatch:"node tag_length=\"1 300 m\"  b=1300.0"
+                # assertMatch:"node tag_length=\"10ft 1in\" b=3.0734"
+                # assertMatch:"node tag_length=-1.8km       b=-1800.0"
+                # assertMatch:"node tag_length=-20'2\"      b=-6.1468"
+                # assertMatch:"node tag_length=1.4m         b=1.4"
+                # assertMatch:"node tag_length=1.4meter     b=1.4"
+                # assertMatch:"node tag_length=1.7kilometer b=1700.0"
+                # assertMatch:"node tag_length=1.7km        b=1700.0"
+                # assertMatch:"node tag_length=100in        b=2.54"
+                # assertMatch:"node tag_length=10ft         b=3.048"
+                # assertMatch:"node tag_length=150cm        b=1.5"
+                # assertMatch:"node tag_length=1600.0mm     b=1.6"
+                # assertMatch:"node tag_length=1mi          b=1609.344"
+                # assertMatch:"node tag_length=1nmi         b=1852.0"
+                # assertMatch:"node tag_length=200\"        b=5.08"
+                # assertMatch:"node tag_length=20'2\"       b=6.1468"
+                err.append({'class': 15, 'subclass': 208420761, 'text': mapcss.tr('test unit conversion {0} -> {1}', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss.siunit_length(mapcss.tag(tags, 'tag_length')))})
+
+        # node[any(siunit_length(tag(x)),"no result")=="no result"]
+        if True:
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss.any_(mapcss.siunit_length(mapcss.tag(tags, 'x')), 'no result') == 'no result'))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # assertMatch:"node x=\"23 elephants\""
+                # assertMatch:"node x=1.3.5"
+                # assertMatch:"node x=4-5m"
+                # assertMatch:"node x=5m*3"
+                # assertMatch:"node x=Hello"
+                err.append({'class': 6, 'subclass': 72306003, 'text': {'en': 'test'}})
+
         return err
 
     def way(self, data, tags, nds):
@@ -771,7 +829,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way x=C00;C1;C22"
                 # assertMatch:"way x=C1"
                 # assertNoMatch:"way x=C12"
-                err.append({'class': 15, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
+                err.append({'class': 16, 'subclass': 1785050832, 'text': {'en': 'test #1610'}})
 
         # way:righthandtraffic[x=y][z?]
         if ('x' in keys and 'z' in keys):
@@ -783,7 +841,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{1.tag}","{2.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 16, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
+                err.append({'class': 17, 'subclass': 169712264, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{1.tag}'), mapcss._tag_uncapture(capture_tags, '{2.tag}'))})
 
         # way[x=y][z?]:righthandtraffic
         if ('x' in keys and 'z' in keys):
@@ -795,7 +853,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1603 - {0}{1}","{0.tag}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y z=yes","inside=NL")
-                err.append({'class': 16, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 17, 'subclass': 2074848923, 'text': mapcss.tr('test #1603 - {0}{1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[parking][amenity!~/^(parking|motorcycle_parking)$/]
         if ('parking' in keys):
@@ -861,7 +919,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # throwWarning:tr("test righthandtraffic")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 17, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
+                err.append({'class': 18, 'subclass': 529680562, 'text': mapcss.tr('test righthandtraffic')})
 
         # way!:righthandtraffic
         if True:
@@ -874,7 +932,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # throwWarning:tr("test lefthandtraffic")
                 # -osmoseAssertMatchWithContext:list("way","driving_side=left")
                 # -osmoseAssertNoMatchWithContext:list("way","driving_side=right")
-                err.append({'class': 18, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
+                err.append({'class': 19, 'subclass': 877255184, 'text': mapcss.tr('test lefthandtraffic')})
 
         # way[count(uniq_list(tag_regex("abc")))==2]
         if True:
@@ -920,7 +978,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way oneway=no"
                 # assertMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 19, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 20, 'subclass': 1489464739, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[oneway?!]
         if ('oneway' in keys):
@@ -935,7 +993,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way oneway=no"
                 # assertNoMatch:"way oneway=yes"
                 # assertNoMatch:"way x=y"
-                err.append({'class': 19, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
+                err.append({'class': 20, 'subclass': 722694187, 'text': mapcss.tr('test {0}', mapcss._tag_uncapture(capture_tags, '{0.tag}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"||tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -950,7 +1008,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=Westminster x=yes"
                 # assertMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 20, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 21, 'subclass': 1095325051, 'text': mapcss.tr('test #1303, #1742 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[name*=Trigger][tag("building")=="chapel"&&tag("amenity")=="place_of_worship"][x]
         if ('name' in keys and 'x' in keys):
@@ -965,7 +1023,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way amenity=place_of_worship building=chapel name=Westminster x=yes"
                 # assertNoMatch:"way amenity=place_of_worship name=OsmoseRuleTrigger x=yes"
                 # assertNoMatch:"way building=chapel name=OsmoseRuleTrigger x=yes"
-                err.append({'class': 21, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
+                err.append({'class': 22, 'subclass': 1140742172, 'text': mapcss.tr('test #1303 {0}', mapcss._tag_uncapture(capture_tags, '{2.key}'))})
 
         # way[inside(FR)][x]
         if ('x' in keys):
@@ -977,7 +1035,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
             if match:
                 # throwWarning:tr("test #1742 - {0}","{1.tag}")
                 # -osmoseAssertMatchWithContext:list("way x=y","inside=FR")
-                err.append({'class': 22, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
+                err.append({'class': 23, 'subclass': 1132689531, 'text': mapcss.tr('test #1742 - {0}', mapcss._tag_uncapture(capture_tags, '{1.tag}'))})
 
         # *[a][a=*b]
         if ('a' in keys):
@@ -1059,7 +1117,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertNoMatch:"way maxspeed=5000"
                 # assertNoMatch:"way maxspeed=default"
                 # assertNoMatch:"way"
-                err.append({'class': 23, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
+                err.append({'class': 24, 'subclass': 2063115534, 'text': mapcss.tr('test {0}{1}', 'text', mapcss._tag_uncapture(capture_tags, '{0.key}'))})
 
         # way[tag(a)>tag(b)]
         if True:
@@ -1494,25 +1552,49 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'x': 'It\\\\\'s working'}), expected={'class': 14, 'subclass': 1474979323})
         self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 560627145})
         self.check_err(n.node(data, {'x': 'y'}), expected={'class': 6, 'subclass': 931844076})
-        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 15, 'subclass': 1785050832})
-        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 15, 'subclass': 1785050832})
-        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 15, 'subclass': 1785050832})
+        self.check_err(n.node(data, {'tag_length': '1.2'}), expected={'class': 15, 'subclass': 1907035839})
+        self.check_err(n.node(data, {'b': '6.096', 'tag_length': '20\''}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.3', 'tag_length': '  1,3 m '}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1300.0', 'tag_length': '1 300 m'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '3.0734', 'tag_length': '10ft 1in'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '-1800.0', 'tag_length': '-1.8km'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '-6.1468', 'tag_length': '-20\'2"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.4', 'tag_length': '1.4m'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.4', 'tag_length': '1.4meter'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1700.0', 'tag_length': '1.7kilometer'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1700.0', 'tag_length': '1.7km'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '2.54', 'tag_length': '100in'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '3.048', 'tag_length': '10ft'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.5', 'tag_length': '150cm'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1.6', 'tag_length': '1600.0mm'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1609.344', 'tag_length': '1mi'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '1852.0', 'tag_length': '1nmi'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '5.08', 'tag_length': '200"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'b': '6.1468', 'tag_length': '20\'2"'}), expected={'class': 15, 'subclass': 208420761})
+        self.check_err(n.node(data, {'x': '23 elephants'}), expected={'class': 6, 'subclass': 72306003})
+        self.check_err(n.node(data, {'x': '1.3.5'}), expected={'class': 6, 'subclass': 72306003})
+        self.check_err(n.node(data, {'x': '4-5m'}), expected={'class': 6, 'subclass': 72306003})
+        self.check_err(n.node(data, {'x': '5m*3'}), expected={'class': 6, 'subclass': 72306003})
+        self.check_err(n.node(data, {'x': 'Hello'}), expected={'class': 6, 'subclass': 72306003})
+        self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 16, 'subclass': 1785050832})
+        self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 16, 'subclass': 1785050832})
+        self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 16, 'subclass': 169712264})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 17, 'subclass': 169712264})
         with with_options(n, {'country': 'NL'}):
-            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 16, 'subclass': 2074848923})
+            self.check_err(n.way(data, {'x': 'y', 'z': 'yes'}, [0]), expected={'class': 17, 'subclass': 2074848923})
         self.check_not_err(n.way(data, {'a': 'b', 'c': 'd'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'a': 'b'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_not_err(n.way(data, {'b': 'a', 'd': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         self.check_err(n.way(data, {'b': 'c'}, [0]), expected={'class': 3, 'subclass': 1004069731})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 17, 'subclass': 529680562})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 17, 'subclass': 529680562})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 529680562})
         with with_options(n, {'driving_side': 'left'}):
-            self.check_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 877255184})
+            self.check_err(n.way(data, {}, [0]), expected={'class': 19, 'subclass': 877255184})
         with with_options(n, {'driving_side': 'right'}):
-            self.check_not_err(n.way(data, {}, [0]), expected={'class': 18, 'subclass': 877255184})
+            self.check_not_err(n.way(data, {}, [0]), expected={'class': 19, 'subclass': 877255184})
         self.check_not_err(n.way(data, {'abc': 'def', 'abcdef': 'def'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 346020981})
@@ -1521,33 +1603,33 @@ class Test(TestPluginMapcss):
         self.check_err(n.way(data, {'abc': 'def', 'abcd': 'ghi', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_err(n.way(data, {'abc': 'def', 'abcdef': 'ghi'}, [0]), expected={'class': 6, 'subclass': 57938147})
         self.check_not_err(n.way(data, {'abc': 'def', 'def': 'def'}, [0]), expected={'class': 6, 'subclass': 57938147})
-        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 19, 'subclass': 1489464739})
-        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 19, 'subclass': 722694187})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 20, 'subclass': 1095325051})
-        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
-        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1140742172})
+        self.check_err(n.way(data, {'oneway': '1'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': '4.0'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 20, 'subclass': 1489464739})
+        self.check_err(n.way(data, {'oneway': '0'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_err(n.way(data, {'oneway': 'no'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'oneway': 'yes'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_not_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 20, 'subclass': 722694187})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 21, 'subclass': 1095325051})
+        self.check_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'building': 'chapel', 'name': 'Westminster', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'amenity': 'place_of_worship', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
+        self.check_not_err(n.way(data, {'building': 'chapel', 'name': 'OsmoseRuleTrigger', 'x': 'yes'}, [0]), expected={'class': 22, 'subclass': 1140742172})
         with with_options(n, {'country': 'FR'}):
-            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 22, 'subclass': 1132689531})
+            self.check_err(n.way(data, {'x': 'y'}, [0]), expected={'class': 23, 'subclass': 1132689531})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 97, 'subclass': 2})
         self.check_err(n.way(data, {'x': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
         self.check_not_err(n.way(data, {'y': 'yes'}, [0]), expected={'class': 99, 'subclass': 2})
-        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 23, 'subclass': 2063115534})
-        self.check_not_err(n.way(data, {}, [0]), expected={'class': 23, 'subclass': 2063115534})
+        self.check_err(n.way(data, {'maxspeed': '10000'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': '5000'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {'maxspeed': 'default'}, [0]), expected={'class': 24, 'subclass': 2063115534})
+        self.check_not_err(n.way(data, {}, [0]), expected={'class': 24, 'subclass': 2063115534})
         self.check_not_err(n.way(data, {'a': '0', 'b': '1'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_not_err(n.way(data, {'a': '0', 'b': 'yes'}, [0]), expected={'class': 6, 'subclass': 384294833})
         self.check_err(n.way(data, {'a': '1', 'b': '0'}, [0]), expected={'class': 6, 'subclass': 384294833})

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -561,3 +561,37 @@ node[to_float("3.14e1") = 31.4][to_double("3.1415e1") = 31.415] {
   throwWarning: "test";
   assertMatch: "node x=y";
 }
+
+node[tag_length][siunit_length(tag(tag_length)) == "1.2"] {
+  throwWarning: tr("test unit conversion {0} -> {1}", "{0.value}", siunit_length(tag(tag_length)));
+  assertMatch: "node tag_length=1.2";
+}
+node[tag_length][siunit_length(tag(tag_length)) == tag(b)] {
+  throwWarning: tr("test unit conversion {0} -> {1}", "{0.value}", siunit_length(tag(tag_length)));
+  assertMatch: "node tag_length=\"  1,3 m \" b=1.3"; /* JOSM permits spaces and converts all , to . */
+  assertMatch: "node tag_length=\"1 300 m\"  b=1300.0"; /* JOSM permits spaces and converts all , to . */
+  assertMatch: "node tag_length=1.4m         b=1.4";
+  assertMatch: "node tag_length=1.4meter     b=1.4";
+  assertMatch: "node tag_length=150cm        b=1.5";
+  assertMatch: "node tag_length=1600.0mm     b=1.6";
+  assertMatch: "node tag_length=1.7km        b=1700.0";
+  assertMatch: "node tag_length=1.7kilometer b=1700.0";
+  assertMatch: "node tag_length=-1.8km       b=-1800.0";
+  assertMatch: "node tag_length=10ft         b=3.048";
+  assertMatch: "node tag_length=20'          b=6.096";
+  assertMatch: "node tag_length=100in        b=2.54";
+  assertMatch: "node tag_length=200\"        b=5.08";
+  assertMatch: "node tag_length=1nmi         b=1852.0";
+  assertMatch: "node tag_length=1mi          b=1609.344";
+  assertMatch: "node tag_length=\"10ft 1in\" b=3.0734";
+  assertMatch: "node tag_length=20'2\"       b=6.1468";
+  assertMatch: "node tag_length=-20'2\"      b=-6.1468";
+}
+node[any(siunit_length(tag(x)), "no result") == "no result"] {
+  throwWarning: "test";
+  assertMatch: "node x=Hello";
+  assertMatch: "node x=\"23 elephants\"";
+  assertMatch: "node x=4-5m";
+  assertMatch: "node x=5m*3";
+  assertMatch: "node x=1.3.5";
+}


### PR DESCRIPTION
Implements the new siunit_length mapcss function. Rules using this function are now in the JOSM mapcss files and can be updated after this PR is merged.

This PR implements it without using Pint or any other external package due to extra complications (see #2261)
I think the current implementation should also be easy to adjust in case we have to add another unit (or even another type of unit, like volume)

It also provides a separate string-parsing function which would be useful for #2251 and in plugin Number.py
