### PR TITLE
Test if plugin errors from tests are unique

### DIFF
--- a/plugins/Plugin.py
+++ b/plugins/Plugin.py
@@ -191,6 +191,11 @@ class TestPluginCommon(unittest.TestCase):
                     break
             assert found, str(expected) + " Not found in the errors list" + str(errors)
 
+        # Check if errors are also unique
+        errors_hashableitems = list(map(lambda e: str(e["class"]) + "|" + str(e.get("subclass", "")), errors))
+        non_unique = set([x for x in errors_hashableitems if errors_hashableitems.count(x) > 1])
+        assert len(non_unique) == 0, "Duplicate entry with class|subclass:\n - " + '\n - '.join(non_unique)
+
     def check_not_err(self, errors, log="Error not expected", expected=None):
         if not errors:
             return


### PR DESCRIPTION
Extends the `check_err` function of the plugin tests to also verify that an error is unique. Since plugin-errors are by definition on a per-OSM-object basis, it only needs to ensure there's a unique combination of class+subclass.

It would of course only catch situations that are actually checked with check_err, but every bit of safety is better than a frontend crash due to a duplicate entry :). For regular (Osmosis) analysers with test cases, such a test already exists.

---

An example case would for instance be if someone would replace the `set(...)` of TagFix_Access by `list(...)`, after which [this test line](https://github.com/osm-fr/osmose-backend/pull/2371/files#diff-496c0a72e60eae5c2799241f0d8691e8cde7454296fd735c27e77387476894e2R182) would throw two equal errors for bad value `nope`. Obviously that's just a hypothetical case :)