### PR TITLE
Validate `room`/`rooms` mixup

### DIFF
--- a/plugins/Number.py
+++ b/plugins/Number.py
@@ -74,7 +74,7 @@ be used if the value is valid.''')
 
         # Syntax ("tag", "default unit"), except for integer tags (those are converted automatically)
         self.tag_number = [("diameter", 'mm'), ("distance", 'km'), ("ele", 'm'), ("height", 'm'), ("length", 'm'), ("width", 'm'), ("diameter_crown", 'm'), ("circumference", 'm'), ("depth", 'm')]
-        self.tag_number_integer = ["admin_level", "capital", "heritage", "population", "step_count"] # Only positive integers (no units) allowed
+        self.tag_number_integer = ["admin_level", "capital", "heritage", "population", "rooms", "step_count"] # Only positive integers (no units) allowed
         tag_number_directional = [("maxaxleload", 't'), ("maxheight", 'm'), ("maxheight:physical", 'm'), ("maxlength", 'm'), ("maxspeed", 'km/h'), ("maxspeed:advisory", 'km/h'), ("maxweight", 't'), ("maxweightrating", 't'), ("maxwidth", 'm'), ("maxwidth:physical", 'm'), ("minspeed", 'km/h')]
 
         # Add suffixes to the directional tags, add everything to tag_number

--- a/plugins/indoor.py
+++ b/plugins/indoor.py
@@ -18,7 +18,7 @@ class indoor(PluginMapCSS):
         self.errors[52] = self.def_class(item = 1300, level = 3, tags = mapcss.list_('indoor', 'geom') + mapcss.list_('fix:survey', 'shop'), title = mapcss.tr('This indoor shop should probably be inside a room'))
         self.errors[53] = self.def_class(item = 1300, level = 2, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('This indoor room should have a door'))
         self.errors[21201] = self.def_class(item = 2120, level = 3, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('`{0}` without `{1}` or `{2}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}')))
-        self.errors[21202] = self.def_class(item = 2120, level = 3, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')))
+        self.errors[21202] = self.def_class(item = 2120, level = 3, tags = mapcss.list_('indoor', 'geom'), title = mapcss.tr('`{0}` without `{1}`', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}')), trap = mapcss.tr('For the number of rooms in a facility, use `{0}` instead.', 'rooms=*'))
 
         self.re_2a047336 = re.compile(r'room|corridor|area|level')
 
@@ -70,6 +70,7 @@ class indoor(PluginMapCSS):
                 try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
                 except mapcss.RuleAbort: pass
             if match:
+                # -osmoseTrap:tr("For the number of rooms in a facility, use `{0}` instead.","rooms=*")
                 # -osmoseItemClassLevel:"2120/21202:2/3"
                 # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
                 # fixAdd:"indoor=room"
@@ -174,6 +175,7 @@ class indoor(PluginMapCSS):
                 try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
                 except mapcss.RuleAbort: pass
             if match:
+                # -osmoseTrap:tr("For the number of rooms in a facility, use `{0}` instead.","rooms=*")
                 # -osmoseItemClassLevel:"2120/21202:2/3"
                 # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
                 # fixAdd:"indoor=room"
@@ -219,6 +221,7 @@ class indoor(PluginMapCSS):
                 try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'room')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'indoor')) and (not mapcss._tag_capture(capture_tags, 2, tags, 'buildingpart')))
                 except mapcss.RuleAbort: pass
             if match:
+                # -osmoseTrap:tr("For the number of rooms in a facility, use `{0}` instead.","rooms=*")
                 # -osmoseItemClassLevel:"2120/21202:2/3"
                 # throwWarning:tr("`{0}` without `{1}`","{0.tag}","{1.key}")
                 # fixAdd:"indoor=room"

--- a/plugins/indoor.validator.mapcss
+++ b/plugins/indoor.validator.mapcss
@@ -86,6 +86,7 @@ way:closed[indoor=corridor][shop][inside("DE,CH,FR")] {
 *[room][!indoor][!buildingpart] {
     throwWarning: tr("`{0}` without `{1}`", "{0.tag}", "{1.key}");
     -osmoseItemClassLevel: "2120/21202:2/3";
+    -osmoseTrap: tr("For the number of rooms in a facility, use `{0}` instead.", "rooms=*");
     fixAdd: "indoor=room";
     assertMatch: "node room=office";
 }


### PR DESCRIPTION
1. Validate that `rooms=*` is an (integer) number (Number.py)
2. Add a trap message to the existing `room=*` validator (to make sure people won't just add `indoor=yes` to it as proposed by the rule)