### PR TITLE
Add operator wikidata tag to power merge analysers

### DIFF
--- a/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd2.py
@@ -42,15 +42,22 @@ class Analyser_Merge_power_pole_FR_gracethd2 (Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ['nodes'],
-                    tags = {'power': 'pole'}),
+                    tags = [
+                        {"power": "pole"},
+                        {"disused:power": "pole"},
+                        {"removed:power": "pole"},
+                        {"demolished:power": "pole"},
+                    ]),
                 conflationDistance = conflationDistance,
                 mapping = Mapping(
                     static1 = {'power': 'pole'},
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['modele']),
-                        'operator': lambda res: extract_operator.get(res['gestionnai'],  extract_operator.get(res['proprietai'])),
+                        'operator': lambda res: extract_operator.get(res['gestionnai'])[0] if res['gestionnai'] in extract_operator else extract_operator.get(res['proprietai'])[0] if res['proprietai'] in extract_operator else None,
                         'height': lambda res: res['prof_haut'] if res['prof_haut'] and float(res['prof_haut']) > 6.0 else None},
+                    mapping2 = {
+                        'operator:wikidata': lambda res: extract_operator.get(res['gestionnai'])[1] if res['gestionnai'] in extract_operator else extract_operator.get(res['proprietai'])[1] if res['proprietai'] in extract_operator else None},
                 text = lambda tags, fields: {} )))
 
     extract_material = {

--- a/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
+++ b/analysers/Analyser_Merge_power_pole_FR_gracethd3.py
@@ -42,15 +42,22 @@ class Analyser_Merge_power_pole_FR_gracethd3 (Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ['nodes'],
-                    tags = {'power': 'pole'}),
+                    tags = [
+                        {"power": "pole"},
+                        {"disused:power": "pole"},
+                        {"removed:power": "pole"},
+                        {"demolished:power": "pole"},
+                    ]),
                 conflationDistance = conflationDistance,
                 mapping = Mapping(
                     static1 = {'power': 'pole'},
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['pt_nature']),
-                        'operator': lambda res: extract_operator.get(res['pt_gest'], extract_operator.get(res['pt_prop'])),
+                        'operator': lambda res: extract_operator.get(res['pt_gest'])[0] if res['pt_gest'] in extract_operator else extract_operator.get(res['pt_prop'])[0] if res['pt_prop'] in extract_operator else None,
                         'height': lambda res: res['pt_a_haut'] if res['pt_a_haut'] and float(res['pt_a_haut']) > 6.0 else None},
