### PR TITLE
Check for `maxspeed:(advisory/practical)` > `maxspeed`

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -21,6 +21,8 @@
 
 from modules.OsmoseTranslation import T_
 from plugins.Plugin import Plugin
+from plugins.modules.units import convertToUnit
+from modules.Stablehash import stablehash64
 
 
 class TagFix_Maxspeed(Plugin):
@@ -86,23 +88,49 @@ class TagFix_Maxspeed(Plugin):
 
     def init(self, logger):
         Plugin.init(self, logger)
+        self.errors[303240] = self.def_class(item = 3032, level = 2, tags = ['tag', 'highway'],
+            title = T_('Advisory or practical maxspeed exceeds legal speed limit'))
         self.errors[303241] = self.def_class(item = 3032, level = 1, tags = ['tag', 'highway'],
             title = T_('Discordant maxspeed and source:maxspeed or maxspeed:type'))
 
 
     def way(self, data, tags, nds):
-        if not tags.get('highway') or not tags.get('maxspeed') or not tags['maxspeed'][0] in "0123456789":
-            return
+        err = []
+        maxspeed_tags = list(filter(lambda t: t.startswith('maxspeed') and tags[t][0] in "0123456789", tags))
+
+        # Check that maxspeed:advisory/practical <= maxspeed
+        for t in maxspeed_tags:
+            if not (":advisory" in t or ":practical" in t):
+                continue
+            t_normal = t.replace(":advisory", "", 1).replace(":practical", "", 1)
+            if not t_normal in maxspeed_tags:
+                t_normal = t_normal.replace(":backward", "", 1).replace(":forward", "", 1).replace(":both_ways", "", 1)
+            if t_normal in maxspeed_tags:
+                try:
+                    if convertToUnit(tags[t], 'km/h') > convertToUnit(tags[t_normal], 'km/h'):
+                        err.append({
+                            'class': 303240,
+                            'subclass': stablehash64(t + "|" + t_normal),
+                            'text': {"en": "`{0}={1}` > `{2}={3}`".format(t, tags[t], t_normal, tags[t_normal])}
+                        })
+                except NotImplementedError:
+                    pass # Invalid number, checked in Number.py
+
+        if not "highway" in tags or not "maxspeed" in maxspeed_tags:
+            return err
+
+        # Check maxspeed vs. source:maxspeed / maxspeed:type
         other_maxspeed = tags.get('source:maxspeed', tags.get('maxspeed:type'))
         if other_maxspeed is None or ':' not in other_maxspeed:
-            return
+            return err
 
         source_maxspeed = self.maxspeed_table.get(other_maxspeed.lower()) or self.maxspeed_table_default.get(other_maxspeed.split(':')[1])
         if not source_maxspeed or len(source_maxspeed) == 0:
-            return
+            return err
 
         if tags['maxspeed'] not in source_maxspeed:
-            return [{'class': 303241, 'subclass': 0, 'text': T_('Discordant {0} and {1}', tags['maxspeed'], other_maxspeed)}]
+            err.append({'class': 303241, 'subclass': 0, 'text': T_('Discordant {0} and {1}', tags['maxspeed'], other_maxspeed)})
+        return err
 
 
 ###########################################################################
@@ -113,12 +141,26 @@ class Test(TestPluginCommon):
         a = TagFix_Maxspeed(None)
         a.init(None)
 
+        # Check maxspeed vs. source:maxspeed / maxspeed:type
         assert not a.way(None, {'name': 'foo'}, None)
         assert not a.way(None, {'highway': 'primary'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'source:maxspeed': 'FR:urban'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:type': 'FR:urban'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '30', 'source:maxspeed': 'FR:urban'}, None)
         assert not a.way(None, {'highway': 'primary', 'maxspeed': '30', 'maxspeed:type': 'FR:urban'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': 'none', 'source:maxspeed': 'DE:motorway'}, None)
 
         self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '35', 'source:maxspeed': 'FR:urban'}, None))
         self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '35', 'maxspeed:type': 'FR:urban'}, None))
+
+
+        # Check that maxspeed:advisory/practical <= maxspeed
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:advisory': '40'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '50 mph', 'maxspeed:advisory': '9 mph'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': 'none', 'maxspeed:advisory': '100'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:emergency:practical': '100'}, None)
+        assert not a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:backward:advisory': '40'}, None)
+
+        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:advisory': '60'}, None))
+        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '50', 'maxspeed:backward:advisory': '60'}, None))
+        self.check_err(a.way(None, {'highway': 'primary', 'maxspeed': '50 mph', 'maxspeed:practical': '60 mph'}, None))


### PR DESCRIPTION
In nearly all cases the higher advisory/practical maxspeed was added before the legal maxspeed was added/updated (at a lower value than the practical/advisory maxspeed). Most likely they're thus leftover tags from older times. Examples:
- https://www.openstreetmap.org/way/1194270430
- https://www.openstreetmap.org/way/26929177
- https://www.openstreetmap.org/way/301134151
- https://www.openstreetmap.org/way/73533371
- https://www.openstreetmap.org/way/341562647

