### PR TITLE
Make NSI country filter uniform

### DIFF
--- a/plugins/Name_Script.py
+++ b/plugins/Name_Script.py
@@ -120,7 +120,7 @@ appropriate.'''),
 
         self.whitelist_names = set()
         if country:
-            self.whitelist_names = whitelist_from_nsi(country[:2].lower())
+            self.whitelist_names = whitelist_from_nsi(country)
 
     def node(self, data, tags):
         err = []

--- a/plugins/Name_UpperCase.py
+++ b/plugins/Name_UpperCase.py
@@ -49,10 +49,10 @@ class Name_UpperCase(Plugin):
         self.country = None
 
         if "country" in self.father.config.options:
-            self.country = self.father.config.options.get("country")[:2]
-            self.whitelist = set(UpperCase_WhiteList.get(self.country, []))
+            self.country = self.father.config.options.get("country")
+            self.whitelist = set(UpperCase_WhiteList.get(self.country.split("-")[0], []))
             nsi_whitelist = set(filter(lambda name: self.UpperTitleCase.match(name) and not self.RomanNumber.match(name),
-                                       whitelist_from_nsi(self.country.lower())))
+                                       whitelist_from_nsi(self.country)))
             self.whitelist.update(nsi_whitelist)
         else:
             self.whitelist = set()
@@ -61,7 +61,7 @@ class Name_UpperCase(Plugin):
         err = []
         if "name" in tags:
             # Whitelist bus stops in Greece, see #2368
-            if self.country and self.country == "GR" and "public_transport" in tags and tags["public_transport"] in ("stop_position", "platform", "station"):
+            if self.country and self.country.split("-")[0] == "GR" and "public_transport" in tags and tags["public_transport"] in ("stop_position", "platform", "station"):
                 return err
 
             # first check if the name *might* match

--- a/plugins/TagFix_Brand.py
+++ b/plugins/TagFix_Brand.py
@@ -153,4 +153,41 @@ class Test(TestPluginCommon):
         a.father = father()
         a.init(None)
 
+        # Include CA, exclude CA-QC
         assert a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
+
+    def test_CA_ON(self):
+        a = TagFix_Brand(None)
+        class _config:
+            options = {"country": "CA-ON"}
+        class father:
+            config = _config()
+        a.father = father()
+        a.init(None)
+
+        # Include CA, exclude CA-QC
+        assert a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
+
+    def test_CA_QC_LAN(self):
+        a = TagFix_Brand(None)
+        class _config:
+            options = {"country": "CA-QC-LAN"}
+        class father:
+            config = _config()
+        a.father = father()
+        a.init(None)
+
+        # Include CA, exclude CA-QC
+        assert not a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
+
+    def test_CA_QC(self):
+        a = TagFix_Brand(None)
+        class _config:
+            options = {"country": "CA-QC"}
+        class father:
+            config = _config()
+        a.father = father()
+        a.init(None)
+
+        # Include CA, exclude CA-QC
+        assert not a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -39,13 +39,15 @@ def download_nsi():
 def nsi_rule_applies(locationSet, country):
     if not "include" in locationSet and not "exclude" in locationSet:
         return True
+    incl = set(map(lambda c: str(c).lower().replace('.geojson', '', 1), locationSet["include"] if "include" in locationSet else []))
+    excl = set(map(lambda c: str(c).lower().replace('.geojson', '', 1), locationSet["exclude"] if "exclude" in locationSet else []))
     # For extract with country="AB-CD-EF", check "AB-CD-EF", then "AB-CD", then "AB", then worldwide ("001")
     for c in ['-'.join(country.lower().split("-")[:i]) for i in range(country.count("-")+1, 0, -1)]:
-        if "exclude" in locationSet and c in locationSet["exclude"]:
+        if c in excl:
             return False
-        if "include" in locationSet and c in locationSet["include"]:
+        if c in incl:
             return True
-    return not "include" in locationSet or "001" in locationSet["include"]
+    return len(incl) == 0 or "001" in locationSet["include"]
 
 
 # Gets all valid (shop, amenity, ...) names that exist within a certain country


### PR DESCRIPTION
- Let all plugins use the same function, `nsi_rule_applies`, to evaluate the locationSet of NSI
- Allow country codes with subcodes (like "NL-GE") instead of only the country ("NL")

This doesn't fix 2358 completely yet, but makes a fix easier. 
Also, for cases where the geojson file has the same code as the Osmose extract (such as Iowa, Quebec, ...) this makes it work again.

For canada it also fixes some cases that never worked, e.g. [this entry](https://nsi.guide/index.html?t=operators&k=amenity&v=post_depot&tt=canada%20post&cc=ca) previously wasn't parsed well due to including `ca` but excluding `ca-qc`. We previously didn't support such "subregion-exclusions". 