### PR TITLE
Involve disused and demolished power towers in French merge analysis

### DIFF
--- a/analysers/analyser_merge_power_tower_FR.py
+++ b/analysers/analyser_merge_power_tower_FR.py
@@ -49,7 +49,7 @@ class Analyser_Merge_Power_Tower_FR(Analyser_Merge_Point):
                         {"power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
                         {"disused:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
                         {"removed:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
-                        {"demolished:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]}
+                        {"demolished:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
                     ]),
 #               osmRef = "ref:FR:RTE", # Commented initial. Only issues missing tower. Then when the missing tower number lower, uncomment to integrate ref into OSM.
                 conflationDistance = 10,

--- a/analysers/analyser_merge_power_tower_FR.py
+++ b/analysers/analyser_merge_power_tower_FR.py
@@ -45,8 +45,13 @@ class Analyser_Merge_Power_Tower_FR(Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ["nodes"],
-                    tags = [{"power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]}]),
-#                osmRef = "ref:FR:RTE", # Commented initial. Only issues missing tower. Then when the missing tower number lower, uncomment to integrate ref into OSM.
+                    tags = [
+                        {"power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
+                        {"disused:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
+                        {"removed:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]},
+                        {"demolished:power": ["tower", "pole", "terminal", "portal", "insulator"], "operator": [False, "RTE"]}
+                    ]),
+#               osmRef = "ref:FR:RTE", # Commented initial. Only issues missing tower. Then when the missing tower number lower, uncomment to integrate ref into OSM.
                 conflationDistance = 10,
                 mapping = Mapping(
                     static1 = {


### PR DESCRIPTION
I propose to involve disused and demolished power towers in French merge analysis as to avoid false positives.

Disused power towers are left in OSM with lifecycle prefix to avoid any further contribution since they remain visible on aerial imagery for a significant period of time.
When moved to `disused:power` or `demolished:powr` key, Osmose raise new warnings as they are still in open data too.

This PR will avoid such warnings to raise against disused OSM feature
https://osmose.openstreetmap.fr/fr/issue/2ff3bbd7-0265-7086-c7ce-fc27417243cb
https://www.openstreetmap.org/node/1770640476

If successful, the same behavior will be implemented on merge_power_pole analyzers.