### PR TITLE
Fix timestamp check

### DIFF
--- a/modules/OsmPbf_libosmbf.py
+++ b/modules/OsmPbf_libosmbf.py
@@ -85,35 +85,35 @@ class OsmPbfReader(OsmReader, osm_pbf_parser.Visitor):
         osm_pbf_parser.read_osm_pbf(self._pbf_file, self)
 
 
-    def node(self, osmid, lon, lat, tags):
+    def node(self, osmid, lon, lat, tags, timestamp):
         data = {
             'id': osmid,
             'lon': lon,
             'lat': lat,
             'tag': tags,
             #'version'
-            #'timestamp'
+            'timestamp': timestamp,
             #'uid'
         }
         self._output.NodeCreate(data)
 
-    def way(self, osmid, tags, refs):
+    def way(self, osmid, tags, refs, timestamp):
         data = {
             'id': osmid,
             'tag': tags,
             'nd': refs,
             #'version'
-            #'timestamp'
+            'timestamp': timestamp,
             #'uid'
         }
         self._output.WayCreate(data)
 
-    def relation(self, osmid, tags, ref):
+    def relation(self, osmid, tags, ref, timestamp):
         data = {
             'id': osmid,
             'tag': tags,
             #'version'
-            #'timestamp'
+            'timestamp': timestamp,
             #'uid'
             'member': ref,
         }

--- a/modules/osm_pbf_parser/osm_pbf_parser.cc
+++ b/modules/osm_pbf_parser/osm_pbf_parser.cc
@@ -80,7 +80,7 @@ struct Visitor
 
   void node_callback(uint64_t osmid, double lon, double lat, const Tags & tags, const uint64_t timestamp) {
       if (!tags.empty() && (since_timestamp == 0 || timestamp == 0 || timestamp >= since_timestamp)) {
-          call_method<void>(self, "node", osmid, lon, lat, tagsToDict(tags));
+          call_method<void>(self, "node", osmid, lon, lat, tagsToDict(tags), timestamp);
       } else {
           filtered_nodes_osmid.push_back(osmid);
       }
@@ -92,7 +92,7 @@ struct Visitor
 
   void way_callback(uint64_t osmid, const Tags & tags, const std::vector<uint64_t> & refs, const uint64_t timestamp) {
       if (since_timestamp == 0 || timestamp == 0 || timestamp >= since_timestamp) {
-          call_method<void>(self, "way", osmid, tagsToDict(tags), nodeIdToList(refs));
+          call_method<void>(self, "way", osmid, tagsToDict(tags), nodeIdToList(refs), timestamp);
       } else {
           filtered_ways_osmid.push_back(osmid);
       }
@@ -104,7 +104,7 @@ struct Visitor
 
   void relation_callback(uint64_t osmid, const Tags & tags, const References & refs, const uint64_t timestamp) {
       if (since_timestamp == 0 || timestamp == 0 || timestamp >= since_timestamp) {
-          call_method<void>(self, "relation", osmid, tagsToDict(tags), referencesToDict(refs));
+          call_method<void>(self, "relation", osmid, tagsToDict(tags), referencesToDict(refs), timestamp);
       } else {
           filtered_relations_osmid.push_back(osmid);
       }

--- a/plugins/Construction.py
+++ b/plugins/Construction.py
@@ -88,11 +88,16 @@ exceeded.'''))
             date = self.convert2date(tagDate)
 
         end_date = False
-        if date:
-            end_date = date
-        elif "timestamp" in data:
-            end_date = datetime.datetime.strptime(data["timestamp"][0:10], "%Y-%m-%d") + self.date_limit
-        else:
+        try:
+            if date:
+                end_date = date
+            elif data["timestamp"] > 0:
+                end_date = datetime.datetime.fromtimestamp(data["timestamp"]) + self.date_limit
+            else:
+                return
+        except:
+            # This should only trigger in case the pbf reader is updated (and the plugin not), causing the timestamp format to change (or be absent)
+            print("Error: Unexpected format of timestamp or no timestamp provided, expected numerical timestamp")
             return
 
         delta = int(self.total_seconds(self.today - end_date))
@@ -122,6 +127,9 @@ class Test(TestPluginCommon):
         self.p.init(None)
 
     def test(self):
+        # Use today, so it won't trigger due to the timestamp in this test
+        ts = datetime.datetime.timestamp(datetime.datetime.today())
+
         constr_tags = [{"construction": "yes"},
                        {"highway": "construction"},
                        {"landuse": "construction"},
@@ -155,31 +163,34 @@ class Test(TestPluginCommon):
                 for val_d in correct_dates:
                     t = tags.copy()
                     t.update({tag_d: val_d})
-                    self.check_err(self.p.node({}, t), t)
+                    self.check_err(self.p.node({"timestamp": ts}, t), t)
                 for val_d in not_correct_dates:
                     t = tags.copy()
                     t.update({tag_d: val_d})
-                    assert not self.p.way({}, t, None), t
+                    assert not self.p.way({"timestamp": ts}, t, None), t
 
         for tags in other_tags:
             for tag_d in self.p.tag_date:
                 for val_d in correct_dates:
                     t = tags.copy()
                     t.update({tag_d: val_d})
-                    assert not self.p.relation({}, t, None), t
+                    assert not self.p.relation({"timestamp": ts}, t, None), t
 
     def test_timestamp(self):
         tags = {"construction": "yes"}
         for ts in ["2003-01-04", "1989-03-10"]:
-            self.check_err(self.p.node({"timestamp": ts}, tags), ts)
-        for ts in ["2078-01-04"]:
-            assert not self.p.node({"timestamp": ts}, tags), ts
+            ts_int = datetime.datetime.timestamp(datetime.datetime.strptime(ts,"%Y-%m-%d"))
+            self.check_err(self.p.node({"timestamp": ts_int}, tags), ts)
+        for ts in ["2078-01-04", str(datetime.datetime.today())[0:10]]:
+            ts_int = datetime.datetime.timestamp(datetime.datetime.strptime(ts,"%Y-%m-%d"))
+            assert not self.p.node({"timestamp": ts_int}, tags), ts
+        assert not self.p.node({"timestamp": 0}, tags)
 
     def test_recall(self):
         tags = {"construction": "yes"}
         today = datetime.datetime.today()
         td = datetime.timedelta(days=6 * 30)
         for i in range(5, 10, 1):
-            e = self.p.node({"timestamp": (today - i*td).strftime("%Y-%m-%d")}, tags)
+            e = self.p.node({"timestamp": datetime.datetime.timestamp(today - i*td)}, tags)
             self.check_err(e, i)
             assert e["subclass"] == i - 5


### PR DESCRIPTION
1. Propagate timestamp to python (as int)
2. Convert Construction.py to use int (seconds from epoch) rather than string dates
3. Add a log warning to ensure a change to the pbf reader won't go unnoticed again

#2314