### PR TITLE
remove motorway and trunk exclusions from almost junction check.

### DIFF
--- a/analysers/analyser_osmosis_highway_almost_junction.py
+++ b/analysers/analyser_osmosis_highway_almost_junction.py
@@ -45,7 +45,7 @@ FROM (
     FROM
       highways
     WHERE
-      highway NOT IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'service', 'footway', 'path', 'platform', 'steps') AND
+      highway NOT IN ('service', 'footway', 'path', 'platform', 'steps') AND
       NOT is_construction AND
       NOT is_polygon AND
       ST_Length(linestring_proj) > 10


### PR DESCRIPTION
I'm not sure why these were initially excluded and would be helpful to find accidentally disconnected roads. 
If there's a different check I should use or another reason for the exclusion let me know.