### PR TITLE
Exclude parking=layby in analyser_osmosis_parking_highway.py

### DIFF
--- a/analysers/analyser_osmosis_parking_highway.py
+++ b/analysers/analyser_osmosis_parking_highway.py
@@ -67,7 +67,7 @@ FROM (
 WHERE
   tags?'amenity' AND
   tags->'amenity' = 'parking' AND
-  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane'))
+  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane', 'layby'))
 """
 
 sql13 = """
@@ -125,7 +125,7 @@ class Analyser_Osmosis_Parking_highway(Analyser_Osmosis):
             detail = T_(
 '''There should be a `highway` feature leading to this parking facility
 to allow for correct routing. Add a road or check if `parking=*` is
-correct. If it is a street side parking (`parking=street_side`) or lane,
+correct. If it is a street side parking (`parking=street_side`), layby (`parking=layby`) or lane,
 then add appropriate tags.
 
 See [parking](https://wiki.openstreetmap.org/wiki/Key:parking) tag on the wiki.'''))


### PR DESCRIPTION
Add parking=layby to parking=* types which do not require an access highway (parking=street_side and parking=lane).

The wiki page for [parking=layby](https://wiki.openstreetmap.org/wiki/Tag:parking%3Dlayby) describes it as being similar to parking=street_side and also states: "There is often no physical barrier between the road and the lay-by. If there is then consider using highway=rest_area instead."

Encouraging users to add a non-existent access highway to connect a layby for routing would be unhelpful.