### PR TITLE
Fix Tanzania: add the script for the Swahili language 

### DIFF
--- a/modules/languages.py
+++ b/modules/languages.py
@@ -94,6 +94,7 @@ language2scripts = {
     'sr': ['Cyrillic'],
     'sr-Latn': [u'[A-Za-zČĆĐŠŽčćđšž]'],
     'sv': ['Latin'],
+    'sw': ['Latin'],
     'ta': ['Tamil'],
     'tg': ['Arabic', 'Cyrillic'],
     'th': ['Thai'],

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -2167,6 +2167,25 @@ class TestPluginCommon(unittest.TestCase):
             f = "analyser_" + a + ".py"
             assert f in analyser_files, "Not found: {0}".format(f)
 
+    def test_countrycode(self):
+        # Ensure country codes are uppercase and two letters (before any "-")
+        countries = list(map(lambda c: c.analyser_options.get("country"), config.values()))
+        assert [] == list(filter(lambda d: d is not None and len(d.split("-", 1)[0]) != 2, countries))
+        assert [] == list(filter(lambda d: d is not None and d != d.upper(), countries))
+
+    def test_languages(self):
+        # Ensure languages are lowercase and mapped to a script
+        from modules.languages import language2scripts
+        languages = []
+        for lang in list(map(lambda c: c.analyser_options.get("language"), config.values())):
+            if isinstance(lang, list):
+                languages.extend(lang)
+            elif lang is not None:
+                languages.append(lang)
+
+        assert set() == set(filter(lambda d: d[:2] != d[:2].lower(), languages))
+        assert set() == set(filter(lambda d: d not in language2scripts, languages))
+
 if __name__ == "__main__":
 
   import json

--- a/plugins/Name_Script.py
+++ b/plugins/Name_Script.py
@@ -102,6 +102,7 @@ appropriate.'''),
             for language in languages:
                 if not self.lang[language]:
                     languages = None
+                    break
 
             # Build default regex
             if languages:


### PR DESCRIPTION
- Adds test cases for country codes and languages, so that mistakes are already detected by pytest/github workers
- ~Remove the exception thrown during runtime. (Doesn't serve a purpose anymore, mistakes are detected by the tests)~
- Add `sw` as a Latin script (based on [Wikipedia](https://en.m.wikipedia.org/wiki/Swahili_language#Orthography))

Fixes #2420