### PR TITLE
Add mapping for fishing shops

### DIFF
--- a/merge_data/shop_FR.mapping.json
+++ b/merge_data/shop_FR.mapping.json
@@ -620,10 +620,13 @@
       },
       {
         "shop": "bicycle"
+      },
+      {
+        "shop": "fishing"
       }
     ],
     "generate": {
-      "shop": "sports;outdoor;bicycle",
+      "shop": "sports;outdoor;bicycle;fishing",
       "fixme": "select a shop type"
     }
   },


### PR DESCRIPTION
Attempting to fix [this type of issue](https://osmose.openstreetmap.fr/fr/issue/176f36b8-7d10-3c2d-648d-e425837b9a70) where the shop exists but is tagged as `fishing` [wiki](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dfishing) so it remains unintegrated (at least I believe that is the reason, [the correct node](https://www.openstreetmap.org/node/6613051963#map=19/44.563690/6.495121) has all other tags including `ref:FR:SIREN`)

This my first contribution to osmose, feel free to make any remarks on things I might have missed !