### PR TITLE
Map AT abbreviations to Osmose equivalent

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,15 +1818,15 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederosterreich", 77189, "AT-3")
-at_state("burgenland", 76909, "AT-1")
-at_state("karnten", 52345, "AT-2")
-at_state("oberosterreich", 102303, "AT-4")
-at_state("salzburg", 86539, "AT-5")
-at_state("steiermark", 35183, "AT-6")
-at_state("tirol", 52343, "AT-7")
-at_state("wien", 109166, "AT-9")
-at_state("vorarlberg", 74942, "AT-8")
+at_state("niederosterreich", 77189, "AT-NOE")
+at_state("burgenland", 76909, "AT-B")
+at_state("karnten", 52345, "AT-K")
+at_state("oberosterreich", 102303, "AT-OOE")
+at_state("salzburg", 86539, "AT-S")
+at_state("steiermark", 35183, "AT-ST")
+at_state("tirol", 52343, "AT-T")
+at_state("wien", 109166, "AT-W")
+at_state("vorarlberg", 74942, "AT-V")
 
 #########################################################################
 

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,10 +1818,10 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederoesterreich", 77189, "AT-NOE")
+at_state("niederosterreich", 77189, "AT-NOE")
 at_state("burgenland", 76909, "AT-B")
-at_state("kaernten", 52345, "AT-K")
-at_state("oberoesterreich", 102303, "AT-OOE")
+at_state("karnten", 52345, "AT-K")
+at_state("oberosterreich", 102303, "AT-OOE")
 at_state("salzburg", 86539, "AT-S")
 at_state("steiermark", 35183, "AT-ST")
 at_state("tirol", 52343, "AT-T")

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -1818,10 +1818,10 @@ de_state("thueringen", 62366, "DE-TH")
 
 at_state = gen_country('europe', 'austria', download_repo=OSMFR, language='de', proj=32633)
 
-at_state("niederosterreich", 77189, "AT-NOE")
+at_state("niederoesterreich", 77189, "AT-NOE")
 at_state("burgenland", 76909, "AT-B")
-at_state("karnten", 52345, "AT-K")
-at_state("oberosterreich", 102303, "AT-OOE")
+at_state("kaernten", 52345, "AT-K")
+at_state("oberoesterreich", 102303, "AT-OOE")
 at_state("salzburg", 86539, "AT-S")
 at_state("steiermark", 35183, "AT-ST")
 at_state("tirol", 52343, "AT-T")

--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -38,8 +38,6 @@ class TagFix_Maxspeed(Plugin):
     maxspeed_table = {
         'at:rural': ['100'],
         'at:trunk': ['100'],
-        'at:urban40': ['40'],
-        'at:urban30': ['30'],
         'be-bru:rural': ['70'],
         'be-bru:urban': ['30'],
         'be:motorway': ['120'],

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -39,6 +39,16 @@ def download_nsi():
 
 # Countries in NSI with different ids or spanning multiple Osmose extracts
 _nsi_to_osmose_map = {
+    # Austria
+    "at-3": ["at-noe"], # Niederösterreich
+    "at-1": ["at-b"], # Burgenland
+    "at-2": ["at-k"], # Kärnten
+    "at-4": ["at-ooe"], # Oberösterreich
+    "at-5": ["at-s"], # Salzburg
+    "at-6": ["at-st"], # Steiermark
+    "at-7": ["at-t"], # Tirol
+    "at-9": ["at-w"], # Wien
+    "at-8": ["at-v"], # Vorarlberg
     # China
     "hk": ["cn-91"], # Hong Kong
     "mo": ["cn-92"], # Macau


### PR DESCRIPTION
NSI uses the country codes as defined in https://en.wikipedia.org/wiki/ISO_3166-2:AT
As the country codes were redefined in #2504 we need to map them to the ISO equivalent

@wolfbert 