### PR TITLE
Don't warn on bridges mapped as (pedestrian) area

### DIFF
--- a/analysers/analyser_osmosis_highway_tunnel_bridge.py
+++ b/analysers/analyser_osmosis_highway_tunnel_bridge.py
@@ -140,6 +140,7 @@ WHERE
             (NOT bt_connections.tags?'covered' OR bt_connections.tags->'covered' = 'no')
         )
     ) AND
+    NOT bt_ways.is_area AND -- any point of an area can be an end point
     NOT bt_ways.is_construction AND NOT bt_connections.is_construction AND
     -- Below: filter all cases where one would for instance walk from a building directly onto a bridge
     (NOT bt_connections.tags?'indoor' OR bt_connections.tags->'indoor' = 'no') AND


### PR DESCRIPTION
For an pedestrian area, we cannot determine the starting point of the bridge, so any node can be a valid starting point.

Involves this region: https://osmose.openstreetmap.fr/nl/map/#zoom=8&lat=52.241&lon=5.504&item=7012&level=1%2C2%2C3&loc=15/51.51804/5.10913
Example: https://www.openstreetmap.org/way/1277780728

Follow-up fix for #2301