+                    mapping2 = {
+                        'operator:wikidata': lambda res: extract_operator.get(res['pt_gest'])[1] if res['pt_gest'] in extract_operator else extract_operator.get(res['pt_prop'])[1] if res['pt_prop'] in extract_operator else None},
                 text = lambda tags, fields: {} )))
 
     extract_material = {

--- a/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd2_vendee.py
@@ -35,6 +35,6 @@ class Analyser_Merge_power_pole_FR_gracethd2_vendee(Analyser_Merge_power_pole_FR
             conflationDistance=5,
             classs=1010,
             extract_operator = {
-                'ENEDIS': 'Enedis'
+                'ENEDIS': ['Enedis', 'Q3587594']
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_bretagne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_bretagne.py
@@ -35,6 +35,6 @@ class Analyser_Merge_power_pole_FR_gracethd3_bretagne(Analyser_Merge_power_pole_
             conflationDistance=5,
             classs=1020,
             extract_operator = {
-                'ORMB0000000003': 'Enedis'
+                'ORMB0000000003': ['Enedis','Q3587594']
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_dordogne.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_dordogne.py
@@ -35,6 +35,6 @@ class Analyser_Merge_power_pole_FR_gracethd3_dordogne(Analyser_Merge_power_pole_
             conflationDistance=5,
             classs=1030,
             extract_operator = {
-                'OR000000000003': 'Enedis'
+                'OR000000000003': ['Enedis','Q3587594']
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_gracethd3_jura.py
+++ b/analysers/analyser_merge_power_pole_FR_gracethd3_jura.py
@@ -35,6 +35,6 @@ class Analyser_Merge_power_pole_FR_gracethd3_jura(Analyser_Merge_power_pole_FR_g
             conflationDistance=5,
             classs=1040,
             extract_operator = {
-                'OR00000003': 'Enedis'
+                'OR00000003': ['Enedis', 'Q3587594']
             },
             logger=logger)

--- a/analysers/analyser_merge_power_pole_FR_spec_enedis.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_enedis.py
@@ -55,7 +55,12 @@ class Analyser_Merge_power_pole_FR_spec_enedis (Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ['nodes'],
-                    tags = {'power': ['pole', 'tower']}),
+                    tags = [
+                        {"power": ["pole", "tower"]},
+                        {"disused:power": ["pole", "tower"]},
+                        {"removed:power": ["pole", "tower"]},
+                        {"demolished:power": ["pole", "tower"]},
+                    ]),
                 conflationDistance = 6,
                 mapping = Mapping(
                     static1 = {'power': 'pole'},

--- a/analysers/analyser_merge_power_pole_FR_spec_fibre5962.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_fibre5962.py
@@ -59,7 +59,8 @@ class Analyser_Merge_power_pole_FR_spec_fibre5962 (Analyser_Merge_Point):
                     static2 = {'source': self.source},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['t_ptech__2']),
-                        'operator': lambda res: self.extract_operator.get(res['t_organism'])[0] if res['t_organism'] in self.extract_operator else None,
+                        'operator': lambda res: self.extract_operator.get(res['t_organism'])[0] if res['t_organism'] in self.extract_operator else None},
+                    mapping2 = {
                         'operator:wikidata': lambda res: self.extract_operator.get(res['t_organism'])[1] if res['t_organism'] in self.extract_operator else None},
                 text = lambda tags, fields: {} )))
 

--- a/analysers/analyser_merge_power_pole_FR_spec_sde18.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_sde18.py
@@ -48,11 +48,16 @@ class Analyser_Merge_power_pole_FR_spec_sde18 (Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ['nodes'],
-                    tags = {'power': 'pole'}),
+                    tags = [
+                        {"power": "pole"},
+                        {"disused:power": "pole"},
+                        {"removed:power": "pole"},
+                        {"demolished:power": "pole"},
+                    ]),
                 conflationDistance = 5,
                 mapping = Mapping(
-                    static1 = {'power': 'pole'},
-                    static2 = {'source': self.source, 'highway': 'street_lamp', 'operator':'Enedis', 'operator:wikidata':'Q3587594'},
+                    static1 = {'power': 'pole', 'operator':'Enedis'},
+                    static2 = {'source': self.source, 'highway': 'street_lamp', 'operator:wikidata':'Q3587594'},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['_matiere']),
                         'height': lambda res: res['hauteur'] if res['hauteur'] and res['hauteur'] > 6.0 else None},

--- a/analysers/analyser_merge_power_pole_FR_spec_sdey.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_sdey.py
@@ -46,21 +46,20 @@ class Analyser_Merge_power_pole_FR_spec_sdey (Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ['nodes'],
-                    tags = {'power': 'pole'}),
+                    tags = [
+                        {"power": "pole"},
+                        {"disused:power": "pole"},
+                        {"removed:power": "pole"},
+                        {"demolished:power": "pole"},
+                    ]),
                 conflationDistance = 5,
                 mapping = Mapping(
-                    static1 = {'power': 'pole'},
-                    static2 = {'source': self.source, 'highway': 'street_lamp'},
+                    static1 = {'power': 'pole', 'operator':'Enedis'},
+                    static2 = {'source': self.source, 'highway': 'street_lamp', 'operator:wikidata':'Q3587594'},
                     mapping1 = {
                         'material': lambda res: self.extract_material.get(res['matieresup']),
-                        'operator': lambda res: self.extract_operator.get(res['natursupor']),
                         'height': lambda res: res['haut_mat_m'] if res['haut_mat_m'] and res['haut_mat_m'].isnumeric() and float(res['haut_mat_m']) > 6.0 else None},
                 text = lambda tags, fields: {} )))
