### PR TITLE
Famlam number

### DIFF
--- a/plugins/modules/units.py
+++ b/plugins/modules/units.py
@@ -107,4 +107,28 @@ def convertToUnit(x, convertTo):
     if convertTo == "nmi": # default for distance over water
         return convertToUnit(x, 'm') / 1852
 
+    # Speed based conversions
+    if convertTo == "km/h": # default for speed
+        if x["unit"] in ('kph', 'kmh', 'kmph'):
+            return x["value"]
+        if x["unit"] == 'mph':
+            return x["value"] * 1.609344
+        if x["unit"] == "knots":
+            return x["value"] * 1.852
+
+    # Weight based conversions
+    if convertTo == "t": # default for weight
+        if x["unit"] in ('st', 'ST', 'T', 'ton', 'tons'):
+            return x["value"] * 0.9071847
+        if x["unit"] == 'lt':
+            return x["value"] * 1.016047
+        if x["unit"] in ('lbs', 'lb'):
+            return x["value"] * 0.00045359237
+        if x["unit"] == 'cwt':
+            return x["value"] * 0.05080
+        if x["unit"].endswith('g'):
+            prefix = x["unit"][0:-1]
+            if prefix in _si_prefixes:
+                return x["value"] * _si_prefixes[prefix] / 1e6
+
     raise NotImplementedError("Unknown conversion: {0} to {1}".format(str(x), convertTo))


### PR DESCRIPTION
Simplify plugin "Number" by implementing the other unit conversions involved

(I could now have changed `m["value"] < 5` on line 126 to `convertToUnit(m, i[1]) < 5` to ensure it triggers on anything < 5 km/h rather than <5 [any unit], but I suspect the purpose wasn't to check on the actual speed, but rather on the fact that there's probably no traffic signs or so that say 1-4 [km/h | knots | mph]. The difference is ~81 ways worldwide)