### PR TITLE
Remove unnecessary check for transformer frequency tag

### DIFF
--- a/plugins/Power.validator.mapcss
+++ b/plugins/Power.validator.mapcss
@@ -43,12 +43,3 @@ node[power=transformer][voltage] {
     -osmoseItemClassLevel: "9100/91002/2";
     -osmoseTags: list("tag");
 }
-
-node[power=transformer][!frequency] {
-    throwWarning: tr("Power Transformers should have a frequency tag");
-    -osmoseItemClassLevel: "9100/91003/3";
-    -osmoseTags: list("tag");
-
-    assertMatch: "node power=transformer";
-    assertNoMatch: "node power=transformer frequency=50";
-}


### PR DESCRIPTION
This check claims to come from JOSM but it seems to have been removed from JOSM.

In general, we don't require that frequency is tagged on power objects unless it differs from the standard grid frequency.

This also agrees with the [wiki page](https://wiki.openstreetmap.org/wiki/Tag:power=transformer)

cc @flacombe 