-
-    extract_operator = {
-        'EP+BT': 'Enedis',
-        'EP+BT+FT': 'Enedis'
-    }
 
     extract_material = {
         'BOIS': 'wood',

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -58,8 +58,38 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
                         "substation": "minor_distribution", # Currently default value, we're unable to destinguish distribution and minor_distribution in opendata
                         "voltage": "20000"}, # Currently lawful default value as there is no opendata to define it. Mappers may be knowledgeable
                     mapping2 = {
-                        "operator": "GRD",
-                        "name": lambda fields: fields["Nom poste"] if fields["Nom poste"] != "" and fields["GRD"] != "Strasbourg Électricité Réseaux" else None,
-                        "ref": lambda fields: fields["Nom poste"] if fields["Nom poste"] != "" and fields["GRD"] == "Strasbourg Électricité Réseaux" else None,
+                        "name": lambda fields: fields["Nom poste"] if fields["Nom poste"] != "" else None,
+                        "operator": lambda res: self.extract_operator.get(res['GRD'])[0] if res['GRD'] in self.extract_operator else res['GRD'],
+                        "operator:wikidata": lambda res: self.extract_operator.get(res['GRD'])[1] if res['GRD'] in self.extract_operator else None,
                         "source": lambda fields: self.source() + " - " + fields["GRD"]},
                 )))
+
+    # Main source: https://wiki.openstreetmap.org/wiki/Power_networks/France/Exploitants#Entreprises_de_distribution
+    extract_operator = {
+        "Coopérative d'électricité de Saint Martin de Londres": ['CESML', None],
+        #"Ene'O - Energies Services Occitans": [None, 'Q115468993'],
+        'Enedis': ['Enedis', 'Q3587594'],
+        #'Energie développement services du Briançonnais': [None, None],
+        'Energie et Services de Seyssel': ['ESSeyssel', 'Q92878829'],
+        #'Gascogne Energies Services': [None, None],
+        'Gedia': ['Gedia', 'Q115469036'],
+        'GÉRÉDIS': ['Gérédis', 'Q112115590'],
+        'GreenAlp': ['GreenAlp', 'Q115580260'],
+        #'Gignac Energie': [None, None],
+        "Régie d'Electricité de Thônes": ['REThones', 'Q115579327'],
+        #'Régie Services Energie': [None, None],
+        'réséda': ['réséda', 'Q112115721'],
+        'SOREA': ['Sorea', 'Q115470007'],
+        'SRD': ['SRD', 'Q110319893'],
+        #'SEM Beauvois Distrelec': [None, None],
+        #'SEML ENERGIES HAUTE TARENTAISE': [None, None],
+        'SICAE du Carmausin': ['SICAE-Carmausin', None],
+        'SICAE Est': ['SICAE Est', 'Q112115648'],
+        'SICAE Oise': ['SICAE Oise', 'Q112115524'],
+        'SICAE de la Somme et du Cambraisis': ['SICAE-Somme', 'Q112115660'],
+        'SICAP': ['SICAP', None],
+        'Strasbourg Électricité Réseaux': ['Strasbourg Électricité Réseaux', 'Q107352347'],
+        "Syndicat d'électricité synergie Maurienne": ['Synergie Maurienne', None],
+        'Synelva': ['Synelva', 'Q115470023'],
+        'Vialis': ['Vialis', 'Q113841490'],
+    }


### PR DESCRIPTION
Hello

It is proposed to generalise `operator:wikidata` tag in all merge power analysers.

It will be a goodenough fix #451 

Following success of #2440, let's involve disused, removed and demolished poles and towers to power poles analysers