### PR TITLE
Add `maxspeed:hgv:conditional` to Mapillary matching tags

### DIFF
--- a/merge_data/mapillary-traffic-signs.mapping.json
+++ b/merge_data/mapillary-traffic-signs.mapping.json
@@ -33,6 +33,12 @@
         "maxspeed:conditional": {
           "like": "5{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "5{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -71,6 +77,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "10{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "10{speed_limit_unit} @ %"
         }
       }
@@ -113,6 +125,12 @@
         "maxspeed:conditional": {
           "like": "15{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "15{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -151,6 +169,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "20{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "20{speed_limit_unit} @ %"
         }
       }
@@ -202,6 +226,12 @@
         "maxspeed:conditional": {
           "like": "30{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "30{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -241,6 +271,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "35{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "35{speed_limit_unit} @ %"
         }
       }
@@ -283,6 +319,12 @@
         "maxspeed:conditional": {
           "like": "40{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "40{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -322,6 +364,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "45{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "45{speed_limit_unit} @ %"
         }
       }
@@ -368,6 +416,12 @@
         "maxspeed:conditional": {
           "like": "50{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "50{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -406,6 +460,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "60{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "60{speed_limit_unit} @ %"
         }
       }
@@ -450,6 +510,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "70{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "70{speed_limit_unit} @ %"
         }
       }
@@ -505,6 +571,12 @@
         "maxspeed:conditional": {
           "like": "80{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "80{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -558,6 +630,12 @@
         "maxspeed:conditional": {
           "like": "90{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "90{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -609,6 +687,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "100{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "100{speed_limit_unit} @ %"
         }
       }
@@ -665,6 +749,12 @@
         "maxspeed:conditional": {
           "like": "110{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "110{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -714,6 +804,12 @@
         "maxspeed:conditional": {
           "like": "120{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "120{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -761,6 +857,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "130{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "130{speed_limit_unit} @ %"
         }
       }
@@ -1157,6 +1259,12 @@
         "maxspeed:conditional": {
           "like": "5{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "5{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1197,6 +1305,12 @@
         "maxspeed:conditional": {
           "like": "10{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "10{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1235,6 +1349,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "15{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "15{speed_limit_unit} @ %"
         }
       }
@@ -1281,6 +1401,12 @@
         "maxspeed:conditional": {
           "like": "20{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "20{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1322,6 +1448,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "25{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "25{speed_limit_unit} @ %"
         }
       }
@@ -1369,6 +1501,12 @@
         "maxspeed:conditional": {
           "like": "30{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "30{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1410,6 +1548,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "35{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "35{speed_limit_unit} @ %"
         }
       }
@@ -1456,6 +1600,12 @@
         "maxspeed:conditional": {
           "like": "40{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "40{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1499,6 +1649,12 @@
         "maxspeed:conditional": {
           "like": "45{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "45{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1539,6 +1695,12 @@
         "maxspeed:conditional": {
           "like": "50{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "50{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1576,6 +1738,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "55{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "55{speed_limit_unit} @ %"
         }
       }
@@ -1618,6 +1786,12 @@
         "maxspeed:conditional": {
           "like": "60{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "60{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1655,6 +1829,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "65{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "65{speed_limit_unit} @ %"
         }
       }
@@ -1697,6 +1877,12 @@
         "maxspeed:conditional": {
           "like": "70{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "70{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1734,6 +1920,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "75{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "75{speed_limit_unit} @ %"
         }
       }
@@ -1775,6 +1967,12 @@
         "maxspeed:conditional": {
           "like": "80{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "80{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1814,6 +2012,12 @@
         "maxspeed:conditional": {
           "like": "90{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "90{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1851,6 +2055,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "100{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "100{speed_limit_unit} @ %"
         }
       }
@@ -1897,6 +2107,12 @@
         "maxspeed:conditional": {
           "like": "110{speed_limit_unit} @ %"
         }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
+          "like": "110{speed_limit_unit} @ %"
+        }
       }
     ],
     "generate_tags": {
@@ -1934,6 +2150,12 @@
       {
         "highway": null,
         "maxspeed:conditional": {
+          "like": "120{speed_limit_unit} @ %"
+        }
+      },
+      {
+        "highway": null,
+        "maxspeed:hgv:conditional": {
           "like": "120{speed_limit_unit} @ %"
         }
       }


### PR DESCRIPTION
See #2241

As it seems that the majority of `maxspeed:psv:conditional` and `maxspeed:bus:conditional` are combined with `maxspeed:hgv:conditional` (and I think it's very likely they'll have the same conditional speeds) I suspect that adding `maxspeed:hgv:conditional` is sufficient to cover for all three conditional tags