### PR TITLE
Use unit parsing module in Number.py

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -21,6 +21,7 @@
 
 from modules.OsmoseTranslation import T_
 from plugins.Plugin import Plugin
+from plugins.modules.units import parseNumberUnitString, convertToUnit
 import re
 
 class Number(Plugin):
@@ -31,7 +32,7 @@ class Number(Plugin):
             title = T_('Invalid numerical value'),
             detail = T_(
 '''The tag expects a numeric value with decimals using a period character
-and not a comma. \\ For guidelines on numeric values with units see [the
+and not a comma. For guidelines on numeric values with units see [the
 wiki](https://wiki.openstreetmap.org/wiki/Map_Features/Units).'''),
             fix = T_(
 '''Make sure the relevant tag value is numeric and in the expected format
@@ -62,57 +63,83 @@ be used if the value is valid.''')
 '''Check that you have used the correct unit and a supported abbreviation of the unit.'''),
             resource = "https://wiki.openstreetmap.org/wiki/Map_features/Units"
         )
+        self.errors[30915] = self.def_class(item = 3091, level = 3, tags = ['value', 'fix:chair'],
+            title = T_('Discouraged unit alias'),
+            detail = T_(
+'''The tag uses an unexpected unit.'''),
+            fix = T_(
+'''Check that you have used the correct unit and a supported abbreviation of the unit.'''),
+            resource = "https://wiki.openstreetmap.org/wiki/Map_features/Units"
+        )
 
-        self.tag_number = ["diameter", "distance", "ele", "height", "length", "width", "diameter_crown", "circumference", "depth"]
+        # Syntax ("tag", "default unit"), except for integer tags (those are converted automatically)
+        self.tag_number = [("diameter", 'mm'), ("distance", 'km'), ("ele", 'm'), ("height", 'm'), ("length", 'm'), ("width", 'm'), ("diameter_crown", 'm'), ("circumference", 'm'), ("depth", 'm')]
         self.tag_number_integer = ["admin_level", "capital", "heritage", "population", "step_count"] # Only positive integers (no units) allowed
-        tag_number_directional = ["maxaxleload", "maxheight", "maxheight:physical", "maxlength", "maxspeed", "maxspeed:advisory", "maxweight", "maxwidth", "minspeed"]
+        tag_number_directional = [("maxaxleload", 't'), ("maxheight", 'm'), ("maxheight:physical", 'm'), ("maxlength", 'm'), ("maxspeed", 'km/h'), ("maxspeed:advisory", 'km/h'), ("maxweight", 't'), ("maxwidth", 'm'), ("minspeed", 'km/h')]
 
         # Add suffixes to the directional tags, add everything to tag_number
         for i in ["", ":forward", ":backward"]:
-            self.tag_number.extend(list(map(lambda tag: tag + i, tag_number_directional)))
-        self.tag_number.extend(self.tag_number_integer)
+            self.tag_number.extend(list(map(lambda t: (t[0] + i, t[1]), tag_number_directional)))
+        self.tag_number.extend(list(map(lambda t: (t, None), self.tag_number_integer)))
 
