### PR TITLE
Error with empty value + warning

### DIFF
--- a/plugins/TagFix_BadValue.py
+++ b/plugins/TagFix_BadValue.py
@@ -127,6 +127,13 @@ However, this should probably still conform to the typical format used for value
         for k in keyss:
             if tags[k] in ("unknown", "*"):
                 err.append({"class": 40613, "subclass": stablehash64(k), "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])) })
+            elif len(tags[k].strip()) == 0 and k not in check_list_open and k not in self.check_list_closed:
+                err.append({
+                    "class": 3040,
+                    "subclass": stablehash64(k),
+                    "text": T_("Concerns tag: `{0}`", '='.join([k, tags[k]])),
+                    "fix": {"-": [k]}
+                })
 
         return err
 
@@ -158,6 +165,9 @@ class Test(TestPluginCommon):
                   {"sport": "rugby_union;shot-put;long-jump"}, # good;whitelisted;bad
                   {"access": "unknown"},
                   {"tracktype": "gradde1"},
+                  {"leaf_cycle": ""},
+                  {"wetland": ""},
+                  {"random_key": ""},
                  ]:
             self.check_err(a.node(None, t), t)
             self.check_err(a.way(None, t, None), t)

--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -96,7 +96,7 @@ class TagFix_Maxspeed(Plugin):
 
     def way(self, data, tags, nds):
         err = []
-        maxspeed_tags = list(filter(lambda t: t.startswith('maxspeed') and tags[t][0] in "0123456789", tags))
+        maxspeed_tags = list(filter(lambda t: t.startswith('maxspeed') and tags[t] and tags[t][0] in "0123456789", tags))
 
         # Check that maxspeed:advisory/practical <= maxspeed
         for t in maxspeed_tags:


### PR DESCRIPTION
Surprisingly this is the first time I'm encountering them, so I always thought they didn't exist, but the following taught me otherwise:
```
2024-12-31 10:39:59       File "/data/project/osmose/backend/plugins/TagFix_Maxspeed.py", line 99, in way
2024-12-31 10:39:59         maxspeed_tags = list(filter(lambda t: t.startswith('maxspeed') and tags[t][0] in "0123456789", tags))
2024-12-31 10:39:59                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-12-31 10:39:59       File "/data/project/osmose/backend/plugins/TagFix_Maxspeed.py", line 99, in <lambda>
2024-12-31 10:39:59         maxspeed_tags = list(filter(lambda t: t.startswith('maxspeed') and tags[t][0] in "0123456789", tags))
2024-12-31 10:39:59                                                                            ~~~~~~~^^^
2024-12-31 10:39:59     IndexError: string index out of range
```

### Tags without value

Some examples from this extract: (this extract has 7 of them)
- https://www.openstreetmap.org/way/474159364
- https://www.openstreetmap.org/node/11141071205


This PR fixes the issue and adds a warning against those that aren't warned against yet.


Also:

### Happy new year!