### PR TITLE
Split parking without highway rules

### DIFF
--- a/analysers/analyser_osmosis_parking_highway.py
+++ b/analysers/analyser_osmosis_parking_highway.py
@@ -43,27 +43,11 @@ CREATE INDEX park_highway_linestring_idx ON park_highway USING gist(linestring)
 sql12 = """
 CREATE TEMP TABLE parkings AS
 SELECT
-  *
-FROM (
-  SELECT
-    'W' || id AS type_id,
-    tags,
-    ST_MakePolygon(ways.linestring) AS poly
-  FROM
-    ways
-  WHERE
-    is_polygon AND
-    tags != ''::hstore
-  UNION ALL
-    SELECT
-      'R' || id AS type_id,
-      tags,
-      poly
-    FROM
-      multipolygons
-    WHERE
-      is_valid
-) AS t
+  type || id as type_id,
+  tags,
+  poly
+FROM
+  polygons
 WHERE
   tags?'amenity' AND
   tags->'amenity' = 'parking' AND
@@ -74,14 +58,17 @@ sql13 = """
 SELECT
   pr.type_id,
   ST_AsText(ST_PointOnSurface(pr.poly)),
-  pr.tags->'park_ride' != 'no',
-  ST_Perimeter(ST_Transform(pr.poly, {proj})) / ST_Area(ST_Transform(pr.poly, {proj}))
+  pr.tags->'park_ride' != 'no'
 FROM
   parkings AS pr
   LEFT JOIN park_highway AS highway ON
     ST_Intersects(pr.poly, highway.linestring)
 WHERE