-        self.units = ["m", "cm", "mm", "km", "mi", "nmi", # distance excluding feet'inch"
+        self.units = [# length units via convertToUnit, the others are yet to be implemented there
                       "km/h", "mph", "knots", # speed
                       "t", "kg", "st", "lbs", "lt", "cwt"] # weight
 
-        self.Number = re.compile(u"^((?:-?[0-9]+(?:[.][0-9]+)?)|(?:[.][0-9]+))(?: ?([a-zA-Z23/]{1,5})|'(?:[0-9]*(?:[.][0-9]+)?\")?|\")?$")
         self.MaxspeedExtraValue = ["none", "default", "signals", "national", "no", "unposted", "walk", "urban", "variable"]
         self.MaxspeedClassValue = re.compile(u'^[A-Z]*:')
         self.MaxheightExtraValue = ["default", "below_default", "no_indications", "no_sign", "none", "unsigned"]
 
     def node(self, data, tags):
         for i in self.tag_number:
-            if i in tags:
-                m = self.Number.match(tags[i])
+            tag = i[0]
+            if tag in tags:
+                m = parseNumberUnitString(tags[tag])
                 if (not m and
-                    not (i == "width" and tags[i] == "narrow") and
-                    not (i == "capital" and tags[i] == "yes") and
-                    not (i == "heritage" and tags[i] == "yes") and
-                    not (("maxspeed" in i or "minspeed" in i) and (
-                        tags[i] in self.MaxspeedExtraValue or
-                        self.MaxspeedClassValue.match(tags[i]) or
-                        (tags[i] == "implicit" and ("traffic_sign" in tags) and "maxspeed" in tags["traffic_sign"].split(";"))
+                    not (tag == "width" and tags[tag] == "narrow") and
+                    not (tag == "capital" and tags[tag] == "yes") and
+                    not (tag == "heritage" and tags[tag] == "yes") and
+                    not (("maxspeed" in tag or "minspeed" in tag) and (
+                        tags[tag] in self.MaxspeedExtraValue or
+                        self.MaxspeedClassValue.match(tags[tag]) or
+                        (tags[tag] == "implicit" and ("traffic_sign" in tags) and "maxspeed" in tags["traffic_sign"].split(";"))
                     )) and
-                    not (i == "maxheight" and tags[i] in self.MaxheightExtraValue)
+                    not (tag == "maxheight" and tags[tag] in self.MaxheightExtraValue)
                 ):
-                    return {"class": 3091, "subclass": 1, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]])) }
+                    return {"class": 3091, "subclass": 1, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]])) }
                 if not m:
                     continue
 
+                if m["unit"] and (any(x in m["unit"] for x in (',', '-', ';', '.', '~')) or m["unit"][0].strip() == ''):
+                    # Invalid numbers, or multiple values
+                    return {"class": 3091, "subclass": 8, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]])) }
+
                 # Below here only tags containing numbers with/without unit remain
-                if i in self.tag_number_integer and str(int(abs(float(m.group(1))))) != tags[i]:
+                if tag in self.tag_number_integer and str(int(abs(m["value"]))) != tags[tag]:
                     # Expected: positive integer, found: decimal number or number with unit
-                    return {"class": 3093, "subclass": 4, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]])) }
-                elif m.group(2) and not m.group(2) in self.units:
-                    return {"class": 3094, "subclass": 6, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]])) }
-                elif i == "height" and float(m.group(1)) > 500:
-                    return {"class": 3092, "subclass": 2, "text": T_("`height={0}` is really tall, consider changing to `ele=*`", m.group(1)),
-                             "fix": {"-": ["height"], "+": {"ele": tags["height"]}} }
-                elif "maxspeed" in i and float(m.group(1)) < 5 and not "waterway" in tags:
-                    return {"class": 3092, "subclass": 3, "text": T_('`{0}` is really slow', 'maxspeed=' + m.group(1))}
-                elif i == "width" and float(m.group(1)) <= 0 and "highway" in tags: # seems to be an old iD bug
-                    return {"class": 3092, "subclass": 5, "text": T_("Concerns tag: `{0}`", '='.join([i, tags[i]]))}
+                    return {"class": 3093, "subclass": 4, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]])) }
+                if m["unit"] and not m["unit"] in self.units:
+                    try:
+                        convertToUnit(m, i[1]) # Will throw in case conversion to the default unit (i[1]) isn't possible
+                    except NotImplementedError:
+                        return {"class": 3094, "subclass": 6, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]])) }
+                if tag == "height":
+                    try:
+                        if convertToUnit(m, 'm') > 500:
+                            return {"class": 3092, "subclass": 2, "text": T_("`height={0}` is really tall, consider changing to `ele=*`", tags[tag]),
+                                 "fix": {"-": ["height"], "+": {"ele": tags["height"]}} }
+                    except: # E.g. height in speed units; TODO: remove try/except once all units of self.unit are dealt with in convertToUnit
+                        return {"class": 3094, "subclass": 7, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]])) }
+                elif "maxspeed" in tag and m["value"] < 5 and not "waterway" in tags:
+                    return {"class": 3092, "subclass": 3, "text": T_('`{0}` is really slow', 'maxspeed=' + tags[tag])}
+                elif tag == "width" and m["value"] <= 0 and "highway" in tags: # seems to be an old iD bug
+                    return {"class": 3092, "subclass": 5, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]]))}
+
+                # Warn about "highly discouraged" aliases from the wiki, like 'kilometer' instead of 'km'
+                if m["unit"] and (
+                        (len(m["unit"].replace('/', '')) >= 4 and m["unit"] not in ("l/min", "knots")) or
+                        (m["unit"] in ("m3/s", "m3/h", "kph", "kmh", "ST", "T", "ton", "lb", "ft", "in"))):
+                    return {"class": 30915, "subclass": 9, "text": T_("Concerns tag: `{0}`", '='.join([tag, tags[tag]]))}
 
     def way(self, data, tags, nds):
         return self.node(data, tags)
