### PR TITLE
add Electra Q128592938 , remove email, wrong duplicate of operator:email

### DIFF
--- a/analysers/analyser_merge_charging_station_FR.py
+++ b/analysers/analyser_merge_charging_station_FR.py
@@ -32,6 +32,7 @@ class Analyser_Merge_Charging_station_FR(Analyser_Merge_Point):
         "bouygues": "Q3046208",
         "freshmile": "Q111209120",
         "lidl": "Q115764851",
+        "Electra": "Q128592938",
     }
 
     def __init__(self, config, logger=None):
@@ -81,7 +82,6 @@ with `capacity=6` can sometimes match to 3 charging station with `capacity=2`'''
                         "ref:EU:EVSE": "id_station_itinerance"
                     },
                     mapping2={
-                        "email": "contact_operateur",
                         "operator:phone": "telephone_operateur",
                         "operator:email": "contact_operateur",
                         "start_date": "date_mise_en_service",


### PR DESCRIPTION
fix https://github.com/osm-fr/osmose-backend/issues/2296 (in addition to to the fix done with https://github.com/Jungle-Bus/ref-EU-EVSE/pull/9 )