### PR TITLE
Map NSI-country-names to Osmose country names / Fix failing tests

### DIFF
--- a/plugins/TagFix_Brand.py
+++ b/plugins/TagFix_Brand.py
@@ -137,12 +137,36 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299", "brand:wikidata": "Q1234567"})
         assert not a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
 
-        # Operators
+        # Operator only for FR-pac
+        assert not a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "operator": "Bataillon de marins-pompiers de Marseille"})
+
+    def test_FR13(self):
+        a = TagFix_Brand(None)
+        class _config:
+            options = {"country": "FR-13"}
+        class father:
+            config = _config()
+        a.father = father()
+        a.init(None)
+
+        # Operator only enabled for FR-pac, which contains FR-13
         assert a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "operator": "Bataillon de marins-pompiers de Marseille"})
         assert not a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "operator": "Bataillon de marins-pompiers de Marseille", "operator:wikidata": "Q2891011"})
-        assert not a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "not:operator:wikidata": "Q2891011"})
-        assert not a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "operator": "Unknown firestation"})
 
+    def test_LU(self):
+        a = TagFix_Brand(None)
+        class _config:
+            options = {"country": "LU"}
+        class father:
+            config = _config()
+        a.father = father()
+        a.init(None)
+
+        # Operators
+        assert a.node(None, {"amenity": "fire_station", "operator": "CGDIS"})
+        assert not a.node(None, {"amenity": "fire_station", "operator": "CGDIS", "operator:wikidata": "Q55334052"})
+        assert not a.node(None, {"amenity": "fire_station", "not:operator:wikidata": "Q55334052"})
+        assert not a.node(None, {"amenity": "fire_station", "operator": "Unknown firestation"})
 
     def test_CA(self):
         a = TagFix_Brand(None)

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -36,11 +36,66 @@ def download_nsi():
     return results['nsi']
 
 
+# Countries in NSI with different ids or spanning multiple Osmose extracts
+_nsi_to_osmose_map = {
+    # China
+    "hk": ["cn-91"], # Hong Kong
+    "mo": ["cn-92"], # Macau
+    # France
+    "fr-ara": [f"fr-{d:02}" for d in [1, 3, 7, 15, 26, 38, 42, 43, 63, 69, 73, 74]],  # Auvergne-Rhône-Alpes
+    "fr-bfc": [f"fr-{d:02}" for d in [21, 25, 39, 58, 70, 71, 89, 90]],  # Bourgogne-Franche-Comté
+    "fr-bre": [f"fr-{d:02}" for d in [22, 29, 35, 56]],  # Bretagne
+    "fr-cvl": [f"fr-{d:02}" for d in [18, 28, 36, 37, 41, 45]],  # Centre-Val de Loire
+    "fr-ges": [f"fr-{d:02}" for d in [8, 10, 51, 52, 54, 55, 57, 67, 68, 88]],  # Grand Est
+    "fr-hdf": [f"fr-{d:02}" for d in [2, 59, 60, 62, 80]],  # Hauts-de-France
+    "fr-idf": [f"fr-{d:02}" for d in [75, 77, 78, 91, 92, 93, 94, 95]],  # Île-de-France
+    "fr-nor": [f"fr-{d:02}" for d in [14, 27, 50, 61, 76]],  # Normandie
+    "fr-naq": [f"fr-{d:02}" for d in [16, 17, 19, 23, 24, 33, 40, 47, 64, 79, 86, 87]],  # Nouvelle-Aquitaine
+    "fr-occ": [f"fr-{d:02}" for d in [9, 11, 12, 30, 31, 32, 34, 46, 48, 65, 66, 81, 82]],  # Occitanie
+    "fr-pac": [f"fr-{d:02}" for d in [4, 5, 6, 13, 83, 84]],  # Provence-Alpes-Côte d'Azur
+    "fr-pdl": [f"fr-{d:02}" for d in [44, 49, 53, 72, 85]],  # Pays de la Loire
+    "fr-20r": ["fr-2a", "fr-2b"],  # Corse
+    "fx": ['fr-2a', 'fr-2b'] + [f"fr-{d:02}" for d in range(1,96)], # continental France
+    "gf": ["fr-gf"], # French Guiana
+    "gp": ["fr-gp"], # Guadeloupe
+    "mf": ["fr-mf"], # Saint-Martin, French part
+    "mq": ["fr-mq"], # Martinique
+    "pf": ["fr-pf"], # French Polynesia
+    "re": ["fr-re"], # Réunion
+    "yt": ["fr-yt"], # Mayotte
+    # Other
+    "el": ["gr"], # Greece
+    "ic": ["es-gc", "es-tf"], # Canary Islands
+    "id-jw": ["id-jb", "id-ji", "id-jt", "id-jk", "id-bt"], # Java
+    "ja": ["jm"], # Jamaica
+    "kv": ["xk"], # Kosovo
+    "pi": ["ph"], # Philippines
+    "ra": ["ar"], # Argentina
+    "us-vi": ["vi"], # Virgin Islands
+}
+
+# Convert NSI country codes to Osmose country codes if possible
+def _nsi_to_osmose_extracts(regionlist):
+    out = []
+    if not regionlist:
+        return out
+    for c in regionlist:
+        if not isinstance(c, str):
+            continue # Coordinates (with optional radius) rather than an extract, unsupported
+        c = c.lower().replace('.geojson', '', 1)
+        if c in _nsi_to_osmose_map:
+            out.extend(_nsi_to_osmose_map[c])
+        else:
+            out.append(c)
+    return out
+
+
+# Check if the locationSet object from NSI matches the country
 def nsi_rule_applies(locationSet, country):
     if not "include" in locationSet and not "exclude" in locationSet:
         return True
