### PR TITLE
Update public transport tags for STAN french network in analyser

### DIFF
--- a/analysers/analyser_merge_public_transport_FR_stan.py
+++ b/analysers/analyser_merge_public_transport_FR_stan.py
@@ -42,13 +42,13 @@ class Analyser_Merge_Public_Transport_FR_stan(Analyser_Merge_Point):
             Conflate(
                 select = Select(
                     types = ["nodes", "ways"],
-                    tags = [{"highway": "platform", "public_transport": "platform"}]),
+                    tags = [{"highway": "bus_stop", "public_transport": "platform"}]),
                 conflationDistance = 2,
                 osmRef = "gtfs:stop_id:FR-GES-STAN",
                 mapping = Mapping(
                     static1 = {
                         "public_transport": "platform",
-                        "highway": "platform",
+                        "highway": "bus_stop",
                         "bus": "yes",
                     },
                     static2 = {"source": self.source},
@@ -57,7 +57,10 @@ class Analyser_Merge_Public_Transport_FR_stan(Analyser_Merge_Point):
                         "gtfs:stop_id:FR-GES-STAN": "stop_id",
                         "gtfs:stop_name:FR-GES-STAN": "stop_name",
                         "wheelchair": lambda fields: self.wheelchair_boarding[fields.get("wheelchair_boarding")]},
-                    mapping2 = {"name": "stop_name", "ref": "stop_code"},
+                    mapping2 = {
+                        "name": "stop_name",
+                        "ref": "stop_code"
+                    },
                     text = lambda tags, fields: T_("{0} stop of {1}", place, fields["stop_name"]) )))
 
     wheelchair_boarding = {


### PR DESCRIPTION
Hello,

We recently started adding the `gtfs:stop_id:FR-GES-STAN=` tags to platform elements based on GTFS and PTNA data. However, the current Osmose analyser does not recognize these stops, so adjustments are required for proper detection.

Previous tags:
<img src="https://github.com/user-attachments/assets/ead12902-260e-403e-882f-64a4d752bbe4" />

New tags:
<img src="https://github.com/user-attachments/assets/3757421a-34e1-4903-bc15-d0acba233bd0" />

Example screenshot:
<img src="https://github.com/user-attachments/assets/ac5ee269-7402-4ebb-9d81-e9baba2de91b" />

Would you mind reviewing my PR and confirming if the changes meet the requirements for Osmose integration? Thank you for your time!