### PR TITLE
Fix dataset for merge_power_branch_FR

### DIFF
--- a/analysers/analyser_merge_power_branch_FR.py
+++ b/analysers/analyser_merge_power_branch_FR.py
@@ -43,7 +43,7 @@ class Analyser_Merge_Power_Branch_FR(Analyser_Merge_Point):
                 url="https://opendata.reseaux-energies.fr/explore/dataset/postes-electriques-rte",
                 attribution="data.gouv.fr:RTE")),
             Load_XY("Longitude poste (DD)", "Latitude poste (DD)",
-                select = {"FONCTION": "Poste de piquage"}),
+                select = {"FONCTION": "Point de piquage"}),
             Conflate(
                 select = Select(
                     types = ["nodes"],


### PR DESCRIPTION
I've just noticed that ODRE had changed the select value for `merge_power_branch_FR` at the beginning of 2024
See https://osmose.openstreetmap.fr/fr/issues/graph.png?item=8281&start_date=2023-01

This fix may revive #2027 