### PR TITLE
Fix 2383 - whitelist unicode Roman numbers

### DIFF
--- a/analysers/analyser_osmosis_highway_name_close.py
+++ b/analysers/analyser_osmosis_highway_name_close.py
@@ -29,7 +29,7 @@ sql10_regex = """regexp_replace(regexp_replace(regexp_replace(regexp_replace(reg
 '[-\\[\\]\\{{\\}}\\(\\)\"\\\\/]', '', 'g'),
 '(1st|2nd|3rd|[04-9]th)( |$)', '_', 'g'),
 '(1ra|2da|3ra|4ta|5ta|6ta|7ma|8va|9na|0ma|1er|2do|3ro|4to|5to|6to|7mo|8vo|9no|0mo)( |$)', '_', 'g'),
-'[/.0-9\u0660-\u0669\u06F0-\u06F9]', ' ', 'g'),
+'[/.0-9\u0660-\u0669\u06F0-\u06F9\u2160-\u2188]', ' ', 'g'), -- Numbers, Arabic numbers (u06**), Roman numbers (u21**)
 '(^| )[a-zA-Z](?= |$)', '\\1', 'g'),
 '(^| )[IVXLDCM]+(?= |$)', '\\1', 'g'),
 ' +', ' ', 'g')"""


### PR DESCRIPTION
See #2383 
Whitelist Roman numerals, a subset of the ["Number Forms" unicode block](https://en.wiktionary.org/wiki/Appendix:Unicode/Number_Forms)

Since these are undoubtedly numbers, I put them with the numbers (thus not requiring a space before or after to determine it's a Roman number, which we do require for regular Roman wring styles like I, II, III, IV, ...). Due to the removal of repeating spaces in the last regex I _think_ that shouldn't matter.