@@ -131,12 +158,13 @@ class Test(TestPluginCommon):
         for d in ["194", "14 m", "0.6m", "1cm", "narrow", "8 km", "400m", "10'", "10'11\"", "1'9.8\"", "1.18\"", "-6"]:
             assert not a.node(None, {"width":d}), ("width='{0}'".format(d))
 
-        for d in ["3,75", "foo", "18,4m", "4.8 cars", "4810"]:
+        for d in ["3,75", "foo", "18,4m", "4.8 cars", "12 km/h", "12 t", "4810", "４"]:
             self.check_err(a.node(None, {"height":d}), ("height='{0}'".format(d)))
             self.check_err(a.way(None, {"height":d}, None), ("height='{0}'".format(d)))
             self.check_err(a.relation(None, {"height":d}, None), ("height='{0}'".format(d)))
+        assert not a.node(None, {"height": "650 mm"})
 
-        for d in ["foo", "18kph", "1", "30 c"]:
+        for d in ["foo", "18kph", "1", "30 c", "30 m", "70;80 km/h", "70-80", "42.5.5"]:
             self.check_err(a.node(None, {"maxspeed":d}), ("maxspeed='{0}'".format(d)))
             self.check_err(a.node(None, {"maxspeed:backward":d}), ("maxspeed:backward='{0}'".format(d)))
 
@@ -144,8 +172,10 @@ class Test(TestPluginCommon):
             assert not a.node(None, {"maxspeed":d}), ("maxspeed='{0}'".format(d))
             assert not a.node(None, {"minspeed:forward":d}), ("minspeed:forward='{0}'".format(d))
 
-        t = {"maxspeed":"1", "waterway": "river"}
-        assert not a.node(None, {"maxspeed":"1", "waterway": "river"}), t
+        for d in ["50 millimeters", "40 metre", "30 feet", "30 in", "10 mile"]:
+            self.check_err(a.node(None, {"distance": d}), ("distance='{0}'".format(d)))
+
+        assert not a.node(None, {"maxspeed":"1", "waterway": "river"})
 
         assert not a.node(None, {"maxspeed": "implicit", "traffic_sign": "maxspeed"})
 

--- a/plugins/modules/units.py
+++ b/plugins/modules/units.py
@@ -24,8 +24,8 @@
 
 import re
 
