### PR TITLE
Add merge analyser for French power poles in Vendee

### DIFF
--- a/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
@@ -49,7 +49,7 @@ class Analyser_Merge_power_pole_FR_gracethd2 (Analyser_Merge_Point):
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['modele']),
-                        'operator': lambda res: extract_operator.get(res['gestionnai'],  extract_operator.get(res['proprietai'])) ,
+                        'operator': lambda res: extract_operator.get(res['gestionnai'],  extract_operator.get(res['proprietai'])),
                         'height': lambda res: res['prof_haut'] if res['prof_haut'] and float(res['prof_haut']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
 

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
@@ -59,4 +59,3 @@ class Analyser_Merge_power_pole_FR_gracethd2 (Analyser_Merge_Point):
         'PCMP': 'epoxy',
         'PMET': 'steel'
     }
-

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
@@ -49,7 +49,7 @@ class Analyser_Merge_power_pole_FR_gracethd2 (Analyser_Merge_Point):
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['modele']),
-                        'operator': lambda res: extract_operator.get(res['gestionnai']) if res['gestionnai'] and extract_operator.get(res['gestionnai']) else extract_operator.get(res['proprietai']) if res['proprietai'] and extract_operator.get(res['proprietai']) else None,
+                        'operator': lambda res: extract_operator.get(res['gestionnai'],  extract_operator.get(res['proprietai'])) ,
                         'height': lambda res: res['prof_haut'] if res['prof_haut'] and float(res['prof_haut']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
 

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
@@ -24,7 +24,7 @@ from modules.OsmoseTranslation import T_
 from .Analyser_Merge import Analyser_Merge_Point, SHP, LoadGeomCentroid, Conflate, Select, Mapping
 
 
-class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
+class Analyser_Merge_power_pole_FR_gracethd2 (Analyser_Merge_Point):
     def __init__(self, config, source_url, dataset_name, source, srid, conflationDistance, classs, extract_operator = None, logger = None):
         Analyser_Merge_Point.__init__(self, config, logger)
         self.def_class_missing_official(item = 8290, id = classs + 1, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
@@ -38,7 +38,7 @@ class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
             source_url,
             dataset_name,
             SHP(source, srid = srid, zip="*.shp"),
-            LoadGeomCentroid(),
+            LoadGeomCentroid(select = {"modele": ["PBOI", "PBET", "PCMP", "PMET"]}),
             Conflate(
                 select = Select(
                     types = ['nodes'],
@@ -48,9 +48,9 @@ class Analyser_Merge_power_pole_FR_gracethd (Analyser_Merge_Point):
                     static1 = {'power': 'pole'},
                     static2 = {'source': self.source},
                     mapping1 = {
-                        'material': lambda res: self.extract_material.get(res['pt_nature']),
-                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else extract_operator.get(res['pt_prop']) if res['pt_prop'] and extract_operator.get(res['pt_prop']) else None,
-                        'height': lambda res: res['pt_a_haut'] if res['pt_a_haut'] and float(res['pt_a_haut']) > 6.0 else None},
+                        'material': lambda res: self.extract_material.get(res['modele']),
+                        'operator': lambda res: extract_operator.get(res['gestionnai']) if res['gestionnai'] and extract_operator.get(res['gestionnai']) else extract_operator.get(res['proprietai']) if res['proprietai'] and extract_operator.get(res['proprietai']) else None,
+                        'height': lambda res: res['prof_haut'] if res['prof_haut'] and float(res['prof_haut']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
 
     extract_material = {

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Merge import Analyser_Merge_Point, SHP, LoadGeomCentroid, Conflate, Select, Mapping
+
+
+class Analyser_Merge_power_pole_FR_gracethd3 (Analyser_Merge_Point):
+    def __init__(self, config, source_url, dataset_name, source, srid, conflationDistance, classs, extract_operator = None, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8290, id = classs + 1, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole not integrated'))
+        self.def_class_possible_merge(item = 8291, id = classs + 3, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole integration suggestion'))
+        self.def_class_update_official(item = 8290, id = classs + 4, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole update'))
+
+        self.init(
+            source_url,
+            dataset_name,
+            SHP(source, srid = srid, zip="*.shp"),
+            LoadGeomCentroid(),
+            Conflate(
+                select = Select(
+                    types = ['nodes'],
+                    tags = {'power': 'pole'}),
+                conflationDistance = conflationDistance,
+                mapping = Mapping(
+                    static1 = {'power': 'pole'},
+                    static2 = {'source': self.source},
+                    mapping1 = {
+                        'material': lambda res: self.extract_material.get(res['pt_nature']),
+                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else extract_operator.get(res['pt_prop']) if res['pt_prop'] and extract_operator.get(res['pt_prop']) else None,
+                        'height': lambda res: res['pt_a_haut'] if res['pt_a_haut'] and float(res['pt_a_haut']) > 6.0 else None},
+                text = lambda tags, fields: {} )))
+
+    extract_material = {
+        'PBOI': 'wood',
+        'PBET': 'concrete',
+        'PCMP': 'epoxy',
+        'PMET': 'steel'
+    }

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
@@ -49,7 +49,7 @@ class Analyser_Merge_power_pole_FR_gracethd3 (Analyser_Merge_Point):
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['pt_nature']),
-                        'operator': lambda res: extract_operator.get(res['pt_gest']) if res['pt_gest'] and extract_operator.get(res['pt_gest']) else extract_operator.get(res['pt_prop']) if res['pt_prop'] and extract_operator.get(res['pt_prop']) else None,
+                        'operator': lambda res: extract_operator.get(res['pt_gest'], extract_operator.get(res['pt_prop'])),
                         'height': lambda res: res['pt_a_haut'] if res['pt_a_haut'] and float(res['pt_a_haut']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
 

--- a/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2024                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from .Analyser_Merge_power_pole_FR_gracethd2 import Analyser_Merge_power_pole_FR_gracethd2
+from .Analyser_Merge import SourceDataGouv
+
+class Analyser_Merge_power_pole_FR_gracethd2_vendee(Analyser_Merge_power_pole_FR_gracethd2):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_power_pole_FR_gracethd2.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-de-la-vendee/',
+            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP de la Vendée',
+            source=SourceDataGouv(
+                attribution="Vendée Numérique",
+                dataset="673d09a837eab9c52f42268b",
+                resource="cc66ae17-26a2-43f5-aea3-37496775776c"),
+            srid = 2154,
+            conflationDistance=5,
+            classs=1000,
+            extract_operator = {
+                'ENEDIS': 'Enedis'
+            },
+            logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
@@ -39,4 +39,3 @@ class Analyser_Merge_power_pole_FR_gracethd2_vendee(Analyser_Merge_power_pole_FR
                 'ENEDIS': 'Enedis'
             },
             logger=logger)
-

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_bretagne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_bretagne.py
@@ -20,22 +20,22 @@
 ##                                                                       ##
 ###########################################################################
 
-from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge_power_pole_FR_gracethd3 import Analyser_Merge_power_pole_FR_gracethd3
 from .Analyser_Merge import SourceDataGouv
 
-class Analyser_Merge_power_pole_FR_gracethd_dordogne(Analyser_Merge_power_pole_FR_gracethd):
+class Analyser_Merge_power_pole_FR_gracethd3_bretagne(Analyser_Merge_power_pole_FR_gracethd3):
     def __init__(self, config, logger = None):
-        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
-            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-de-la-dordogne/',
-            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP de la Dordogne',
+        Analyser_Merge_power_pole_FR_gracethd3.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/recensement-poteaux-enedis-reutilises-dans-le-cadre-du-deploiement-ftth-du-projet-bretagne-tres-haut-debit/',
+            dataset_name='Recensement poteaux ENEDIS réutilisés dans le cadre du déploiement FTTH du projet Bretagne Très Haut Débit',
             source=SourceDataGouv(
-                attribution="Syndicat Mixte Périgord Numérique",
-                dataset="659d72fb641c7c0d6fe6cc59",
-                resource="82e49c1f-976f-4be7-ab20-0a58e9badb56"),
+                attribution="Mégalis Bretagne",
+                dataset="6613a43e5b40aaa8022d3787",
+                resource="b00051b6-69e5-42c3-8229-f6b556561d83"),
             srid = 2154,
             conflationDistance=5,
             classs=1000,
             extract_operator = {
-                'OR000000000003': 'Enedis'
+                'ORMB0000000003': 'Enedis'
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_dordogne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_dordogne.py
@@ -20,22 +20,22 @@
 ##                                                                       ##
 ###########################################################################
 
-from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge_power_pole_FR_gracethd3 import Analyser_Merge_power_pole_FR_gracethd3
 from .Analyser_Merge import SourceDataGouv
 
-class Analyser_Merge_power_pole_FR_gracethd_jura(Analyser_Merge_power_pole_FR_gracethd):
+class Analyser_Merge_power_pole_FR_gracethd3_dordogne(Analyser_Merge_power_pole_FR_gracethd3):
     def __init__(self, config, logger = None):
-        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
-            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-du-jura/',
-            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP du Jura',
+        Analyser_Merge_power_pole_FR_gracethd3.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-de-la-dordogne/',
+            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP de la Dordogne',
             source=SourceDataGouv(
-                attribution="SIDEC Jura",
-                dataset="66158cdd04686348037417af",
-                resource="3f427bbd-f2bb-49dc-9457-c0aad16b1529"),
+                attribution="Syndicat Mixte Périgord Numérique",
+                dataset="659d72fb641c7c0d6fe6cc59",
+                resource="82e49c1f-976f-4be7-ab20-0a58e9badb56"),
             srid = 2154,
             conflationDistance=5,
             classs=1000,
             extract_operator = {
-                'OR00000003': 'Enedis'
+                'OR000000000003': 'Enedis'
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_jura.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_jura.py
@@ -20,22 +20,22 @@
 ##                                                                       ##
 ###########################################################################
 
-from .Analyser_Merge_power_pole_FR_gracethd import Analyser_Merge_power_pole_FR_gracethd
+from .Analyser_Merge_power_pole_FR_gracethd3 import Analyser_Merge_power_pole_FR_gracethd3
 from .Analyser_Merge import SourceDataGouv
 
-class Analyser_Merge_power_pole_FR_gracethd_bretagne(Analyser_Merge_power_pole_FR_gracethd):
+class Analyser_Merge_power_pole_FR_gracethd3_jura(Analyser_Merge_power_pole_FR_gracethd3):
     def __init__(self, config, logger = None):
-        Analyser_Merge_power_pole_FR_gracethd.__init__(self, config,
-            source_url='https://www.data.gouv.fr/fr/datasets/recensement-poteaux-enedis-reutilises-dans-le-cadre-du-deploiement-ftth-du-projet-bretagne-tres-haut-debit/',
-            dataset_name='Recensement poteaux ENEDIS réutilisés dans le cadre du déploiement FTTH du projet Bretagne Très Haut Débit',
+        Analyser_Merge_power_pole_FR_gracethd3.__init__(self, config,
+            source_url='https://www.data.gouv.fr/fr/datasets/appuis-aeriens-enedis-utilises-dans-le-cadre-du-deploiement-de-la-fibre-sur-le-rip-du-jura/',
+            dataset_name='Appuis aériens ENEDIS utilisés dans le cadre du déploiement de la Fibre sur le RIP du Jura',
             source=SourceDataGouv(
-                attribution="Mégalis Bretagne",
-                dataset="6613a43e5b40aaa8022d3787",
-                resource="b00051b6-69e5-42c3-8229-f6b556561d83"),
+                attribution="SIDEC Jura",
+                dataset="66158cdd04686348037417af",
+                resource="3f427bbd-f2bb-49dc-9457-c0aad16b1529"),
             srid = 2154,
             conflationDistance=5,
             classs=1000,
             extract_operator = {
-                'ORMB0000000003': 'Enedis'
+                'OR00000003': 'Enedis'
             },
             logger=logger)

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -307,7 +307,7 @@ include_aquitaine = [
     'merge_winery_FR_aquitaine',
 ]
 france_departement("aquitaine/dordogne", 7375, "FR-24", include=include_aquitaine + [
-    'merge_power_pole_FR_gracethd_dordogne'
+    'merge_power_pole_FR_gracethd3_dordogne'
 ])
 france_departement("aquitaine/gironde", 7405, "FR-33", include=include_aquitaine + [
     # Bordeaux
@@ -347,7 +347,7 @@ france_departement("bourgogne/yonne", 7392, "FR-89")
 
 include_bretagne = [
     # Bretagne
-    'merge_power_pole_FR_gracethd_bretagne'
+    'merge_power_pole_FR_gracethd3_bretagne'
 ]
 france_departement("bretagne/cotes_d_armor", 7398, "FR-22", include=include_bretagne)
 france_departement("bretagne/ille_et_vilaine", 7465, "FR-35", include=include_bretagne + [
@@ -383,7 +383,7 @@ france_departement("corse/haute_corse", 76931, "FR-2B")
 france_departement("franche_comte/doubs", 7462, "FR-25")
 france_departement("franche_comte/jura", 7460, "FR-39", include=[
     'merge_hydrants_FR_SDIS_39',
-    'merge_power_pole_FR_gracethd_jura'
+    'merge_power_pole_FR_gracethd3_jura'
 ])
 france_departement("franche_comte/haute_saone", 7423, "FR-70")
 france_departement("franche_comte/territoire_de_belfort", 7410, "FR-90")
@@ -470,7 +470,9 @@ france_departement("pays_de_la_loire/maine_et_loire", 7409, "FR-49", include=[
 ])
 france_departement("pays_de_la_loire/mayenne", 7438, "FR-53")
 france_departement("pays_de_la_loire/sarthe", 7443, "FR-72")
-france_departement("pays_de_la_loire/vendee", 7402, "FR-85")
+france_departement("pays_de_la_loire/vendee", 7402, "FR-85", include=[
+    'merge_power_pole_FR_gracethd2_vendee'
+])
 
 france_departement("picardie/aisne", 7411, "FR-02")
 france_departement("picardie/oise", 7427, "FR-60")


### PR DESCRIPTION
Vendée Numérique is a local authority in Vendée (France) who manage very high speed Internet broadband rollout.

They recently published power poles points used for fibre roll out that could be useful to complete power poles there.

This new analysis comes with a brand new gracethd2 abstract analyser as they still use Grace THD v2 instead of usual v3 which was already available.
As a consequence, current abstract gracethd analyser was moved to gracethd3 as to prevent any confusion.