### PR TITLE
Exclude half_on_kerb and on_kerb from missing access way check

### DIFF
--- a/analysers/analyser_osmosis_parking_highway.py
+++ b/analysers/analyser_osmosis_parking_highway.py
@@ -51,7 +51,7 @@ FROM
 WHERE
   tags?'amenity' AND
   tags->'amenity' = 'parking' AND
-  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane', 'layby'))
+  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane', 'layby', 'half_on_kerb', 'on_kerb'))
 """
 
 sql13 = """


### PR DESCRIPTION
Although rare, it's not forbidden and we've had several requests for it. In the example of issue #2491, way 1358235286, one can clearly see well-defined parking areas alongside a small part of the way, similar to how one would mark parking=street_side separately.

I didn't add it to the text suggestions because it's rare. The wiki still says "Mostly used as a value for parking:left=*, parking:right=* or parking:both=* on a street tagged with highway=*."