### PR TITLE
Remove unnecessary globals, fix lint

### DIFF
--- a/mapcss/mapcss2osmose.py
+++ b/mapcss/mapcss2osmose.py
@@ -660,10 +660,7 @@ subclass_blacklist = []
 is_meta_rule = False
 
 def to_p(t):
-    global item_default
-    global class_map, class_index, meta_tags, item, class_id, level, tags, subclass_id, group, group_class, text, text_class, fix, class_info_text
-    global tests, class_, regex_store, set_store
-    global subclass_blacklist
+    global class_index, meta_tags, item, class_id, level, tags, subclass_id, group, group_class, text, text_class, fix, class_info_text
     global is_meta_rule
 
     if isinstance(t, str):
@@ -937,8 +934,6 @@ def parse_mapcss(inputfile):
     return listener, tree
 
 def compile(inputfile, class_name, mapcss_url = None, only_for = [], not_for = [], prefix = ""):
-    global item_default, class_map, subclass_blacklist, class_index, meta_tags
-
     listener, tree = parse_mapcss(inputfile)
 
     build_mock_rules()
@@ -953,7 +948,6 @@ def compile(inputfile, class_name, mapcss_url = None, only_for = [], not_for = [
     tree = filter_support_rules(tree)
     selectors_type = segregate_selectors_type(tree)
 
-    global class_, tests, regex_store, set_store
     rules = dict(map(lambda t: [t, to_p({'type': 'stylesheet', 'rules': selectors_type[t]})], sorted(selectors_type.keys(), key = lambda a: {'node': 0, 'way': 1, 'relation':2}[a])))
     items = build_items(class_)
 


### PR DESCRIPTION

```
mapcss/mapcss2osmose.py:663:5  `global item_default` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:664:5  `global class_map` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:665:5  `global tests` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:665:5  `global class_` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:665:5  `global regex_store` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:665:5  `global set_store` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:666:5  `global subclass_blacklist` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:940:5  `global item_default` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:940:5  `global class_map` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:940:5  `global subclass_blacklist` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:940:5  `global class_index` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:940:5  `global meta_tags` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:956:5  `global class_` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:956:5  `global tests` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:956:5  `global regex_store` is unused: name is never assigned in scope [pyflakes]
mapcss/mapcss2osmose.py:956:5  `global set_store` is unused: name is never assigned in scope [pyflakes]
```