### PR TITLE
Implement method for special country codes

### DIFF
--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -344,6 +344,34 @@ def functionExpression_rule_flags(t, c):
         c['flags'].append('relational')
     return t
 
+specialCountryMap = {
+    # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#exceptional-reservations
+    # None here simply means 'not yet implemented by us'
+    'AC': None,
+    'CP': None,
+    'CQ': None,
+    'DG': None,
+    'EA': None,
+    'EU': None,
+    'EZ': None,
+    'FX': ['FR-69M', 'FR-69D', 'FR-2A', 'FR-2B'] + list(map(lambda n: 'FR-{:02}'.format(n), range(1,96))),
+    'IC': None,
+    'SU': None,
+    'TA': None,
+    'UK': None,
+    'UN': None,
+}
+def functionExpression_insideoutside(t, c):
+    """
+    type = functionExpression
+    convert unconventional country codes to Osmose equivalent
+    """
+    if t['name'] in ('inside', 'outside'):
+        countries = t["params"][0]["value"].split(',')
+        countries = list(map(lambda x: x if x not in specialCountryMap or (specialCountryMap[x] is None and not print("Warning: special country code not implemented yet: " + x)) else ','.join(specialCountryMap[x]), countries))
+        t["params"][0]["value"] = ','.join(countries)
+    return t
+
 def rule_after_flags(t, c):
     """
     type = rule
@@ -479,6 +507,7 @@ rewrite_rules_change_before = [
     ('booleanExpression', booleanExpression_operator_to_function),
     ('functionExpression', functionExpression_param_regex),
     ('functionExpression', functionExpression_regexp_flags),
+    ('functionExpression', functionExpression_insideoutside),
     ('pseudo_class', pseudo_class_righthandtraffic),
     # Safty
     ('rule', rule_declarations_order),

--- a/plugins/tests/test_mapcss_parsing_evaluation.py
+++ b/plugins/tests/test_mapcss_parsing_evaluation.py
@@ -809,6 +809,87 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 # assertMatch:"node x=Hello"
                 err.append({'class': 6, 'subclass': 72306003, 'text': {'en': 'test'}})
 
+        # node[x][inside("FX,NL")]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.inside(self.father.config.options, 'FR-69M,FR-69D,FR-2A,FR-2B,FR-01,FR-02,FR-03,FR-04,FR-05,FR-06,FR-07,FR-08,FR-09,FR-10,FR-11,FR-12,FR-13,FR-14,FR-15,FR-16,FR-17,FR-18,FR-19,FR-20,FR-21,FR-22,FR-23,FR-24,FR-25,FR-26,FR-27,FR-28,FR-29,FR-30,FR-31,FR-32,FR-33,FR-34,FR-35,FR-36,FR-37,FR-38,FR-39,FR-40,FR-41,FR-42,FR-43,FR-44,FR-45,FR-46,FR-47,FR-48,FR-49,FR-50,FR-51,FR-52,FR-53,FR-54,FR-55,FR-56,FR-57,FR-58,FR-59,FR-60,FR-61,FR-62,FR-63,FR-64,FR-65,FR-66,FR-67,FR-68,FR-69,FR-70,FR-71,FR-72,FR-73,FR-74,FR-75,FR-76,FR-77,FR-78,FR-79,FR-80,FR-81,FR-82,FR-83,FR-84,FR-85,FR-86,FR-87,FR-88,FR-89,FR-90,FR-91,FR-92,FR-93,FR-94,FR-95,NL')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=DE")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-02")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-GP")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=NL")
+                err.append({'class': 6, 'subclass': 759484915, 'text': {'en': 'test'}})
+
+        # node[x][inside("FX,NL,FR-GF")]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.inside(self.father.config.options, 'FR-69M,FR-69D,FR-2A,FR-2B,FR-01,FR-02,FR-03,FR-04,FR-05,FR-06,FR-07,FR-08,FR-09,FR-10,FR-11,FR-12,FR-13,FR-14,FR-15,FR-16,FR-17,FR-18,FR-19,FR-20,FR-21,FR-22,FR-23,FR-24,FR-25,FR-26,FR-27,FR-28,FR-29,FR-30,FR-31,FR-32,FR-33,FR-34,FR-35,FR-36,FR-37,FR-38,FR-39,FR-40,FR-41,FR-42,FR-43,FR-44,FR-45,FR-46,FR-47,FR-48,FR-49,FR-50,FR-51,FR-52,FR-53,FR-54,FR-55,FR-56,FR-57,FR-58,FR-59,FR-60,FR-61,FR-62,FR-63,FR-64,FR-65,FR-66,FR-67,FR-68,FR-69,FR-70,FR-71,FR-72,FR-73,FR-74,FR-75,FR-76,FR-77,FR-78,FR-79,FR-80,FR-81,FR-82,FR-83,FR-84,FR-85,FR-86,FR-87,FR-88,FR-89,FR-90,FR-91,FR-92,FR-93,FR-94,FR-95,NL,FR-GF')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=DE")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-02")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-GF")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-GP")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=NL")
+                err.append({'class': 6, 'subclass': 336478965, 'text': {'en': 'test'}})
+
+        # node[x][inside("FX,NL,FR")]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.inside(self.father.config.options, 'FR-69M,FR-69D,FR-2A,FR-2B,FR-01,FR-02,FR-03,FR-04,FR-05,FR-06,FR-07,FR-08,FR-09,FR-10,FR-11,FR-12,FR-13,FR-14,FR-15,FR-16,FR-17,FR-18,FR-19,FR-20,FR-21,FR-22,FR-23,FR-24,FR-25,FR-26,FR-27,FR-28,FR-29,FR-30,FR-31,FR-32,FR-33,FR-34,FR-35,FR-36,FR-37,FR-38,FR-39,FR-40,FR-41,FR-42,FR-43,FR-44,FR-45,FR-46,FR-47,FR-48,FR-49,FR-50,FR-51,FR-52,FR-53,FR-54,FR-55,FR-56,FR-57,FR-58,FR-59,FR-60,FR-61,FR-62,FR-63,FR-64,FR-65,FR-66,FR-67,FR-68,FR-69,FR-70,FR-71,FR-72,FR-73,FR-74,FR-75,FR-76,FR-77,FR-78,FR-79,FR-80,FR-81,FR-82,FR-83,FR-84,FR-85,FR-86,FR-87,FR-88,FR-89,FR-90,FR-91,FR-92,FR-93,FR-94,FR-95,NL,FR')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=DE")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-02")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-GF")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-GP")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=NL")
+                err.append({'class': 6, 'subclass': 1675393091, 'text': {'en': 'test'}})
+
+        # node[x][inside("NL,FX,DE")][outside("FR-02")]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.inside(self.father.config.options, 'NL,FR-69M,FR-69D,FR-2A,FR-2B,FR-01,FR-02,FR-03,FR-04,FR-05,FR-06,FR-07,FR-08,FR-09,FR-10,FR-11,FR-12,FR-13,FR-14,FR-15,FR-16,FR-17,FR-18,FR-19,FR-20,FR-21,FR-22,FR-23,FR-24,FR-25,FR-26,FR-27,FR-28,FR-29,FR-30,FR-31,FR-32,FR-33,FR-34,FR-35,FR-36,FR-37,FR-38,FR-39,FR-40,FR-41,FR-42,FR-43,FR-44,FR-45,FR-46,FR-47,FR-48,FR-49,FR-50,FR-51,FR-52,FR-53,FR-54,FR-55,FR-56,FR-57,FR-58,FR-59,FR-60,FR-61,FR-62,FR-63,FR-64,FR-65,FR-66,FR-67,FR-68,FR-69,FR-70,FR-71,FR-72,FR-73,FR-74,FR-75,FR-76,FR-77,FR-78,FR-79,FR-80,FR-81,FR-82,FR-83,FR-84,FR-85,FR-86,FR-87,FR-88,FR-89,FR-90,FR-91,FR-92,FR-93,FR-94,FR-95,DE')) and (mapcss.outside(self.father.config.options, 'FR-02')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=DE")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-02")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-12")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-GF")
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-GP")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=NL")
+                err.append({'class': 6, 'subclass': 658590773, 'text': {'en': 'test'}})
+
+        # node[x][inside("FR")][outside("FX")]
+        if ('x' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'x')) and (mapcss.inside(self.father.config.options, 'FR')) and (mapcss.outside(self.father.config.options, 'FR-69M,FR-69D,FR-2A,FR-2B,FR-01,FR-02,FR-03,FR-04,FR-05,FR-06,FR-07,FR-08,FR-09,FR-10,FR-11,FR-12,FR-13,FR-14,FR-15,FR-16,FR-17,FR-18,FR-19,FR-20,FR-21,FR-22,FR-23,FR-24,FR-25,FR-26,FR-27,FR-28,FR-29,FR-30,FR-31,FR-32,FR-33,FR-34,FR-35,FR-36,FR-37,FR-38,FR-39,FR-40,FR-41,FR-42,FR-43,FR-44,FR-45,FR-46,FR-47,FR-48,FR-49,FR-50,FR-51,FR-52,FR-53,FR-54,FR-55,FR-56,FR-57,FR-58,FR-59,FR-60,FR-61,FR-62,FR-63,FR-64,FR-65,FR-66,FR-67,FR-68,FR-69,FR-70,FR-71,FR-72,FR-73,FR-74,FR-75,FR-76,FR-77,FR-78,FR-79,FR-80,FR-81,FR-82,FR-83,FR-84,FR-85,FR-86,FR-87,FR-88,FR-89,FR-90,FR-91,FR-92,FR-93,FR-94,FR-95')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # throwWarning:"test"
+                # -osmoseAssertNoMatchWithContext:list("node x=1","inside=FR-02")
+                # -osmoseAssertMatchWithContext:list("node x=1","inside=FR-GF")
+                err.append({'class': 6, 'subclass': 170749071, 'text': {'en': 'test'}})
+
         return err
 
     def way(self, data, tags, nds):
@@ -1576,6 +1657,58 @@ class Test(TestPluginMapcss):
         self.check_err(n.node(data, {'x': '4-5m'}), expected={'class': 6, 'subclass': 72306003})
         self.check_err(n.node(data, {'x': '5m*3'}), expected={'class': 6, 'subclass': 72306003})
         self.check_err(n.node(data, {'x': 'Hello'}), expected={'class': 6, 'subclass': 72306003})
+        with with_options(n, {'country': 'DE'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 759484915})
+        with with_options(n, {'country': 'FR'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 759484915})
+        with with_options(n, {'country': 'FR-02'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 759484915})
+        with with_options(n, {'country': 'FR-GP'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 759484915})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 759484915})
+        with with_options(n, {'country': 'DE'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'FR'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'FR-02'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'FR-GF'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'FR-GP'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 336478965})
+        with with_options(n, {'country': 'DE'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'FR'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'FR-02'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'FR-GF'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'FR-GP'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 1675393091})
+        with with_options(n, {'country': 'DE'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR-02'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR-12'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR-GF'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR-GP'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'NL'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 658590773})
+        with with_options(n, {'country': 'FR-02'}):
+            self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 170749071})
+        with with_options(n, {'country': 'FR-GF'}):
+            self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 170749071})
         self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 16, 'subclass': 1785050832})

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -595,3 +595,46 @@ node[any(siunit_length(tag(x)), "no result") == "no result"] {
   assertMatch: "node x=5m*3";
   assertMatch: "node x=1.3.5";
 }
+
+
+node[x][inside("FX,NL")] {
+  throwWarning: "test";
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=NL");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-02");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-GP");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=DE");
+}
+node[x][inside("FX,NL,FR-GF")] {
+  throwWarning: "test";
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=NL");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-02");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-GF");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-GP");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=DE");
+}
+node[x][inside("FX,NL,FR")] {
+  throwWarning: "test";
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=NL");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-02");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-GF");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-GP");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=DE");
+}
+node[x][inside("NL,FX,DE")][outside("FR-02")] {
+  throwWarning: "test";
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=NL");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=DE");
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-12");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-02");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-GF");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-GP");
+}
+node[x][inside("FR")][outside("FX")] {
+  throwWarning: "test";
+  -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-GF");
+  -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-02");
+}


### PR DESCRIPTION
- Implement method to convert special country codes to Osmose-codes
  - `FX` is already implemented
  - Others from [the special ones](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#exceptional-reservations) will trigger a console warning, to be implemented when needed
- Add test cases

Fixes #2318 