-    incl = set(map(lambda c: str(c).lower().replace('.geojson', '', 1), locationSet["include"] if "include" in locationSet else []))
-    excl = set(map(lambda c: str(c).lower().replace('.geojson', '', 1), locationSet["exclude"] if "exclude" in locationSet else []))
+    incl = _nsi_to_osmose_extracts(locationSet.get("include"))
+    excl = _nsi_to_osmose_extracts(locationSet.get("exclude"))
     # For extract with country="AB-CD-EF", check "AB-CD-EF", then "AB-CD", then "AB", then worldwide ("001")
     for c in ['-'.join(country.lower().split("-")[:i]) for i in range(country.count("-")+1, 0, -1)]:
         if c in excl:
@@ -65,3 +120,24 @@ def whitelist_from_nsi(country, nsi = download_nsi(), nsiprefix = 'brands/'):
                     whitelist.add(preset["tags"]["name"])
                 whitelist.add(preset["displayName"])
     return whitelist
+
+
+
+
+# Get a list of regions in NSI that aren't covered yet
+#import osmose_config as o_c
+#_debug_osmose_countries = list(filter(None, map(lambda c: c.analyser_options.get("country"), o_c.config.values())))
+#_debug_osmose_missing_countries = set()
+#def _debug_list_unsupported_countries(cc):
+#    if isinstance(cc, str):
+#        cc = cc.replace('.geojson', '', 1).upper()
+#        if cc not in _debug_osmose_countries and cc.lower() not in _nsi_to_osmose_map and not any(filter(lambda c: c.startswith(cc + "-"), _debug_osmose_countries)):
+#            _debug_osmose_missing_countries.add(cc.lower())
+#nsi = download_nsi()
+#for details in nsi.values():
+#    if "items" in details:
+#        for preset in details["items"]:
+#            if "locationSet" in preset:
+#                list(map(_debug_list_unsupported_countries, preset["locationSet"].get("include", [])))
+#                list(map(_debug_list_unsupported_countries, preset["locationSet"].get("exclude", [])))
+#print("Unsupported countries from NSI: " + ", ".join(sorted(_debug_osmose_missing_countries)))


### PR DESCRIPTION
See #2385 

In some cases NSI uses a different country subdivision than Osmose.
This adds a map for such cases.

It doesn't fix cases where:
1. The subdivision in NSI is finer than in Osmose, e.g. Denmark, which NSI splits in DK-81 etc
2. Coordinates are used instead

