### PR TITLE
setting dhist requires install of pickleshare

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ notebook
 pandas
 ipyleaflet
 scipy
+pickleshare


### PR DESCRIPTION
The Jupyter notebooks required this. Not sure if it's the proper place to add.