### PR TITLE
Update texts of soundex test

### DIFF
--- a/analysers/analyser_osmosis_soundex.py
+++ b/analysers/analyser_osmosis_soundex.py
@@ -229,14 +229,13 @@ class Analyser_Osmosis_Soundex(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
 
-        # Check langues for country are writen with alphabets
+        # Check languages for country are writen with alphabets
         self.scripts = 'language' in config.options and languages.scripts(config.options['language'])
         if self.scripts and len(self.scripts) == 1 and (self.scripts[0] == 'Latin' or self.scripts[0].startswith('[A-Za-z')):
             self.classs[1] = self.def_class(item = 5050, level = 2, tags = ['name', 'fix:survey'],
-                title = T_('Soundex test'),
+                title = T_('Possibly misspelled name'),
                 detail = T_(
-'''A street name "sounds" similar to that of another street but is
-not spelled the same way.'''),
+'''A name "sounds" similar to that of another but is not spelled the same way.'''),
                 fix = T_(
 '''After you have checked that it is a mistake, change the name.'''),
                 trap = T_(
@@ -271,5 +270,6 @@ his name not need be transformed into "Jean Monnet",
         self.run(sql06, lambda res: {
             "class":1,
             "data":[self.way_full, self.positionAsText],
-            "fix":{"name":res[2].replace(res[3], res[4])}
+            "fix":{"name":res[2].replace(res[3], res[4])},
+            "text": T_("{0} 'sounds' similar to {1} but is spelled differently", res[3], res[4])
         } )


### PR DESCRIPTION
#2116

- Clarify its not for streets (only) but for everything, e.g. in NL there's a `leisure=sports_centre` and a `healthcare=clinic` detected too
- Improve the title (used the suggested one by mnalis)
- Add some extra clarification text (my personal wishlist, sometimes the change is so small, e.g. i vs í, that it looks like it's proposing to add the same...)
- Fix a typo