### PR TITLE
Fix lint: avoid generating tests for mapcss if there are no tests

### DIFF
--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -942,7 +942,26 @@ def compile(inputfile, class_name, mapcss_url = None, only_for = [], not_for = [
     global class_, tests, regex_store, set_store
     rules = dict(map(lambda t: [t, to_p({'type': 'stylesheet', 'rules': selectors_type[t]})], sorted(selectors_type.keys(), key = lambda a: {'node': 0, 'way': 1, 'relation':2}[a])))
     items = build_items(class_)
-    asserts = build_tests(tests)
+
+    asserts = ""
+    if tests:
+        asserts = """
+
+from plugins.PluginMapCSS import TestPluginMapcss
+
+
+class Test(TestPluginMapcss):
+    def test(self):
+        n = """ + prefix + class_name + """(None)
+        class _config:
+            options = {"country": None, "language": None}
+        class father:
+            config = _config()
+        n.father = father()
+        n.init(None)
+        data = {'id': 0, 'lat': 0, 'lon': 0}
+
+        """ + build_tests(tests).replace("\n", "\n        ") + "\n"
 
     mapcss = ("""#-*- coding: utf-8 -*-
 import modules.mapcss_lib as mapcss
@@ -972,24 +991,8 @@ class """ + prefix + class_name + """(PluginMapCSS):
 
         """ + rules[t].replace("\n", "\n        ") + """
         return err
-""", sorted(rules.keys(), key = lambda a: {'node': 0, 'way': 1, 'relation':2}[a]))) + """
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = """ + prefix + class_name + """(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-        """ + asserts.replace("\n", "\n        ") + """
-""").replace("        \n", "\n")
+""", sorted(rules.keys(), key = lambda a: {'node': 0, 'way': 1, 'relation':2}[a])))
+    + asserts).replace("        \n", "\n")
     return mapcss
 
 

--- a/plugins/Josm_ItalySpecific.py
+++ b/plugins/Josm_ItalySpecific.py
@@ -82,20 +82,3 @@ class Josm_ItalySpecific(PluginMapCSS):
                 err.append({'class': 21001, 'subclass': 0, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Josm_ItalySpecific(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-

--- a/plugins/Josm_Rules_Brazilian_Specific.py
+++ b/plugins/Josm_Rules_Brazilian_Specific.py
@@ -4848,20 +4848,3 @@ class Josm_Rules_Brazilian_Specific(PluginMapCSS):
                 }})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Josm_Rules_Brazilian_Specific(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-

--- a/plugins/Josm_Seamark.py
+++ b/plugins/Josm_Seamark.py
@@ -1115,20 +1115,3 @@ class Josm_Seamark(PluginMapCSS):
                 err.append({'class': 9012010, 'subclass': 1214402030, 'text': mapcss.tr('{0} sign require {1} set to left or right', mapcss._tag_uncapture(capture_tags, '{0.value}'), mapcss._tag_uncapture(capture_tags, '{1.key}'))})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Josm_Seamark(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-

--- a/plugins/Josm_religion.py
+++ b/plugins/Josm_religion.py
@@ -101,20 +101,3 @@ class Josm_religion(PluginMapCSS):
                 }})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Josm_religion(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-

--- a/plugins/Josm_ru_housenumber.py
+++ b/plugins/Josm_ru_housenumber.py
@@ -77,20 +77,3 @@ class Josm_ru_housenumber(PluginMapCSS):
                 err.append({'class': 9017001, 'subclass': 774061168, 'text': mapcss.tr('Номера домов не соответствующие принятому соглашению')})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Josm_ru_housenumber(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-

--- a/plugins/Power.py
+++ b/plugins/Power.py
@@ -59,20 +59,3 @@ class Power(PluginMapCSS):
                 err.append({'class': 91001, 'subclass': 0, 'text': mapcss.tr('Power Transformers should always be on a node')})
 
         return err
-
-
-from plugins.PluginMapCSS import TestPluginMapcss
-
-
-class Test(TestPluginMapcss):
-    def test(self):
-        n = Power(None)
-        class _config:
-            options = {"country": None, "language": None}
-        class father:
-            config = _config()
-        n.father = father()
-        n.init(None)
-        data = {'id': 0, 'lat': 0, 'lon': 0}
-
-


### PR DESCRIPTION
mapcss2osmose always generated the test code, also if there were 0 asserts.
Files starting with `plugins/Josm_*` are excluded from linting in [pylama.ini](https://github.com/osm-fr/osmose-backend/blob/dev/pylama.ini)

The file Power.py wasn't, thus causing:
```
plugins/Power.py:76:9 W0612 local variable 'data' is assigned to but never used [pyflakes]
plugins/Power.py:78:1 W391 blank line at end of file [pycodestyle]
```

This PR just stops the generation of test code if there are no tests. I thought that was a better solution than whitelisting it.

(Note I cannot remove the whitelist for `Josm_*` files due to other issues with the `set XYZ` commands, which frequently results in `W0612 local variable 'XYZ' is assigned to but never used` if XYZ isn't used in node + way + relation. This however doesn't affect Power.py and is more difficult to fix)