### PR TITLE
Fix duplicate error in Osmosis_Useless

### DIFF
--- a/analysers/analyser_osmosis_useless.py
+++ b/analysers/analyser_osmosis_useless.py
@@ -86,7 +86,7 @@ FROM
 """
 
 sql30 = """
-SELECT
+SELECT DISTINCT
     relations.id,
     relation_members.relation_id,
     ST_AsText(relation_locate(relations.id))


### PR DESCRIPTION
Log: https://buildbot.osmose.openstreetmap.fr/#/builders/358/builds/1414/steps/3/logs/stdio
sql: https://github.com/osm-fr/osmose-backend/blob/dev/analysers/analyser_osmosis_useless.py#L88-L102

XML output
```xml
<error class="3">
<relation id="7186916" version="90" user="xillo">
</relation>
<relation id="7186918" version="56" user="xillo">
<tag k="ref" v="41" />
<tag k="name" v="Fraser - Belconnen (Community Bus Station) via Charnwood, Flynn and Melba" />
<tag k="type" v="route" />
<tag k="route" v="bus" />
<tag k="network" v="Transport Canberra" />
<tag k="operator" v="ACTION" />
<tag k="public_transport:version" v="1" />
</relation>
<location lat="-35.2000733" lon="149.0434821" />
</error>
<error class="3">
<relation id="7186916" version="90" user="xillo">
</relation>
<relation id="7186918" version="56" user="xillo">
<tag k="ref" v="41" />
<tag k="name" v="Fraser - Belconnen (Community Bus Station) via Charnwood, Flynn and Melba" />
<tag k="type" v="route" />
<tag k="route" v="bus" />
<tag k="network" v="Transport Canberra" />
<tag k="operator" v="ACTION" />
<tag k="public_transport:version" v="1" />
</relation>
<location lat="-35.2000733" lon="149.0434821" />
</error>
```

Cause: [relation 7186918](https://www.openstreetmap.org/relation/7186918) contains the same [member](https://www.openstreetmap.org/relation/7186916) twice while matching the conditions of sql30. Hence, two exactly identical results were produced. And this crashed the frontend