### PR TITLE
Implement universal Wiki reader

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -40,3 +40,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-requests.packages.urllib3.util.retry]
 ignore_missing_imports = True
+[mypy-wikitextparser.*]
+ignore_missing_imports = True

--- a/plugins/TagFix_Tree.py
+++ b/plugins/TagFix_Tree.py
@@ -22,6 +22,7 @@
 from modules.OsmoseTranslation import T_
 from plugins.Plugin import Plugin
 from modules.downloader import urlread
+from plugins.modules.wikiReader import read_wiki_table
 
 
 class TagFix_Tree(Plugin):
@@ -34,7 +35,7 @@ class TagFix_Tree(Plugin):
         allowed_leaf_cycle = ("evergreen", "deciduous")
 
         data = urlread(u"https://wiki.openstreetmap.org/w/index.php?title=Tag:natural%3Dtree/List_of_Species&action=raw", 1)
-        data = list(map(lambda x: list(filter(lambda z: len(z) > 0, map(lambda y: y.strip(), x.split("|")))), data.split("|-")[1:-1]))
+        data = read_wiki_table(data)
         species_map = {}
         for row in data: # data: list of [species, species:wikidata, leaf_cycle, leaf_type]
             this_species = {}

--- a/plugins/TagWatchFrViPofm.py
+++ b/plugins/TagWatchFrViPofm.py
@@ -25,6 +25,7 @@ from modules.downloader import urlread
 from modules.Stablehash import stablehash, stablehash64
 import re
 from collections import defaultdict
+from plugins.modules.wikiReader import read_wiki_table, wikitag2text
 
 
 class TagWatchFrViPofm(Plugin):
@@ -52,43 +53,43 @@ class TagWatchFrViPofm(Plugin):
         self._update_ks_vr = defaultdict(dict)
         self._update_kr_vr = defaultdict(dict)
 
-        reline = re.compile(r"^\|([^|]*)\|\|([^|]*)\|\|([^|]*)\|\|([^|]*).*")
-
         # Obtain the info from https://wiki.openstreetmap.org/index.php?title=Tagging_mistakes
         data = urlread(u"https://wiki.openstreetmap.org/index.php?title=Tagging_mistakes&action=raw", 1)
