### PR TITLE
Add merge analyser for French Enedis power distribution poles

### DIFF
--- a/analysers/analyser_merge_power_pole_FR_spec_enedis.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_enedis.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyrights François Lacombe - 2025                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Merge import Analyser_Merge_Point, SourceDataGouv, CSV, Load_XY, Conflate, Select, Mapping
+
+
+class Analyser_Merge_power_pole_FR_spec_enedis (Analyser_Merge_Point):
+    def __init__(self, config, logger = None):
+        Analyser_Merge_Point.__init__(self, config, logger)
+        self.def_class_missing_official(item = 8290, id = 1001, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole not integrated'))
+        self.def_class_possible_merge(item = 8291, id = 1003, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole integration suggestion'))
+        self.def_class_update_official(item = 8290, id = 1004, level = 3, tags = ['merge', 'power', 'fix:chair', 'fix:survey'],
+            title = T_('Power pole update'))
+
+        self.init(
+            "https://www.data.gouv.fr/fr/datasets/supports-eclairage-public-du-sde18/",
+            "Position géographique des poteaux électriques HTA et BT Enedis",
+            CSV(SourceDataGouv(
+                attribution="Enedis",
+                dataset="679574c33c924b19bd3f9ffd",
+                resource="c047d86c-4922-4934-8ffc-350935bded1a"
+            )),
+            Load_XY("lng", "lat"),
+            Conflate(
+                select = Select(
+                    types = ['nodes'],
+                    tags = {'power': 'pole'}),
+                conflationDistance = 3,
+                mapping = Mapping(
+                    static1 = {'power': 'pole'},
+                    static2 = {'source': self.source, 'operator':'Enedis', 'operator:wikidata':'Q3587594'},
+                text = lambda tags, fields: {} )))


### PR DESCRIPTION
It is proposed to add a new analyser to merge Enedis open data regarding distribution power poles in France.

As original dataset contains more than 1.5M of suitable features, a manual preprocess is done to restrict to first 300k rows for now. Thus it will generate less than 300k warnings.
Dataset will be regularly updated with new features as the amount of osmose warnings get lower.

This analyser is planed to be updated later with poles material once available in Enedis dataset at the end of the year.