-  highway.id IS NULL
+  highway.id IS NULL AND
+  (
+    pr.tags?'parking' OR
+    (pr.tags?'park_ride' AND pr.tags->'park_ride' != 'no')
+  )
 """
 
 
@@ -113,14 +100,14 @@ HAVING
 
 class Analyser_Osmosis_Parking_highway(Analyser_Osmosis):
 
-    requires_tables_common = ['highways', 'multipolygons']
+    requires_tables_common = ['highways', 'polygons']
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs[1] = self.def_class(item = 3161, level = 1, tags = ['highway', 'fix:chair'],
+        self.classs[1] = self.def_class(item = 3161, level = 1, tags = ['highway', 'fix:chair', 'parking'],
             title = T_('Missing access way to parking'),
             detail = T_('There should be a `highway` feature leading to this parking facility to allow for correct routing.'))
-        self.classs[2] = self.def_class(item = 3161, level = 3, tags = ['highway', 'fix:chair'],
+        self.classs[2] = self.def_class(item = 3161, level = 3, tags = ['highway', 'fix:chair', 'parking'],
             title = T_('Missing access way to parking'),
             detail = T_(
 '''There should be a `highway` feature leading to this parking facility
@@ -129,7 +116,7 @@ correct. If it is a street side parking (`parking=street_side`), layby (`parking
 then add appropriate tags.
 
 See [parking](https://wiki.openstreetmap.org/wiki/Key:parking) tag on the wiki.'''))
-        self.classs[3] = self.def_class(item = 3161, level = 3, tags = ['highway'],
+        self.classs[3] = self.def_class(item = 3161, level = 3, tags = ['highway', 'parking'],
             title = T_('Inconsistent access of parking'),
             detail = T_('''The `access` tag of the parking does not match the `access` tag of the ways inside the parking.
 As a result, this public parking space can only be reached via limited-access roads.'''),
@@ -142,9 +129,7 @@ As a result, this public parking space can only be reached via limited-access ro
         self.run(sql12)
         self.run(sql13.format(proj=self.config.options["proj"]), lambda res: {
             "class": 1 if res[2] else 2,
-            "data": [self.any_full, self.positionAsText],
-            # Street side parkings typically have a perimeter/area ratio > 0.1
-            "fix": {"+": {"parking": "street_side"}} if res[3] > 0.1 else None,
+            "data": [self.any_full, self.positionAsText]
         })
         self.run(sql20, lambda res: {
             "class": 3,
@@ -173,9 +158,8 @@ class Test(TestAnalyserOsmosis):
 
         self.root_err = self.load_errors()
         self.check_err(cl="1", elems=[("way", "101")])
-        self.check_err(cl="2", elems=[("way", "100")], fixes=[{"+": {"parking": "street_side"}}])
-        self.check_err(cl="2", elems=[("way", "124")], fixes=[])
-        self.check_err(cl="2", elems=[("way", "125")], fixes=[])
+        self.check_err(cl="2", elems=[("way", "124")])
+        self.check_err(cl="2", elems=[("way", "125")])
         self.check_err(cl="3", elems=[("way", "103"), ("way", "102")])
         self.check_err(cl="3", elems=[("way", "118"), ("way", "119"), ("way", "120")])
-        self.check_num_err(6)
+        self.check_num_err(5)

--- a/plugins/TagFix_MultipleTag2.py
+++ b/plugins/TagFix_MultipleTag2.py
@@ -30,6 +30,7 @@ class TagFix_MultipleTag2(PluginMapCSS):
         self.errors[71301] = self.def_class(item = 7130, level = 3, tags = mapcss.list_('tag') + mapcss.list_('highway', 'maxheight', 'fix:survey'), title = mapcss.tr('Missing maxheight tag'), detail = mapcss.tr('Missing `maxheight=*` or `maxheight:physical=*` for a tunnel or a way under a bridge.'))
         self.errors[303210] = self.def_class(item = 3032, level = 3, tags = mapcss.list_('tag'), title = mapcss.tr('Fence with {0} tag, also add {1}', mapcss._tag_uncapture(capture_tags, '{1.key}'), mapcss._tag_uncapture(capture_tags, '{2.key}')))
         self.errors[303211] = self.def_class(item = 3032, level = 3, tags = mapcss.list_('tag'), title = mapcss.tr('suspicious tag combination'))
+        self.errors[316150] = self.def_class(item = 3161, level = 3, tags = mapcss.list_('tag') + mapcss.list_('highway', 'fix:chair', 'parking'), title = mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}=*')), detail = mapcss.tr('Indicate the type of parking, for example `parking=street_side`, `parking=surface` or `parking=underground`, to distinguish between major parking lots and roadside parking. Add access tags and/or service ways through the parking lot as desired.'), resource = 'https://wiki.openstreetmap.org/wiki/Key:parking')
 
         self.re_066203d3 = re.compile(r'^[0-9]+$')
         self.re_2ae49e65 = re.compile(r'^(motorway_link|trunk_link|primary|primary_link|secondary|secondary_link)$')
@@ -237,6 +238,21 @@ class TagFix_MultipleTag2(PluginMapCSS):
                     '+': dict([
                     (mapcss.concat(mapcss._tag_uncapture(capture_tags, '{0.key}='), mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.replace(mapcss.concat(';', mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.tag(tags, 'alt_name')))), ';'), mapcss.concat(';', mapcss.tag(tags, 'name'), ';'), ';')))))).split('=', 1)])
                 }})
+
+        # node[amenity=parking][!parking]
+        if ('amenity' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'parking')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'parking')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway","fix:chair","parking")
+                # -osmoseDetail:tr("Indicate the type of parking, for example `parking=street_side`, `parking=surface` or `parking=underground`, to distinguish between major parking lots and roadside parking. Add access tags and/or service ways through the parking lot as desired.")
+                # -osmoseItemClassLevel:"3161/316150/3"
+                # -osmoseResource:"https://wiki.openstreetmap.org/wiki/Key:parking"
+                # throwWarning:tr("{0} without {1}","{0.tag}","{1.key}=*")
+                err.append({'class': 316150, 'subclass': 0, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}=*'))})
 
         # node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable]
         if ('tunnel' in keys):
@@ -548,6 +564,21 @@ class TagFix_MultipleTag2(PluginMapCSS):
                     (mapcss.concat(mapcss._tag_uncapture(capture_tags, '{0.key}='), mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.replace(mapcss.concat(';', mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.tag(tags, 'alt_name')))), ';'), mapcss.concat(';', mapcss.tag(tags, 'name'), ';'), ';')))))).split('=', 1)])
                 }})
 
+        # area[amenity=parking][!parking]
+        if ('amenity' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'parking')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'parking')) and (mapcss._tag_capture(capture_tags, -1, tags, 'area') != mapcss._value_const_capture(capture_tags, -1, 'no', 'no')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway","fix:chair","parking")
+                # -osmoseDetail:tr("Indicate the type of parking, for example `parking=street_side`, `parking=surface` or `parking=underground`, to distinguish between major parking lots and roadside parking. Add access tags and/or service ways through the parking lot as desired.")
+                # -osmoseItemClassLevel:"3161/316150/3"
+                # -osmoseResource:"https://wiki.openstreetmap.org/wiki/Key:parking"
+                # throwWarning:tr("{0} without {1}","{0.tag}","{1.key}=*")
+                err.append({'class': 316150, 'subclass': 0, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}=*'))})
+
         return err
 
     def relation(self, data, tags, members):
@@ -719,6 +750,23 @@ class TagFix_MultipleTag2(PluginMapCSS):
                     (mapcss.concat(mapcss._tag_uncapture(capture_tags, '{0.key}='), mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.replace(mapcss.concat(';', mapcss.join_list(';', mapcss.trim_list(mapcss.split(';', mapcss.tag(tags, 'alt_name')))), ';'), mapcss.concat(';', mapcss.tag(tags, 'name'), ';'), ';')))))).split('=', 1)])
                 }})
 
+        # area[amenity=parking][!parking]
+        if ('amenity' in keys and 'type' in keys):
+            match = False
+            if not match:
+                capture_tags = {}
+                try: match = ((mapcss._tag_capture(capture_tags, 0, tags, 'amenity') == mapcss._value_capture(capture_tags, 0, 'parking')) and (not mapcss._tag_capture(capture_tags, 1, tags, 'parking')) and (mapcss._tag_capture(capture_tags, -1, tags, 'type') == mapcss._value_capture(capture_tags, -1, 'multipolygon')))
+                except mapcss.RuleAbort: pass
+            if match:
+                # -osmoseTags:list("highway","fix:chair","parking")
+                # -osmoseDetail:tr("Indicate the type of parking, for example `parking=street_side`, `parking=surface` or `parking=underground`, to distinguish between major parking lots and roadside parking. Add access tags and/or service ways through the parking lot as desired.")
+                # -osmoseItemClassLevel:"3161/316150/3"
+                # -osmoseResource:"https://wiki.openstreetmap.org/wiki/Key:parking"
+                # throwWarning:tr("{0} without {1}","{0.tag}","{1.key}=*")
+                # assertNoMatch:"relation type=multipolygon amenity=parking parking=street_side"
+                # assertMatch:"relation type=multipolygon amenity=parking"
+                err.append({'class': 316150, 'subclass': 0, 'text': mapcss.tr('{0} without {1}', mapcss._tag_uncapture(capture_tags, '{0.tag}'), mapcss._tag_uncapture(capture_tags, '{1.key}=*'))})
+
         return err
 
 
@@ -769,3 +817,5 @@ class Test(TestPluginMapcss):
         self.check_not_err(n.way(data, {'bridge': 'yes', 'tunnel': 'no'}, [0]), expected={'class': 40303, 'subclass': 0})
         self.check_err(n.way(data, {'bridge': 'yes', 'tunnel': 'yes'}, [0]), expected={'class': 40303, 'subclass': 0})
         self.check_err(n.relation(data, {}, []), expected={'class': 21102, 'subclass': 0})
+        self.check_not_err(n.relation(data, {'amenity': 'parking', 'parking': 'street_side', 'type': 'multipolygon'}, []), expected={'class': 316150, 'subclass': 0})
+        self.check_err(n.relation(data, {'amenity': 'parking', 'type': 'multipolygon'}, []), expected={'class': 316150, 'subclass': 0})

--- a/plugins/TagFix_MultipleTag2.validator.mapcss
+++ b/plugins/TagFix_MultipleTag2.validator.mapcss
@@ -235,6 +235,19 @@ area[tourism=caravan_site][name][name=~/^[0-9]+$/][!ref][!building] {
 }
 
 
+node[amenity=parking][!parking],
+area[amenity=parking][!parking] {
+  throwWarning: tr("{0} without {1}", "{0.tag}", "{1.key}=*");
+  assertMatch: "relation type=multipolygon amenity=parking";
+  assertNoMatch: "relation type=multipolygon amenity=parking parking=street_side";
+  -osmoseItemClassLevel: "3161/316150/3";
+  -osmoseTags: list("highway", "fix:chair", "parking");
+  -osmoseDetail: tr("Indicate the type of parking, for example `parking=street_side`, `parking=surface` or `parking=underground`, to distinguish between major parking lots and roadside parking. Add access tags and/or service ways through the parking lot as desired.");
+  -osmoseResource: "https://wiki.openstreetmap.org/wiki/Key:parking";
+}
+
+
+
 /* Workaround for issue #1766 */
 node[tunnel][!highway][!area:highway][!railway][!waterway][!piste:type][type!=tunnel][public_transport!=platform][route!=ferry][man_made!=pipeline][man_made!=goods_conveyor][man_made!=wildlife_crossing][man_made!=tunnel][power!=cable] {
     throwWarning: tr("{0} on suspicious object", "{0.key}");

--- a/tests/osmosis_parking_highway.osm
+++ b/tests/osmosis_parking_highway.osm
@@ -1,8 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='JOSM'>
-  <node id='1' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81142559988' lon='5.81081705868' />
-  <node id='2' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81135808025' lon='5.81079940245' />
-  <node id='3' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8113093583' lon='5.81128684668' />
   <node id='4' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81168178543' lon='5.81124732951' />
   <node id='5' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81149715231' lon='5.81120481869' />
   <node id='6' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81145374794' lon='5.81169800951' />
@@ -34,7 +31,6 @@
   <node id='32' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127637074' lon='5.81158864692' />
   <node id='33' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81125265703' lon='5.81191567956' />
   <node id='34' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81089098504' lon='5.81286280125' />
-  <node id='35' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81094724532' lon='5.81242823953' />
   <node id='36' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81108272897' lon='5.81232238476' />
   <node id='37' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8110850253' lon='5.81221652998' />
   <node id='38' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81117802654' lon='5.81225552911' />
@@ -54,7 +50,6 @@
   <node id='52' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.8116458994' lon='5.81210974804' />
   <node id='53' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81165393645' lon='5.81218635347' />
   <node id='54' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81171679763' lon='5.81218449637' />
-  <node id='55' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.811376878' lon='5.81130450291' />
   <node id='56' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81134120413' lon='5.81079309111' />
   <node id='57' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81127368437' lon='5.81077543488' />
   <node id='58' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81122496233' lon='5.81126287911' />
@@ -63,14 +58,6 @@
   <node id='61' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81084809207' lon='5.81043376656' />
   <node id='62' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.810780024' lon='5.81115856271' />
   <node id='63' timestamp='2014-03-31T22:00:00Z' version='1' lat='51.81120828942' lon='5.8112637831' />
-  <way id='100' timestamp='2014-03-31T22:00:00Z' version='1'>
-    <nd ref='1' />
-    <nd ref='2' />
-    <nd ref='3' />
-    <nd ref='55' />
-    <nd ref='1' />
-    <tag k='amenity' v='parking' />
-  </way>
   <way id='101' timestamp='2014-03-31T22:00:00Z' version='1'>
     <nd ref='4' />
     <nd ref='5' />
@@ -242,5 +229,6 @@
     <nd ref='63' />
     <nd ref='60' />
     <tag k='amenity' v='parking' />
+    <tag k='parking' v='surface' />
   </way>
 </osm>


### PR DESCRIPTION
Split the rules between:
a) rules without `parking` tag (now via mapcss, asking to add parking tag first) 
b) rules with `parking` tag (same as before: requesting highways to be added through the parking)

This allows users to disable the rule if `parking=*` is absent by only selecting the class that triggers on "b)" (solves #2466), and makes the texts more clear to specify what is requested from the user.


Also:
- updates tests
- use table `polygons` rather than merging ways and multipolygons
- add the tag `parking` where it's missing