### PR TITLE
Fix list_contains (a.k.a. the `~=` mapcss operator) with whitespace after the `;`

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -210,7 +210,7 @@ def string_contains(subject, string):
 
 def list_contains(subject, string):
     if subject is not None and string is not None:
-        return string in subject and string in subject.split(";")
+        return string in subject and any(map(lambda s: s.strip() == string, subject.split(";")))
 
 def at(asset_lat, asset_lon, lat, lon):
     return asset_lat == lat and asset_lon == lon

--- a/plugins/tests/test_mapcss_parsing_evaluation.py
+++ b/plugins/tests/test_mapcss_parsing_evaluation.py
@@ -907,6 +907,7 @@ class test_mapcss_parsing_evaluation(PluginMapCSS):
                 except mapcss.RuleAbort: pass
             if match:
                 # throwWarning:"test #1610"
+                # assertMatch:"way x=\"C00; C1; C22\""
                 # assertMatch:"way x=C00;C1;C22"
                 # assertMatch:"way x=C1"
                 # assertNoMatch:"way x=C12"
@@ -1709,6 +1710,7 @@ class Test(TestPluginMapcss):
             self.check_not_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 170749071})
         with with_options(n, {'country': 'FR-GF'}):
             self.check_err(n.node(data, {'x': '1'}), expected={'class': 6, 'subclass': 170749071})
+        self.check_err(n.way(data, {'x': 'C00; C1; C22'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         self.check_err(n.way(data, {'x': 'C00;C1;C22'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         self.check_err(n.way(data, {'x': 'C1'}, [0]), expected={'class': 16, 'subclass': 1785050832})
         self.check_not_err(n.way(data, {'x': 'C12'}, [0]), expected={'class': 16, 'subclass': 1785050832})

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -26,6 +26,7 @@ way[x~=C1] {
   throwWarning: "test #1610";
   assertMatch: "way x=C1";
   assertMatch: "way x=C00;C1;C22";
+  assertMatch: "way x=\"C00; C1; C22\"";
   assertNoMatch: "way x=C12";
 }
 


### PR DESCRIPTION
The `~=` mapcss operator also allows for whitespace around the values.
E.g. `[a~=y]` is supposed to match:
- `a=y`
- `a=x;y;z`
- `a=x; y; z`

The latter wasn't working with the original implementation

(Note: empty values aren't removed for the `~=` operator: `[a~=""]` matches `a=x;;y` in JOSM)