### PR TITLE
Add common round/large buildings, remove `yurt` as fix suggestion

### DIFF
--- a/analysers/analyser_osmosis_building_shapes.py
+++ b/analysers/analyser_osmosis_building_shapes.py
@@ -38,7 +38,7 @@ WHERE
     ST_MaxDistance(polygon_proj, polygon_proj) > 5 AND
     tags - ARRAY['created_by', 'source', 'name', 'building', 'man_made', 'note:qadastre'] = ''::hstore AND
     tags->'building' NOT IN ('hut', 'ger', 'yurt', 'slurry_tank') AND
-    tags->'man_made' NOT IN ('water_tower', 'reservoir_covered', 'wastewater_plant', 'storage_tank', 'windmill', 'dovecote', 'silo')
+    tags->'man_made' NOT IN ('water_tower', 'reservoir_covered', 'wastewater_plant', 'storage_tank', 'windmill', 'dovecote', 'silo', 'gasometer', 'lighthouse', 'bioreactor')
 """
 
 sql20 = """
@@ -52,7 +52,7 @@ WHERE
     polygon_proj IS NOT NULL AND
     ST_MaxDistance(polygon_proj, polygon_proj) > 300 AND
     tags - ARRAY['created_by', 'source', 'name', 'building', 'note:qadastre'] = ''::hstore AND
-    tags->'building' NOT IN ('warehouse', 'industrial','greenhouse')
+    tags->'building' NOT IN ('warehouse', 'industrial', 'greenhouse', 'manufacture', 'hospital', 'university')
 """
 
 class Analyser_Osmosis_Building_Shapes(Analyser_Osmosis):
@@ -82,7 +82,6 @@ tagged.''')
                 {"+":{"man_made":"dovecote"}},
                 {"+":{"man_made":"silo"}},
                 {"+":{"building":"hut"}},
-                {"+":{"building":"yurt"}},
                 {"+":{"building":"ger"}},
             ]}
             self.callback20 = lambda res: {"class":2, "data":[self.way_full, self.positionAsText], "fix":[


### PR DESCRIPTION
- Add some common large or round building types to remove those false positives
- Remove `yurt` from the fix suggestions ([listed as 'tagging mistake' on the wiki of `building=ger`](https://wiki.openstreetmap.org/wiki/Tag%3Abuilding%3Dger#Possible_tagging_mistakes)). I kept it in the "sql list" for now to avoid false positives