### PR TITLE
Temporary downgrade to pytest 7.4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ tiletanic
 sentry-sdk
 
 # Tests
-pytest
+pytest == 7.4.4 # In v8 it skips the plugins folder, see our issue #2266 and https://github.com/pytest-dev/pytest/issues/12605
 xmltodict
 termcolor
 pylama


### PR DESCRIPTION
pytest versions 8.0.*, 8.1.* and 8.2.* (at least up to 8.2.2) skip the `plugins` folder, thus skipping the tests of the plugins.

Temporary downgrade to pytest 7.4.4.
In case the issue doesn't get fixed, we might have to change the folder structure

Fixes #2266, see that issue for more details and the issue at pytest.

From the Github actions, a fraction of the log, showing both `plugins` and `plugins/tests`
```
plugins/TagWatchFrViPofm.py ....                                         [ 68%]
plugins/Website.py .                                                     [ 69%]
plugins/indoor.py .                                                      [ 69%]
plugins/notprefix.py .                                                   [ 70%]
plugins/tests/Josm_deprecated_test.py .                                  [ 70%]
plugins/tests/Test_mapcss_item_file.py .                                 [ 71%]
plugins/tests/test_mapcss_parsing_evaluation.py .                        [ 71%]
modules/IssuesFile.py .                                                  [ 71%]
modules/OsmBin.py ........                                               [ 75%]
modules/OsmPbf.py .                                                      [ 75%]
modules/OsmPbf_libosmbf.py ...                                           [ 77%]
modules/OsmSax.py ......                                                 [ 79%]
```