### PR TITLE
Involve industrial/generation substations in French distribution merge

### DIFF
--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -48,6 +48,7 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
                 select = Select(
                     types = ["nodes", "ways"],
                     tags = [
+                        {"power": "substation", "substation": ["industrial", "generation"], "operator": [operator[0] for operator in self.extract_operator.values()]},
                         {"power": "substation", "substation": ["distribution", "minor_distribution"]},
                         {"power": None, "transformer": ["distribution", "main"]}]),
                 conflationDistance = 50,


### PR DESCRIPTION
It is proposed to involve `industrial` and `generation` substations in merge_power_substation_minor_FR. Some facilities are taged like this and doesn't prevent Osmose to warn about a missing substation.

It will reduce warnings in item 8280 class 11.

Tests on france_rhone_alpes_haute_savoie shown 5998 warning, less than current 6025 (27 will be removed).