### PR TITLE
Fix: combined `<feet>ft<inch>in` wasn't detected anymore

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -172,7 +172,7 @@ class Test(TestPluginCommon):
             assert not a.node(None, {"maxspeed":d}), ("maxspeed='{0}'".format(d))
             assert not a.node(None, {"minspeed:forward":d}), ("minspeed:forward='{0}'".format(d))
 
-        for d in ["50 millimeters", "40 metre", "30 feet", "30 in", "10 mile"]:
+        for d in ["50 millimeters", "40 metre", "30 feet", "30 in", "10 mile", "6ft 6in"]:
             self.check_err(a.node(None, {"distance": d}), ("distance='{0}'".format(d)))
 
         assert not a.node(None, {"maxspeed":"1", "waterway": "river"})

--- a/plugins/modules/units.py
+++ b/plugins/modules/units.py
@@ -52,7 +52,7 @@ def parseNumberUnitString(string, defaultUnit = None):
     if m:
         return {
             "value": float(m.group(1) + m.group(2)) + float(m.group(1) + m.group(4))/12,
-            "unit": "'"
+            "unit": m.group(3)
         }
     # Regular numbers with optional unit
     m = re.fullmatch(_numunit_re, string)


### PR DESCRIPTION
Previous to #2280 the use of `<feet>ft<inch>in` was reported by class 3091. This detection got lost in that PR.

This fix just returns the unit for feet as it was given as input (either `ft` or `'`) hence enabling the detection again (in the new class 30915)