### PR TITLE
Implement multipolygon support for table buildings

### DIFF
--- a/analysers/analyser_osmosis_building_geodesie_FR.py
+++ b/analysers/analyser_osmosis_building_geodesie_FR.py
@@ -73,13 +73,12 @@ sql12 = """
 DROP VIEW IF EXISTS vicinity CASCADE;
 CREATE VIEW vicinity AS
 SELECT
-    survery_building.id AS s_id,
-    ways.id AS b_id
+    survery_building.id AS s_id
 FROM
     survery_building
-    JOIN buildings AS ways ON
-        survery_building.geom && ways.linestring AND
-        ST_DWithIn(survery_building.geom_transform, polygon_proj, 0.5)
+    JOIN buildings AS b ON
+        survery_building.geom && b.poly AND
+        ST_DWithIn(survery_building.geom_transform, poly_proj, 0.5)
 """
 
 sql13 = """

--- a/analysers/analyser_osmosis_building_shapes.py
+++ b/analysers/analyser_osmosis_building_shapes.py
@@ -26,16 +26,15 @@ from .Analyser_Osmosis import Analyser_Osmosis
 
 sql10 = """
 SELECT
-    id,
-    ST_AsText(way_locate(linestring))
+    type_id,
+    ST_AsText(polygon_locate(poly))
 FROM
     {0}buildings
 WHERE
     wall AND
     npoints > 15 AND
-    polygon_proj IS NOT NULL AND
-    area / ST_Area(ST_MinimumBoundingCircle(polygon_proj)) > 0.95 AND
-    ST_MaxDistance(polygon_proj, polygon_proj) > 5 AND
+    area / ST_Area(ST_MinimumBoundingCircle(poly_proj)) > 0.95 AND
+    ST_MaxDistance(poly_proj, poly_proj) > 5 AND
     tags - ARRAY['created_by', 'source', 'name', 'building', 'man_made', 'note:qadastre'] = ''::hstore AND
     tags->'building' NOT IN ('hut', 'ger', 'yurt', 'slurry_tank') AND
     tags->'man_made' NOT IN ('water_tower', 'reservoir_covered', 'wastewater_plant', 'storage_tank', 'windmill', 'dovecote', 'silo', 'gasometer', 'lighthouse', 'bioreactor')
@@ -43,14 +42,13 @@ WHERE
 
 sql20 = """
 SELECT
-    id,
-    ST_AsText(way_locate(linestring))
+    type_id,
+    ST_AsText(polygon_locate(poly))
 FROM
     {0}buildings
 WHERE
     wall AND
-    polygon_proj IS NOT NULL AND
-    ST_MaxDistance(polygon_proj, polygon_proj) > 300 AND
+    ST_MaxDistance(poly_proj, poly_proj) > 300 AND
     tags - ARRAY['created_by', 'source', 'name', 'building', 'note:qadastre'] = ''::hstore AND
     tags->'building' NOT IN ('warehouse', 'industrial', 'greenhouse', 'manufacture', 'hospital', 'university')
 """
@@ -73,7 +71,7 @@ tagged.''')
                 title = T_('Special building (large)'),
                 detail = detail)
 
-            self.callback10 = lambda res: {"class":1, "data":[self.way_full, self.positionAsText], "fix":[
+            self.callback10 = lambda res: {"class":1, "data":[self.any_full, self.positionAsText], "fix":[
                 {"+":{"man_made":"water_tower"}},
                 {"+":{"man_made":"reservoir_covered"}},
                 {"+":{"man_made":"wastewater_plant"}},
@@ -84,7 +82,7 @@ tagged.''')
                 {"+":{"building":"hut"}},
                 {"+":{"building":"ger"}},
             ]}
-            self.callback20 = lambda res: {"class":2, "data":[self.way_full, self.positionAsText], "fix":[
+            self.callback20 = lambda res: {"class":2, "data":[self.any_full, self.positionAsText], "fix":[
                 {"+":{"man_made":"works"}},
                 {"+":{"shop":"mall"}},
                 {"+":{"shop":"supermarket"}},

--- a/analysers/analyser_osmosis_polygon_small.py
+++ b/analysers/analyser_osmosis_polygon_small.py
@@ -41,7 +41,7 @@ UNION ALL
 
 SELECT
   'R' || id,
-  ST_AsText(multipolygon_locate(poly)),
+  ST_AsText(polygon_locate(poly)),
   ST_Area(poly_proj)
 FROM
   {touched}multipolygons

--- a/doc/3-SQL-basics.md
+++ b/doc/3-SQL-basics.md
@@ -137,6 +137,7 @@ ST_AsText(ST_Centroid(ways.linestring))
 
 SQL Helpers are available to compute a location from OSM objects:
 * `way_locate(linestring)`: extract position from central point on the linestring, avoid joining on `nodes`.
+* `polygon_locate(poly)`: get a position that lies within a (multi)polygon.
 * `relation_locate(id)`: loop over relation members to extract a location.
 * `any_locate(type N/W/R, id)`: get location of variable object types.
 * `array_locate(array[type N/W/R, id])`: get location of array of variable object types.

--- a/osmosis/CreateFunctions.sql
+++ b/osmosis/CreateFunctions.sql
@@ -171,7 +171,7 @@ $$ LANGUAGE plpgsql
    STABLE
    RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION multipolygon_locate(poly geometry) RETURNS geometry AS $$
+CREATE OR REPLACE FUNCTION polygon_locate(poly geometry) RETURNS geometry AS $$
 DECLARE BEGIN
     RETURN ST_PointOnSurface(poly);
 END


### PR DESCRIPTION
### Implement multipolygon support for table `buildings` and convert the analysers accordingly.


Notes:
- For the two cases of `b1.id > b2.id` in analyser_osmosis_building_overlaps I assume this was just such that comparing [A B C] with [A B C] would go like [BA, CA, CB] (n!-n comparisons) rather than [BA, CA, AB, CB, AC, BC] (n^2-n comparisons, if b1!=b2), e.g. it doesn't have to know the numerical value. This makes it much easier to keep it as it is as it may have to compare relations with ways.
- I dropped the `buildings.relation` property. Based on the commit history this was added a decade ago in case a way with tag `building=*` was part of a multipolygon relation. However, nowadays the `building=*` tag should be on the multipolygon relation itself, not on the (outer) way. If it's on the inner way, that's a valid building. (Additionally, this inadvertently also blocked detections involving buildings in e.g. associatedStreet relations)
- In analyser_osmosis_building_in_polygon I switched the other multipolygon implementation to table polygon to simplify it, but forgot to make this a separate commit... apologies
- [offtopic] I'm not sure what analyser osmosis_building_3nodes is supposed to detect, but it seems like an "overlapping buildings" detection dedicated to 3-node buildings and hasn't detected anything since [2018](https://osmose.openstreetmap.fr/nl/issues/graph.png?item=1&source=&class=1&username=&bbox=). Probably it's redundant due to the other overlapping buildings analyser.