### PR TITLE
Updated maxspeed exceptions table

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -58,7 +58,7 @@ class TagFix_Maxspeed(Plugin):
         'ch:rural': ['80'],
         'ch:trunk': ['100'],
         'ch:motorway': ['120'],
-        'cz:trunk': ['80', '110'],
+        'cz:trunk': ['80', '130'],
         'cz:motorway': ['80', '130'],
         'de:living_street': ['walk'],
         'de:rural': ['100'],


### PR DESCRIPTION
I've updated & added values to the exceptions table according to the [maxspeed wiki page](https://wiki.openstreetmap.org/wiki/Key:maxspeed#Implicit_maxspeed_values) (and after some Overpass Turbo queries).

This will help and resolve a lot of false positives, see for example the [391 motorway segments](https://overpass-turbo.eu/s/2bpr) (currently false positive warnings) in Spain that can be resolved.