### PR TITLE
Avoid close name for NNth

### DIFF
--- a/analysers/analyser_osmosis_highway_name_close.py
+++ b/analysers/analyser_osmosis_highway_name_close.py
@@ -79,7 +79,7 @@ class Analyser_Osmosis_Highway_Name_Close(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
 
-        # Check langues for country are writen with alphabets
+        # Check that languages for countries are written with alphabets
         self.alphabet = 'language' in config.options and languages.languages_are_alphabets(config.options['language'])
 
         if self.alphabet:


### PR DESCRIPTION
See #2563 

This avoids e.g. `8th`, `14th` and `22nd` from being converted to `_`, `1_` and `2_` respectively, after which a 1-character difference remains (which is subsequently reported as a close name)

~Not sure why all tests fail but this seems unrelated~