### PR TITLE
Analyser_merge_public_services_FR - fix on wheelchair tags

### DIFF
--- a/analysers/analyser_merge_public_services_FR.py
+++ b/analysers/analyser_merge_public_services_FR.py
@@ -249,8 +249,10 @@ class Public_Services_Source(Source):
                 feature_address["code_postal"],
                 feature_address["nom_commune"],
             ).strip()
-            elem["wheelchair"] = wheelchair_mapping[feature_address["accessibilite"]]
-            elem["wheelchair:description"] = feature_address["note_accessibilite"]
+            access_info = feature_address.get("accessibilite")
+            if access_info:
+                elem["wheelchair"] = wheelchair_mapping[access_info]
+                elem["wheelchair:description"] = feature_address.get("note_accessibilite")
 
             elem["opening_hours"] = parse_opening_hours(feature["plage_ouverture"])
 


### PR DESCRIPTION
There hasn't been any information about wheelchair access in the source file for a few weeks. 
I don't know if this is deliberate or if it will come back.