### PR TITLE
fix: add cycleway to highway not in list for error 1260

### DIFF
--- a/analysers/analyser_osmosis_relation_public_transport.py
+++ b/analysers/analyser_osmosis_relation_public_transport.py
@@ -281,7 +281,7 @@ WHERE
     nodes.tags != ''::hstore AND
     nodes.tags?'highway' AND nodes.tags->'highway' = 'bus_stop' AND
     nodes.tags->'public_transport' != 'stop_position' AND
-    highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform', 'steps')
+    highways.highway NOT IN ('footway', 'cycleway', 'path', 'pedestrian', 'platform', 'steps')
 GROUP BY
     nodes.id,
     nodes.geom
@@ -321,7 +321,7 @@ FROM
 WHERE
     relations.tags->'type' = 'route' AND
     relations.tags->'route' IN ('bus', 'trolleybus', 'coach', 'share_taxi', 'school_bus', 'walking_bus') AND
-    highways.highway NOT IN ('footway', 'path', 'pedestrian', 'platform', 'steps')
+    highways.highway NOT IN ('footway', 'cycleway', 'path', 'pedestrian', 'platform', 'steps')
 GROUP BY
     relations.id,
     nodes.id,


### PR DESCRIPTION
This fixes the error 1260 where the bus stop is part of a way, it should have public_transport=stop_position tag. Cycleways should be accepted as ways that can have bus stops.

Same for public transport routes error check using the same exception list.

closes #2651