### PR TITLE
Require parks to be at least 5x5 m2

### DIFF
--- a/analysers/analyser_osmosis_polygon_small.py
+++ b/analysers/analyser_osmosis_polygon_small.py
@@ -117,7 +117,7 @@ Usually a park contains grass, other vegetation, walking paths. A park often has
             {'key': 'landuse', 'val': 'forest', 'minarea': 20, 'class': 2}, # 20m2 is roughly 1 big tree of 5m diameter
             {'key': 'landuse', 'val': 'farmland', 'minarea': 100, 'class': 3},
             {'key': 'landuse', 'val': 'village_green', 'minarea': 500, 'class': 4},
-            {'key': 'leisure', 'val': 'park', 'minarea': 10, 'class': 5},
+            {'key': 'leisure', 'val': 'park', 'minarea': 25, 'class': 5},
         ]
 
     def analyser_osmosis_full(self):


### PR DESCRIPTION
Closes #1873

> for a park (like the main issue), i'm in favor of starting with a very very conservative value for ex 1m2 or 10m2 to detect indisputable cases... and then gradually raise up

I didn't see any disputable cases (only one false positive reported so far, but that's a picnic_site based on its name, not a park), so lets go to 5x5m "parks" and leave it like that. Although the smallest [formal park](https://www.guinnessworldrecords.com/world-records/66421-smallest-park) is only 2917.15 cm² big, that doesn't match OSM's [definition](https://wiki.openstreetmap.org/wiki/Tag:leisure=park) of a park as _"A park is an area of open space for recreational use [...]"_