### PR TITLE
Fix table reading with templates that imply cells

### DIFF
--- a/plugins/modules/wikiReader.py
+++ b/plugins/modules/wikiReader.py
@@ -42,6 +42,14 @@ def read_wiki_table(wikitext: str, tab_index: int = 0, keep_markup: bool = False
     if not keep_markup:
         wikitext = wikitextparser.remove_markup(wikitext, replace_tables=False, replace_templates=False)
 
+    # Convert templates that imply cells to text-only templates.
+    # The template name stays the same, so effectively we're changing the definition (adding a hardcoded 'cell on new line' `|` followed by the original template)
+    # Note: this method is not suitable for templates that can be used in- and outside a table. I'm not aware of such templates at the moment
+    cell_template_names = ["Taginfo entry"]
+    cell_template_str = set(map(lambda a: a[0], read_wiki_templates(wikitext, cell_template_names, keep_markup = True)))
+    for ct in cell_template_str:
+        wikitext = wikitext.replace(ct, "\n|" + ct)
+
     t = wikitextparser.parse(wikitext).tables[tab_index]
 
     # Remove header rows if desired

--- a/plugins/tests/wikireader_test.py
+++ b/plugins/tests/wikireader_test.py
@@ -54,6 +54,23 @@ class Test(TestPluginCommon):
             ["Abies pinsapo", "[[:d:Q849381|Q849381]]", "evergreen", "needleleaved"],
             ["Ziziphus jujuba", "[[:d:Q11181633|Q11181633]]", "deciduous", None]]
 
+    def test_wikitable_celltemplate(self):
+        t = """
+{| class="wikitable sortable"
+| ABC || DEF {{Taginfo entry|amenity}} || GHI
+|-
+| ABC || DEF
+{{Taginfo entry|amenity}}
+| {{Key|GHI}}
+|-
+| ABC ||
+{{Taginfo entry|amenity}} ||
+|}
+"""
+        assert read_wiki_table(t) == [
+            ["ABC", "DEF", "{{Taginfo entry|amenity}}", "GHI"],
+            ["ABC", "DEF", "{{Taginfo entry|amenity}}", "{{Key|GHI}}"],
+            ["ABC", "", "{{Taginfo entry|amenity}}", ""]]
 
     def test_wikitemplate(self):
         t = """


### PR DESCRIPTION
See #2469 

I'm using `read_wiki_templates` because it takes care of all possible lower/uppercase and whitespaces, as well as potential nested templates.

Since I don't change the template name, I need to filter for duplicates prior to calling replace. Otherwise, having the same template twice within the table would insert a `\n|` twice as well.