### PR TITLE
Implement `trim_list` function

### DIFF
--- a/mapcss/mapcss_lib.py
+++ b/mapcss/mapcss_lib.py
@@ -434,6 +434,12 @@ def trim(string):
     if string is not None:
         return str_value(string.strip())
 
+#trim_list(list_name)
+#    remove leading and trailing whitespace from a list of strings, will remove entries that are empty afterwards [since r15591]
+def trim_list(l):
+    if l is not None and isinstance(l, list):
+        return list(filter(None, map(lambda s: s.strip(), l)))
+
 #JOSM_search("...")
 #    true, if JOSM search applies to the object
 def JOSM_search(string):
@@ -630,7 +636,7 @@ def to_double(string):
 #uniq_list()
 #    returns a list of strings that only have unique values from a list of strings [since r15353]
 def uniq_list(l):
-    return set(l)
+    return list(set(l))
 
 # siunit_length(str)
 #    convert length units to meter (fault tolerant, ignoring white space)

--- a/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
+++ b/plugins/tests/test_mapcss_parsing_evaluation.validator.mapcss
@@ -638,3 +638,12 @@ node[x][inside("FR")][outside("FX")] {
   -osmoseAssertMatchWithContext:list("node x=1", "inside=FR-GF");
   -osmoseAssertNoMatchWithContext:list("node x=1", "inside=FR-02");
 }
+
+
+node[x][join_list("-", trim_list(split(";", tag("x")))) = "a-b-c"] {
+  throwWarning: "test";
+  assertMatch: "node x=a;b;c";
+  assertMatch: "node x=;a;;b;;c;";
+  assertMatch: "node x=\"a;  b; ; c\"";
+  assertNoMatch: "node x=a;b;0;c";
+}


### PR DESCRIPTION
Implements the `trim_list` mapcss function
(Also ensure list functions always return lists, not sets, in case they get nested)

I didn't compile the test cases as they'd cause a merge conflict with the other PR, but I verified locally that they pass. They'll automatically compile upon the next mapcss update.