### PR TITLE
Update speed limit for cz:trunk to 110, to match reality and OSM wiki 

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -49,7 +49,7 @@ class TagFix_Maxspeed(Plugin):
         'ch:rural': ['80'],
         'ch:trunk': ['100'],
         'ch:motorway': ['120'],
-        'cz:trunk': ['80', '130'],
+        'cz:trunk': ['80', '110'],
         'cz:motorway': ['80', '130'],
         'de:living_street': ['walk'],
         'de:rural': ['100'],


### PR DESCRIPTION
Maxspeed at highway=trunk in Czechia is 110, minspeed is 80. Fixed from previous 130 (which has been wrong for years now, and keeps flagging correctly tagged ways).

See also https://wiki.openstreetmap.org/wiki/Default_speed_limits#cite_ref-:41_158-0 - the PR fixes this value so that it syncs with reality and the wiki maxspeed.