Also my map probably isn't complete, I went through it fairly quickly, but left the code to get the missing entries at the bottom.
Another thing that probably has to be done is to have some library to convert the 3-letter codes (like `fra`) to 2 letter codes (like `fr`). Possibly https://github.com/pycountry/pycountry

Also fixes the tests, since the Marseille firefighter case isn't enabled for all of France


p.s. I don't like the map solution very much, since it'll be difficult to maintain, but as mentioned in the issue I don't see many good alternatives...

<details>
<summary>With the other PR (about incorrect country codes) merged, and ignoring "001", this would be the remaining list of unsupported countries</summary>

```
002
029
039
150
151
155
202
419
830
ag
aldi-sued
aq
aut
bel
bq
bu
conus
crimea
deu
dk-040
dk-81
dk-82
dk-83
dk-84
dk-85
es-ib
esp
fra
gb-abd
gb-abe
gb-bas
gb-bir
gb-con
gb-dev
gb-dnd
gb-dor
gb-east-england
gb-east-midlands
gb-glg
gb-greater-manchester
gb-iow
gb-lan
gb-lon
gb-mik
gb-north-east
gb-north-west
gb-nsm
gb-nwm
gb-ply
gb-som
gb-south-central
gb-south-east-coast
gb-south-west
gb-sry
gb-swd
gb-west-midlands
gb-wil
gb-yorkshire
idn
ie-d
jp-01
jp-08
jp-12
jp-45
jp-46
jp-ntt-east
jp-ntt-west
konsum-dresden
konsum-leipzig
london-cycles
miltonkeynes-cycles
ms,
northern cyprus
nz-auk
nz-bop
nz-can
nz-gis
nz-hkb
nz-mwt
nz-ntl
nz-ota
nz-tas
nz-wgn
nz-wko
ph-00-las_pinas_city
ph-00-mandaluyong_city
ph-00-marikina_city
ph-00-muntinlupa_city
ph-00-navotas_city
ph-00-paranaque_city
ph-00-pasig_city
ph-00-valenzuela_city
ph-01-alaminos_city
ph-01-candon_city
ph-01-dagupan_city
ph-01-san_carlos_city
ph-03-angeles_city
ph-05-naga_city
ph-07-danao_city
ph-07-lapu-lapu_city
ph-07-mandaue_city
ph-07-toledo_city
ph-08-ormoc_city
ph-13-butuan_city
ph-40-batangas_city
ph-40-lipa_city
ph-40-tanauan_city
ph-41-puerto_princesa_city
ph-agn
ph-aur
ph-boh
ph-buk
ph-bul
ph-cas
ph-ceb
ph-dav
ph-din
ph-iln
ph-ils
ph-isa
ph-kal
ph-lag
ph-ley
ph-lun
ph-mas
ph-mdc
ph-msc
ph-msr
ph-nir
ph-nir-bais_city
ph-nir-cadiz_city
ph-nir-la_carlota_city
ph-nir-sagay_city
ph-nir-silay_city
ph-nir-tanjay_city
ph-nsa
ph-nue
ph-nuv
ph-pam
ph-pan
ph-plw
ph-que
ph-sun
ph-sur
ph-zan
ph-zas
ph-zmb
pt-20
pt-30
q19188
q3336843
q644636
sba
stadtmobil-berlin
stadtmobil-hannover
stadtmobil-karlsruhe
stadtmobil-rhein-main
stadtmobil-rhein-neckar
stadtmobil-rhein-ruhr
stadtmobil-stuttgart
stadtmobil-suedbaden
stadtmobil-trier
us-baltimore_and_dc
us-ca-east_bay
us-ca-los_angeles_county
us-ca-orange_county
us-ca-san_francisco
us-ca-san_jose
us-ca-san_luis_obispo_county
us-cat_hood_river
us-fl-florida_keys
us-foodland_eastern
us-ky-peoples_bank_flemingsburg
us-md-baltimore
us-ne-first_state_bank_east
us-ne-first_state_bank_west
us-nv-southern
us-nv-washoe_county
us-ny-new_york_city
us-oh-cuyahoga_county
us-oh-greater_dayton_rta
us-oh-metro_rta
us-peoples_bank_oh
```
</details>