### PR TITLE
Fix 2341: phone vs contact:phone with only spaces/dashes as difference

### DIFF
--- a/plugins/Phone2.py
+++ b/plugins/Phone2.py
@@ -23,19 +23,34 @@ class Phone2(PluginMapCSS):
         err = []
 
 
-        # *[phone][contact:phone][contact:phone!=*phone]
-        # *[fax][contact:fax][contact:fax!=*fax]
+        # *[phone][contact:phone][replace(replace(tag("contact:phone"),"-","")," ","")!=replace(replace(tag("phone"),"-","")," ","")]
+        # *[fax][contact:fax][replace(replace(tag("contact:fax"),"-","")," ","")!=replace(replace(tag("fax"),"-","")," ","")]
+        # *[mobile][contact:mobile][replace(replace(tag("contact:mobile"),"-","")," ","")!=replace(replace(tag("mobile"),"-","")," ","")]
+        # *[instagram][contact:instagram][contact:instagram!=*instagram]
+        # *[facebook][contact:facebook][contact:facebook!=*facebook]
         # *[email][contact:email][contact:email!=*email]
         # *[website][contact:website][contact:website!=*website]
-        if ('contact:email' in keys and 'email' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
+        if ('contact:email' in keys and 'email' in keys) or ('contact:facebook' in keys and 'facebook' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:instagram' in keys and 'instagram' in keys) or ('contact:mobile' in keys and 'mobile' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:phone') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'phone'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:phone'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'phone'), '-', ''), ' ', '')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:fax') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'fax'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:fax'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'fax'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'mobile')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:mobile')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:mobile'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'mobile'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'instagram')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:instagram')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:instagram') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'instagram'))))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'facebook')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:facebook')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:facebook') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'facebook'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
@@ -49,6 +64,7 @@ class Phone2(PluginMapCSS):
                 # group:tr("Different value of tag contact:* and *")
                 # -osmoseItemClassLevel:"3092/3097/2"
                 # throwWarning:tr("Different values of {0} and of {1}","{0.key}","{1.key}")
+                # assertNoMatch:"node phone=\"+31 123-456 789\" contact:phone=\"+31123456789\""
                 # assertMatch:"node phone=1 contact:phone=2"
                 # assertNoMatch:"node website=1 contact:website=1"
                 err.append({'class': 3097, 'subclass': 0, 'text': mapcss.tr('Different values of {0} and of {1}', mapcss._tag_uncapture(capture_tags, '{0.key}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
@@ -61,19 +77,34 @@ class Phone2(PluginMapCSS):
         err = []
 
 
-        # *[phone][contact:phone][contact:phone!=*phone]
-        # *[fax][contact:fax][contact:fax!=*fax]
+        # *[phone][contact:phone][replace(replace(tag("contact:phone"),"-","")," ","")!=replace(replace(tag("phone"),"-","")," ","")]
+        # *[fax][contact:fax][replace(replace(tag("contact:fax"),"-","")," ","")!=replace(replace(tag("fax"),"-","")," ","")]
+        # *[mobile][contact:mobile][replace(replace(tag("contact:mobile"),"-","")," ","")!=replace(replace(tag("mobile"),"-","")," ","")]
+        # *[instagram][contact:instagram][contact:instagram!=*instagram]
+        # *[facebook][contact:facebook][contact:facebook!=*facebook]
         # *[email][contact:email][contact:email!=*email]
         # *[website][contact:website][contact:website!=*website]
-        if ('contact:email' in keys and 'email' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
+        if ('contact:email' in keys and 'email' in keys) or ('contact:facebook' in keys and 'facebook' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:instagram' in keys and 'instagram' in keys) or ('contact:mobile' in keys and 'mobile' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:phone') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'phone'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:phone'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'phone'), '-', ''), ' ', '')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:fax') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'fax'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:fax'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'fax'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'mobile')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:mobile')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:mobile'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'mobile'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'instagram')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:instagram')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:instagram') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'instagram'))))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'facebook')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:facebook')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:facebook') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'facebook'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
@@ -97,19 +128,34 @@ class Phone2(PluginMapCSS):
         err = []
 
 
-        # *[phone][contact:phone][contact:phone!=*phone]
-        # *[fax][contact:fax][contact:fax!=*fax]
+        # *[phone][contact:phone][replace(replace(tag("contact:phone"),"-","")," ","")!=replace(replace(tag("phone"),"-","")," ","")]
+        # *[fax][contact:fax][replace(replace(tag("contact:fax"),"-","")," ","")!=replace(replace(tag("fax"),"-","")," ","")]
+        # *[mobile][contact:mobile][replace(replace(tag("contact:mobile"),"-","")," ","")!=replace(replace(tag("mobile"),"-","")," ","")]
+        # *[instagram][contact:instagram][contact:instagram!=*instagram]
+        # *[facebook][contact:facebook][contact:facebook!=*facebook]
         # *[email][contact:email][contact:email!=*email]
         # *[website][contact:website][contact:website!=*website]
-        if ('contact:email' in keys and 'email' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
+        if ('contact:email' in keys and 'email' in keys) or ('contact:facebook' in keys and 'facebook' in keys) or ('contact:fax' in keys and 'fax' in keys) or ('contact:instagram' in keys and 'instagram' in keys) or ('contact:mobile' in keys and 'mobile' in keys) or ('contact:phone' in keys and 'phone' in keys) or ('contact:website' in keys and 'website' in keys):
             match = False
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:phone') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'phone'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'phone')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:phone')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:phone'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'phone'), '-', ''), ' ', '')))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
-                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:fax') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'fax'))))
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'fax')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:fax')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:fax'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'fax'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'mobile')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:mobile')) and (mapcss.replace(mapcss.replace(mapcss.tag(tags, 'contact:mobile'), '-', ''), ' ', '') != mapcss.replace(mapcss.replace(mapcss.tag(tags, 'mobile'), '-', ''), ' ', '')))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'instagram')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:instagram')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:instagram') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'instagram'))))
+                except mapcss.RuleAbort: pass
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'facebook')) and (mapcss._tag_capture(capture_tags, 1, tags, 'contact:facebook')) and (mapcss._tag_capture(capture_tags, 2, tags, 'contact:facebook') != mapcss._value_capture(capture_tags, 2, mapcss.tag(tags, 'facebook'))))
                 except mapcss.RuleAbort: pass
             if not match:
                 capture_tags = {}
