### PR TITLE
Warn about tags with a literal star value

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -125,7 +125,7 @@ However, this should probably still conform to the typical format used for value
                 err.append({"class": 3040, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         for k in keyss:
-            if tags[k] == "unknown":
+            if tags[k] in ("unknown", "*"):
                 err.append({"class": 40613, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
 
         return err


### PR DESCRIPTION
This usually indicates someone took the wiki or a validator a bit too literal.
Fixes #2380