### PR TITLE
Don't warn for number-only changes in Soundex test

### DIFF
--- a/analysers/analyser_osmosis_soundex.py
+++ b/analysers/analyser_osmosis_soundex.py
@@ -220,7 +220,7 @@ FROM
         phonic_fort.phonic_2oo = phonic_faible.phonic_2oo
 WHERE
     levenshtein(upper(unaccent(phonic_fort.name_2oo)), upper(unaccent(phonic_faible.name_2oo))) <= 1 AND
-    replace(upper(phonic_fort.name_2oo), '-', ' ') <> replace(upper(phonic_faible.name_2oo), '-', ' ')
+    regexp_replace(upper(phonic_fort.name_2oo), '[0-9-]+', ' ') <> regexp_replace(upper(phonic_faible.name_2oo), '[0-9-]+', ' ')
 """
 
 


### PR DESCRIPTION
https://osmose.openstreetmap.fr/nl/issue/9f4f7ff2-70ff-4bb0-ce16-067ebac1e528
Item 5050 class 1

The soundex test reports that `name=Calle 11 de Abril` ([w168672382](https://www.openstreetmap.org/way/168672382)) should be changed to `name=Calle 19 de Abril` (e.g. changing "April 11 street" to "April 19 street").

Purely numerical differences should probably not be reported.

The other possibility to fix this could've been to exclude names with numbers in sql03 already, but in that case one would lose detections of e.g. "Charles 4th College" vs "Charles 4th Collega", e.g. true typos unrelated to the number, hence I prefer this implementation.