-_ftin_re = re.compile("^(-?)(?:(\\d+(?:\\.\\d+)?)(ft|')) ?(?:(\\d+(?:\\.\\d+)?)(in|\"))$") # Regex for combined feet/inch measures
-_numunit_re = re.compile(r"^(-?\d+(?:\.\d+)?) ?(\D.*)?$") # Regex for any number followed by an optional unit
+_ftin_re = re.compile("^(-?)(?:([0-9]+(?:\\.[0-9]+)?)(ft|')) ?(?:([0-9]+(?:\\.[0-9]+)?)(in|\"))$") # Regex for combined feet/inch measures
+_numunit_re = re.compile(r"^(-?[0-9]+(?:\.[0-9]+)?) ?([^0-9].*)?$") # Regex for any number followed by an optional unit
 _si_prefixes = {
     "n": 1E-9, "u": 1E-6, "µ": 1E-6, "m": 0.001, "c": 0.01, "d": 0.1, "da": 10, "h": 100, "k": 1000, "M": 1E6, "G": 1E9, "T": 1E12,
     "nano": 1E-9, "micro": 1E-6, "milli": 0.001, "centi": 0.01, "deci": 0.1, "deca": 10, "hecto": 100, "kilo": 1000, "mega": 1E6, "giga": 1E9, "tera": 1E12,
@@ -41,7 +41,7 @@ _si_prefixes = {
 #   Otherwise a dict with keys:
 #       value [float] - the number in the string
 #       unit [string or None] - the unit
-# For a string with multiple numbers/units, it converts it to a float of the largest unit (e.g. 3'4" becomes 3.33 ft)
+# For a string with multiple numbers/units, it converts it to a float of the largest unit (e.g. 3'4" becomes 3.33')
 def parseNumberUnitString(string, defaultUnit = None):
     if not string or not isinstance(string, str):
         return None
@@ -52,7 +52,7 @@ def parseNumberUnitString(string, defaultUnit = None):
     if m:
         return {
             "value": float(m.group(1) + m.group(2)) + float(m.group(1) + m.group(4))/12,
-            "unit": "ft"
+            "unit": "'"
         }
     # Regular numbers with optional unit
     m = re.fullmatch(_numunit_re, string)
@@ -69,7 +69,7 @@ def parseNumberUnitString(string, defaultUnit = None):
 # Input:
 #   x: either a string with a number + optional unit to parse, or a dict with value:[float] and unit:[string] keys
 #   convertTo: the unit to convert the x-input to (the abbreviation)
-#   If x is a string without unit, it assumes the default unit equals the unit of convertTo
+#   If x has no unit, it assumes the default unit equals the unit of convertTo
 # Returns:
 #   None if the input was None or the string couldn't be parsed into a number + optional unit
 #   The value [float] converted to convertTo units otherwise
@@ -81,7 +81,7 @@ def convertToUnit(x, convertTo):
         x = parseNumberUnitString(x, convertTo)
     if not x:
         return None
-    if x["unit"] == convertTo:
+    if x["unit"] is None or x["unit"] == convertTo:
         return x["value"]
 
     # Length based conversions


### PR DESCRIPTION
Uses the new unit parsing and conversion functions in Number.py
- Stops incorrect warnings for height>500 if the unit wasn't meters but e.g. feet and is (converted to meters) less than 500
- Prepares for checking if the right type of unit is used (e.g. no maxspeed in meters). Will be fully functional as soon as convertToUnit supports weight and speed units too. Right now it already works for speed/weight tags in length units.
   - Adding more conversions is for a follow-up PR
- Move discouraged units to their own class. Previously some were reported by 3091 (like 'kilometer'), some by 3094 (like 'ft'). In practice this new class only works for length units for now until more unit conversions are added
- For this PR I also needed to make 3 small fixes to the unit conversion module:
  - Use default feet notation (') instead of ft
  - If convertToUnit receives a dict, the unit in the dict may be None. Treat it similar to how string inputs are handled
  - Only allow ASCII-numbers (found some other numbers in Japan)

Some small other fixes:
- Include units in some messages, e.g. `maxspeed=2 mph` is really slow instead of `maxspeed=2` is really slow
- Fix a \ in the message of class 3091
