### PR TITLE
Remove unused maxspeed types for Austria

### DIFF
--- a/analysers/analyser_osmosis_parking_highway.py
+++ b/analysers/analyser_osmosis_parking_highway.py
@@ -51,7 +51,7 @@ FROM
 WHERE
   tags?'amenity' AND
   tags->'amenity' = 'parking' AND
-  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane', 'layby'))
+  (NOT tags?'parking' OR tags->'parking' NOT IN ('street_side', 'lane', 'layby', 'half_on_kerb', 'on_kerb'))
 """
 
 sql13 = """

--- a/merge_data/shop_FR.mapping.json
+++ b/merge_data/shop_FR.mapping.json
@@ -620,10 +620,13 @@
       },
       {
         "shop": "bicycle"
+      },
+      {
+        "shop": "fishing"
       }
     ],
     "generate": {
-      "shop": "sports;outdoor;bicycle",
+      "shop": "sports;outdoor;bicycle;fishing",
       "fixme": "select a shop type"
     }
   },

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1817,10 +1817,10 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederoesterreich", 77189, "AT-NOE")
+at_state("niederosterreich", 77189, "AT-NOE")
 at_state("burgenland", 76909, "AT-B")
-at_state("kaernten", 52345, "AT-K")
-at_state("oberoesterreich", 102303, "AT-OOE")
+at_state("karnten", 52345, "AT-K")
+at_state("oberosterreich", 102303, "AT-OOE")
 at_state("salzburg", 86539, "AT-S")
 at_state("steiermark", 35183, "AT-ST")
 at_state("tirol", 52343, "AT-T")

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1817,10 +1817,10 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederosterreich", 77189, "AT-NOE")
+at_state("niederoesterreich", 77189, "AT-NOE")
 at_state("burgenland", 76909, "AT-B")
-at_state("karnten", 52345, "AT-K")
-at_state("oberosterreich", 102303, "AT-OOE")
+at_state("kaernten", 52345, "AT-K")
+at_state("oberoesterreich", 102303, "AT-OOE")
 at_state("salzburg", 86539, "AT-S")
 at_state("steiermark", 35183, "AT-ST")
 at_state("tirol", 52343, "AT-T")


### PR DESCRIPTION
at:urban30 and at:urban40 have been superseded by at:city_limit30 and at:city_limit40 (which will be checked in a separate plugin).

Part of https://github.com/osm-fr/osmose-backend/issues/2503