### PR TITLE
Support 3-letter country codes and numeric codes in NSI

### DIFF
--- a/plugins/TagFix_Brand.py
+++ b/plugins/TagFix_Brand.py
@@ -136,6 +136,7 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299"})
         assert not a.node(None, {"shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299", "brand:wikidata": "Q1234567"})
         assert not a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
+        assert a.node(None, {"name": "La Place", "amenity": "restaurant"}) # as 'fra' rather than 'FR' in NSI
 
         # Operator only for FR-pac
         assert not a.node(None, {"name": "Beautify fire station", "amenity": "fire_station", "operator": "Bataillon de marins-pompiers de Marseille"})
@@ -167,6 +168,8 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"amenity": "fire_station", "operator": "CGDIS", "operator:wikidata": "Q55334052"})
         assert not a.node(None, {"amenity": "fire_station", "not:operator:wikidata": "Q55334052"})
         assert not a.node(None, {"amenity": "fire_station", "operator": "Unknown firestation"})
+
+        assert not a.node(None, {"name": "La Place", "amenity": "restaurant"}) # as 'fra' rather than 'FR' in NSI
 
     def test_CA(self):
         a = TagFix_Brand(None)

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -26,6 +26,7 @@
 
 from modules.downloader import urlread
 import json
+from pycountry import countries as pycountries
 
 
 # Downloads and returns the parsed NSI database
@@ -85,6 +86,14 @@ def _nsi_to_osmose_extracts(regionlist):
         c = c.lower().replace('.geojson', '', 1)
         if c in _nsi_to_osmose_map:
             out.extend(_nsi_to_osmose_map[c])
+        elif len(c) == 3 and c != "001":
+            try:
+                # Convert ISO 3166-1 alpha-3 (3-letter) or numeric code
+                out.append(pycountries.lookup(c).alpha_2.lower())
+            except LookupError:
+                # We don't support any 3-letter/number code except "001", so if conversion
+                # isn't possible, ignore it. Special cases can be in _nsi_to_osmose_map
+                continue
         else:
             out.append(c)
     return out
@@ -131,6 +140,10 @@ def whitelist_from_nsi(country, nsi = download_nsi(), nsiprefix = 'brands/'):
 #def _debug_list_unsupported_countries(cc):
 #    if isinstance(cc, str):
 #        cc = cc.replace('.geojson', '', 1).upper()
+#        try:
+#            cc = pycountries.lookup(cc).alpha_2
+#        except:
+#            pass
 #        if cc not in _debug_osmose_countries and cc.lower() not in _nsi_to_osmose_map and not any(filter(lambda c: c.startswith(cc + "-"), _debug_osmose_countries)):
 #            _debug_osmose_missing_countries.add(cc.lower())
 #nsi = download_nsi()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ vt2geojson
 tiletanic
 sentry-sdk
 wikitextparser
+pycountry
 
 # Tests
 pytest == 7.4.4 # In v8 it skips the plugins folder, see our issue #2266 and https://github.com/pytest-dev/pytest/issues/12605


### PR DESCRIPTION
Followup of #2404
This would fix the last bit of #2385 that we can automate; everything else will require manual mapping in `_nsi_to_osmose_map` when needed

[`pycountry`](https://github.com/pycountry/pycountry) is LGPL-2.1, I think that's compatible with Osmose