-        data = data.split("\n")
-        for line in data:
-            for res in reline.findall(line):
-                only_for = res[3].strip()
-                if only_for in (None, '', country, language) or (country and country.startswith(only_for)):
-                    r = res[1].strip()
-                    c0 = res[2].strip()
-                    tags = ["fix:chair"] if c0 == "" else [c0, "fix:chair"]
-                    c = stablehash(c0)
-                    self.errors[c] = self.def_class(item = 3030, level = 2, tags = tags,
-                        title = {'en': c0},
-                        detail = T_(
+        data = read_wiki_table(data, skip_headers = False)[1:] # Headers in the middle of the table, not supported yet in read_wiki_table
+
+        for row in data:
+            only_for = row[3]
+            if only_for in (None, '', country, language) or (country and country.startswith(only_for)) or only_for.lower().startswith("{{taginfo"): # This also filters out the alphabetical headers
+                r = wikitag2text(row[1]) # replace-value
+                f = wikitag2text(row[0]) # to-be-replaced value
+                c0 = row[2] # the Osmose issue tag and issue title
+                tags = ["fix:chair"] if c0 == "" else [c0, "fix:chair"]
+                c = stablehash(c0)
+                self.errors[c] = self.def_class(item = 3030, level = 2, tags = tags,
+                    title = {'en': c0},
+                    detail = T_(
 '''Simple and frequent errors, can be updated by anyone on the wiki.'''),
-                        resource = 'https://wiki.openstreetmap.org/wiki/Tagging_mistakes')
-                    if u"=" in res[0]:
-                        k = res[0].split(u"=")[0].strip()
-                        v = res[0].split(u"=")[1].strip()
-                        if self.quoted(k):
-                            k = self.quoted2re(k)
-                            if self.quoted(v):
-                                self._update_kr_vr[k][self.quoted2re(v)] = [r, c]
-                            else:
-                                self._update_kr_vs[k][v] = [r, c]
+                    resource = 'https://wiki.openstreetmap.org/wiki/Tagging_mistakes')
+
+                if "=" in f:
+                    k = f.split("=")[0].strip()
+                    v = f.split("=")[1].strip()
+                    if self.quoted(k):
+                        k = self.quoted2re(k)
+                        if self.quoted(v):
+                            self._update_kr_vr[k][self.quoted2re(v)] = [r, c]
                         else:
-                            if self.quoted(v):
-                                self._update_ks_vr[k][self.quoted2re(v)] = [r, c]
-                            else:
-                                self._update_ks_vs[k][v] = [r, c]
+                            self._update_kr_vs[k][v] = [r, c]
                     else:
-                        if self.quoted(res[0]):
-                            self._update_kr[self.quoted2re(res[0])] = [r, c]
+                        if self.quoted(v):
+                            self._update_ks_vr[k][self.quoted2re(v)] = [r, c]
                         else:
-                            self._update_ks[res[0]] = [r, c]
+                            self._update_ks_vs[k][v] = [r, c]
+                else:
+                    if self.quoted(f):
+                        self._update_kr[self.quoted2re(f)] = [r, c]
+                    else:
+                        self._update_ks[f] = [r, c]
 
     def node(self, data, tags):
         err = []
@@ -142,6 +143,7 @@ class Test(TestPluginCommon):
         self.check_err(a.node(None, {"administrative": "boundary"}))
         self.check_err(a.node(None, {"name": "FIXME"}))
         self.check_err(a.node(None, {"Area": "plop"}))
+        self.check_err(a.node(None, {"access": "public"}))
         self.check_err(a.node(None, {"Fixme": "yes"}))
         self.check_err(a.node(None, {"voltage": "10kV"}))
         assert not a.node(None, {"area": "plop"})

--- a/plugins/modules/wikiReader.py
+++ b/plugins/modules/wikiReader.py
@@ -23,19 +23,20 @@
 # This module file contains functions to read MediaWiki markup tables, templates, lists, ...
 
 import wikitextparser
+from typing import Union, Optional
 
 # Get a list of lists containing all cells of a table.
 # Parameters:
-#   wikitext (str) - the text of a wikipedia page
-#   tab_index (int) - the index of the table (if there's multiple tables on the wiki)
-#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
-#   skip_headers (bool) - if True, header rows are removed. Assumes all headers are on top
+#   wikitext - the text of a wikipedia page
+#   tab_index - the index of the table (if there's multiple tables on the wiki)
+#   keep_markup - if False, everything (except Templates) will be converted to plain text
+#   skip_headers - if True, header rows are removed. Assumes all headers are on top
 # Returns:
 #   The cell contents, specified as a list in a list.
 #   The outer list is the rows, the inner list are the cells in that row
 # Throws:
 #   If the table at the specified index isn't found
-def read_wiki_table(wikitext, tab_index = 0, keep_markup = False, skip_headers = True):
+def read_wiki_table(wikitext: str, tab_index: int = 0, keep_markup: bool = False, skip_headers: bool = True) -> list[list[Optional[str]]]:
     # Drops all markup, such as italics, hyperlinks, ...
     if not keep_markup:
         wikitext = wikitextparser.remove_markup(wikitext, replace_tables=False, replace_templates=False)
@@ -54,14 +55,14 @@ def read_wiki_table(wikitext, tab_index = 0, keep_markup = False, skip_headers =
 
 # Get all instances of a certain wiki template within wikitext
 # Parameters:
-#   wikitext (str) - the text of a wikipedia page
-#   template_name (str or list of str) - the name of the template to locate, e.g. 'Deprecated features/item'
-#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
+#   wikitext - the text of a wikipedia page
+#   template_name - the name or names of the template to locate, e.g. 'Deprecated features/item'
+#   keep_markup - if False, everything (except Templates) will be converted to plain text
 # Returns:
 #   A list containing lists of strings with values [template_string, template_name, argument1, argument2, argument3, ...]
 #   Example: ["{{Tag | key | value}}", "Tag", "key", "value"]
 #   (Note that the template_string is affected by the markup removal, so for string replace purposes, use keep_markup=True)
-def read_wiki_templates(wikitext, template_name, keep_markup = False):
+def read_wiki_templates(wikitext: str, template_name: Union[str, list[str]], keep_markup: bool = False) -> list[list[str]]:
     if isinstance(template_name, str):
         template_name = [template_name]
     template_name = list(map(str.lower, template_name))
@@ -78,16 +79,16 @@ def read_wiki_templates(wikitext, template_name, keep_markup = False):
 
 # Get all entries in a list within wikitext
 # Parameters:
-#   wikitext (str) - the text of a wikipedia page
-#   list_index (int) - the index of the list (if there's multiple lists on the wiki)
-#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
-#   include_sublists (bool) - if true, include subitems. If false, only include the highest level items
+#   wikitext - the text of a wikipedia page
+#   list_index - the index of the list (if there's multiple lists on the wiki)
+#   keep_markup - if False, everything (except Templates) will be converted to plain text
+#   include_sublists - if true, include subitems. If false, only include the highest level items
 #       When true, the list item symbol (*, **, #, ##, :, ...) will also be included in the output
 # Returns:
 #   A list with all list items
 # Throws:
 #   If the list at index list_index doesn't exist
-def read_wiki_list(wikitext, list_index = 0, keep_markup = False, include_sublists = False):
+def read_wiki_list(wikitext: str, list_index: int = 0, keep_markup: bool = False, include_sublists: bool = False) -> list[str]:
     if not keep_markup:
         wikitext = wikitextparser.remove_markup(wikitext, replace_templates=False)
 
@@ -100,7 +101,7 @@ def read_wiki_list(wikitext, list_index = 0, keep_markup = False, include_sublis
 
 # Get all list entries within wikitext
 # See read_wiki_list for details (excluding list_index)
-def read_all_wiki_lists(wikitext, keep_markup = False, include_sublists = False):
+def read_all_wiki_lists(wikitext: str, keep_markup: bool = False, include_sublists: bool = False) -> list[str]:
     res = []
     if not keep_markup:
         wikitext = wikitextparser.remove_markup(wikitext, replace_templates=False)
@@ -110,18 +111,18 @@ def read_all_wiki_lists(wikitext, keep_markup = False, include_sublists = False)
         while True:
             res.extend(read_wiki_list(wikitext, list_index=list_index, keep_markup=True, include_sublists=include_sublists))
             list_index += 1
-    except:
+    except IndexError:
         return res
 
 
 # Convert all instances of Tag-templates to textual tags, e.g. {{Tag|oneway|yes}} -> "oneway=yes"
 # Parameters:
-#   wikitext (str) - the text of a wikipedia page
-#   quote (bool) - whether the tag should be wrapped in ``
-#   star_value (bool) - whether empty tag values should be represented by *
+#   wikitext - the text of a wikipedia page
+#   quote - whether the tag should be wrapped in ``
+#   star_value - whether empty tag values should be represented by *
 # Returns:
 #   The wikitext with {{Tag|*}} replaced by the textual tag
-def wikitag2text(wikitext, quote = False, star_value = True):
+def wikitag2text(wikitext: str, quote: bool = False, star_value: bool = True) -> str:
     tag_templates = read_wiki_templates(wikitext, ["Tag", "Key"], keep_markup = True)
     for t in tag_templates:
         k = t[2]

--- a/plugins/modules/wikiReader.py
+++ b/plugins/modules/wikiReader.py
@@ -1,0 +1,135 @@
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights Osmose project 2024                                        ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+
+# This module file contains functions to read MediaWiki markup tables, templates, lists, ...
+
+import wikitextparser
+
+# Get a list of lists containing all cells of a table.
+# Parameters:
+#   wikitext (str) - the text of a wikipedia page
+#   tab_index (int) - the index of the table (if there's multiple tables on the wiki)
+#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
+#   skip_headers (bool) - if True, header rows are removed. Assumes all headers are on top
+# Returns:
+#   The cell contents, specified as a list in a list.
+#   The outer list is the rows, the inner list are the cells in that row
+# Throws:
+#   If the table at the specified index isn't found
+def read_wiki_table(wikitext, tab_index = 0, keep_markup = False, skip_headers = True):
+    # Drops all markup, such as italics, hyperlinks, ...
+    if not keep_markup:
+        wikitext = wikitextparser.remove_markup(wikitext, replace_tables=False, replace_templates=False)
+
+    t = wikitextparser.parse(wikitext).tables[tab_index]
+
+    # Remove header rows if desired
+    removable_header_rows = 0
+    if skip_headers:
+        removable_header_rows = len(list(filter(lambda c: c.is_header, t.cells(column=0))))
+    t = t.data()[removable_header_rows:]
+
+    # Remove whitespace around the cells
+    return list(map(lambda row: list(map(lambda c: c.strip() if isinstance(c, str) else c, row)), t))
+
+
+# Get all instances of a certain wiki template within wikitext
+# Parameters:
+#   wikitext (str) - the text of a wikipedia page
+#   template_name (str or list of str) - the name of the template to locate, e.g. 'Deprecated features/item'
+#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
+# Returns:
+#   A list containing lists of strings with values [template_string, template_name, argument1, argument2, argument3, ...]
+#   Example: ["{{Tag | key | value}}", "Tag", "key", "value"]
+#   (Note that the template_string is affected by the markup removal, so for string replace purposes, use keep_markup=True)
+def read_wiki_templates(wikitext, template_name, keep_markup = False):
+    if isinstance(template_name, str):
+        template_name = [template_name]
+    template_name = list(map(str.lower, template_name))
+
+    # Drops all markup, such as italics, hyperlinks, ...
+    if not keep_markup:
+        wikitext = wikitextparser.remove_markup(wikitext, replace_templates=False)
+
+    # Get all templates that match the filter
+    template_objects = list(filter(lambda t: t.name.strip().lower() in template_name, wikitextparser.parse(wikitext).templates))
+
+    return list(map(lambda t: [t.string, t.name.strip()] + [str(a)[1:].strip() for a in t.arguments], template_objects))
+
+
+# Get all entries in a list within wikitext
+# Parameters:
+#   wikitext (str) - the text of a wikipedia page
+#   list_index (int) - the index of the list (if there's multiple lists on the wiki)
+#   keep_markup (bool) - if False, everything (except Templates) will be converted to plain text
+#   include_sublists (bool) - if true, include subitems. If false, only include the highest level items
+#       When true, the list item symbol (*, **, #, ##, :, ...) will also be included in the output
+# Returns:
+#   A list with all list items
+# Throws:
+#   If the list at index list_index doesn't exist
+def read_wiki_list(wikitext, list_index = 0, keep_markup = False, include_sublists = False):
+    if not keep_markup:
+        wikitext = wikitextparser.remove_markup(wikitext, replace_templates=False)
+
+    lst = wikitextparser.parse(wikitext).get_lists()[list_index]
+    if include_sublists:
+        # Note this contains the list identifier, e.g. *, **, #, ##
+        return list(map(str.strip, lst.fullitems))
+    return list(map(str.strip, lst.items))
+
+
+# Get all list entries within wikitext
+# See read_wiki_list for details (excluding list_index)
+def read_all_wiki_lists(wikitext, keep_markup = False, include_sublists = False):
+    res = []
+    if not keep_markup:
+        wikitext = wikitextparser.remove_markup(wikitext, replace_templates=False)
+
+    try:
+        list_index = 0
+        while True:
+            res.extend(read_wiki_list(wikitext, list_index=list_index, keep_markup=True, include_sublists=include_sublists))
+            list_index += 1
+    except:
+        return res
+
+
+# Convert all instances of Tag-templates to textual tags, e.g. {{Tag|oneway|yes}} -> "oneway=yes"
+# Parameters:
+#   wikitext (str) - the text of a wikipedia page
+#   quote (bool) - whether the tag should be wrapped in ``
+#   star_value (bool) - whether empty tag values should be represented by *
+# Returns:
+#   The wikitext with {{Tag|*}} replaced by the textual tag
+def wikitag2text(wikitext, quote = False, star_value = True):
+    tag_templates = read_wiki_templates(wikitext, ["Tag", "Key"], keep_markup = True)
+    for t in tag_templates:
+        k = t[2]
+        # This part isn't perfect yet, there's special syntax for ;-separated, :-subkeys, :-subvalues, languages, ...
+        v = "*" if star_value else ""
+        if len(t) > 3:
+            v = "".join(t[3:]) or v
+        if v:
+            v = "=" + v
+        wikitext = wikitext.replace(t[0], "{2}{0}{1}{2}".format(k, v, "`" if quote else ""))
+    return wikitext

--- a/plugins/tests/wikireader_test.py
+++ b/plugins/tests/wikireader_test.py
@@ -1,0 +1,68 @@
+#-*- coding: utf-8 -*-
+from plugins.Plugin import TestPluginCommon
+from plugins.modules.wikiReader import read_wiki_table, read_wiki_templates, wikitag2text
+
+class Test(TestPluginCommon):
+    def test_wikitag2text(self):
+        for k in ["{{tag|abc|def}}", "{{Tag|abc|def}}", "{{ Tag | abc | def }}", "{{Key|abc|def}}", "{{Tag|abc||def}}", ]:
+            assert wikitag2text(k) == "abc=def"
+
+        for k in ["{{Tag|abc|}}", "{{tag|abc}}", "{{Key|abc}}"]:
+            assert wikitag2text(k) == "abc=*"
+            assert wikitag2text(k, star_value=False) == "abc"
+
+        assert wikitag2text("{{tag|abc|def}} and {{tag|ghi|jkl}}", quote=True) == "`abc=def` and `ghi=jkl`"
+
+
+    def test_wikitable(self):
+        t = """
+{| class="wikitable"
+! species || species:wikidata || {{key|leaf_cycle}} || {{key|leaf_type}}
+|-
+| Abies alba || [[:d:Q146992|Q146992]] || evergreen     || '''needleleaved'''
+|-
+|Abies pinsapo
+|[[:d:Q849381|Q849381]]
+|evergreen
+|needleleaved
+|-
+| Ziziphus jujuba || [[:d:Q11181633|Q11181633]] || deciduous
+|}"""
+        # Basic table reading + missing cell
+        assert read_wiki_table(t) == [
+            ["Abies alba", "Q146992", "evergreen", "needleleaved"],
+            ["Abies pinsapo", "Q849381", "evergreen", "needleleaved"],
+            ["Ziziphus jujuba", "Q11181633", "deciduous", None]]
+
+        # Header retention and ensuring templates like {{key|*}} are retained
+        assert read_wiki_table(t, skip_headers=False) == [
+            ["species", "species:wikidata", "{{key|leaf_cycle}}", "{{key|leaf_type}}"],
+            ["Abies alba", "Q146992", "evergreen", "needleleaved"],
+            ["Abies pinsapo", "Q849381", "evergreen", "needleleaved"],
+            ["Ziziphus jujuba", "Q11181633", "deciduous", None]]
+
+        # Ensure we can use markup if needed
+        assert read_wiki_table(t, keep_markup=True) == [
+            ["Abies alba", "[[:d:Q146992|Q146992]]", "evergreen", "'''needleleaved'''"],
+            ["Abies pinsapo", "[[:d:Q849381|Q849381]]", "evergreen", "needleleaved"],
+            ["Ziziphus jujuba", "[[:d:Q11181633|Q11181633]]", "deciduous", None]]
+
+
+    def test_wikitemplate(self):
+        t = """
+{{Deprecated features/item|lang={{{lang|}}}
+|suggestion={{Tag|leaf_type}} '''or''' {{Tag|leaf_cycle}}
+|  22  }}
+"""
+        assert read_wiki_templates(t, "Deprecated features/item")[0] == [
+            "{{Deprecated features/item|lang=\n|suggestion={{Tag|leaf_type}} or {{Tag|leaf_cycle}}\n|  22  }}",
+            "Deprecated features/item",
+            "lang=",
+            "suggestion={{Tag|leaf_type}} or {{Tag|leaf_cycle}}",
+            "22"]
+        assert read_wiki_templates(t, "Deprecated features/item", keep_markup = True)[0] == [
+            t.strip(),
+            "Deprecated features/item",
+            "lang={{{lang|}}}",
+            "suggestion={{Tag|leaf_type}} '''or''' {{Tag|leaf_cycle}}",
+            "22"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ protobuf < 4 # 4.x binary not yet compatible with system package, deps of vt2geo
 vt2geojson
 tiletanic
 sentry-sdk
+wikitextparser
 
 # Tests
 pytest == 7.4.4 # In v8 it skips the plugins folder, see our issue #2266 and https://github.com/pytest-dev/pytest/issues/12605


### PR DESCRIPTION
Implemented an initial wiki-reader based on the `wikitextparser` package and required functions
Adds support for reading tables, lists and templates, and adds a function to convert `{{Tag|x|y}}` to `x=y`

Plugins to convert (see #2345 #2351 #2357)
-  TagFix_Tree (table-based)
-  TagWatchFrViPofm (table-based)
-  TagFix_Postcode (table-based)
-  ~TagFix_Tree_Lang_fr (list-based)~ skipped
(The benefits are small at the moment, as it still requires a lot of post-parsing, making this PR unnecessary big. Also see 2361)
-  TagFix_Deprecated (template-based)