@@ -142,5 +188,6 @@ class Test(TestPluginMapcss):
         n.init(None)
         data = {'id': 0, 'lat': 0, 'lon': 0}
 
+        self.check_not_err(n.node(data, {'contact:phone': '+31123456789', 'phone': '+31 123-456 789'}), expected={'class': 3097, 'subclass': 0})
         self.check_err(n.node(data, {'contact:phone': '2', 'phone': '1'}), expected={'class': 3097, 'subclass': 0})
         self.check_not_err(n.node(data, {'contact:website': '1', 'website': '1'}), expected={'class': 3097, 'subclass': 0})

--- a/plugins/Phone2.validator.mapcss
+++ b/plugins/Phone2.validator.mapcss
@@ -31,8 +31,8 @@ meta[lang=fr] {
     description: "Téléphone";
 }
 
-*[phone][contact:phone][contact:phone!=*phone],
-*[fax][contact:fax][contact:fax!=*fax],
+*[phone][contact:phone][replace(tag("contact:phone"), " ", "")!=replace(tag("phone"), " ", "")],
+*[fax][contact:fax][replace(tag("contact:fax"), " ", "")!=replace(tag("fax"), " ", "")],
 *[email][contact:email][contact:email!=*email],
 *[website][contact:website][contact:website!=*website] {
     group: tr("Different value of tag contact:* and *");
@@ -41,4 +41,5 @@ meta[lang=fr] {
 
     assertMatch: "node phone=1 contact:phone=2";
     assertNoMatch: "node website=1 contact:website=1";
+    assertNoMatch: "node phone=\"+31 123 456 789\" contact:phone=\"+31123456789\"";
 }

--- a/plugins/Phone2.validator.mapcss
+++ b/plugins/Phone2.validator.mapcss
@@ -31,9 +31,9 @@ meta[lang=fr] {
     description: "Téléphone";
 }
 
-*[phone][contact:phone][replace(tag("contact:phone"), " ", "")!=replace(tag("phone"), " ", "")],
-*[fax][contact:fax][replace(tag("contact:fax"), " ", "")!=replace(tag("fax"), " ", "")],
-*[mobile][contact:mobile][replace(tag("contact:mobile"), " ", "")!=replace(tag("mobile"), " ", "")],
+*[phone][contact:phone][replace(replace(tag("contact:phone"), "-", ""), " ", "")!=replace(replace(tag("phone"), "-", ""), " ", "")],
+*[fax][contact:fax][replace(replace(tag("contact:fax"), "-", ""), " ", "")!=replace(replace(tag("fax"), "-", ""), " ", "")],
+*[mobile][contact:mobile][replace(replace(tag("contact:mobile"), "-", ""), " ", "")!=replace(replace(tag("mobile"), "-", ""), " ", "")],
 *[instagram][contact:instagram][contact:instagram!=*instagram],
 *[facebook][contact:facebook][contact:facebook!=*facebook],
 *[email][contact:email][contact:email!=*email],
@@ -44,5 +44,5 @@ meta[lang=fr] {
 
     assertMatch: "node phone=1 contact:phone=2";
     assertNoMatch: "node website=1 contact:website=1";
-    assertNoMatch: "node phone=\"+31 123 456 789\" contact:phone=\"+31123456789\"";
+    assertNoMatch: "node phone=\"+31 123-456 789\" contact:phone=\"+31123456789\"";
 }

--- a/plugins/Phone2.validator.mapcss
+++ b/plugins/Phone2.validator.mapcss
@@ -33,6 +33,9 @@ meta[lang=fr] {
 
 *[phone][contact:phone][replace(tag("contact:phone"), " ", "")!=replace(tag("phone"), " ", "")],
 *[fax][contact:fax][replace(tag("contact:fax"), " ", "")!=replace(tag("fax"), " ", "")],
+*[mobile][contact:mobile][replace(tag("contact:mobile"), " ", "")!=replace(tag("mobile"), " ", "")],
+*[instagram][contact:instagram][contact:instagram!=*instagram],
+*[facebook][contact:facebook][contact:facebook!=*facebook],
 *[email][contact:email][contact:email!=*email],
 *[website][contact:website][contact:website!=*website] {
     group: tr("Different value of tag contact:* and *");


### PR DESCRIPTION
See #2341

Disable the warning of different `phone` and `contact:phone` numbers if the only difference are spaces.
Although the ideal case is that the phone numbers are formatted, I don't think this has any benefit other than just 'looking nicer'. So if both are specified, once with and once without spaces, this shouldn't raise a warning that they're different phone numbers.

Also adds three very popular keys that also frequently occur as `contact:X` or as `X`

(The error in the tests is unrelated, that's fixed by the PR in 2358 )