### PR TITLE
phone vs contact:phone

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -1222,6 +1222,15 @@ class Conflate:
         self.mapping = mapping
 
 
+tag_aliases = {
+    "phone": ["phone", "contact:phone"],
+    "email": ["email", "contact:email"],
+    "website": ["website", "contact:website"],
+    "contact:phone": ["phone", "contact:phone"],
+    "contact:email": ["email", "contact:email"],
+    "contact:website": ["website", "contact:website"],
+}
+
 class Analyser_Merge(Analyser_Osmosis):
 
     def __init__(self, config, logger):
@@ -1351,20 +1360,11 @@ verification of this data.'''))
 
     def mergeTags(self, osm, official, ref, keep_multiple):
         fix = {"+": {}, "~": {}, "-": []}
-        tag_aliases = {
-            "phone": ["phone", "contact:phone"],
-            "email": ["email", "contact:email"],
-            "website": ["website", "contact:website"],
-            "contact:phone": ["phone", "contact:phone"],
-            "contact:email": ["email", "contact:email"],
-            "contact:website": ["website", "contact:website"],
-        }
-
         for o in official:
             if o in tag_aliases:
                 aliases = tag_aliases[o]
                 is_same = (lambda a, b: a.replace(" ", "") == b.replace(" ", "")) if o in ["phone","contact:phone"] else (lambda a, b: a == b)
-                if any(alias in osm and is_same(osm[alias], official[o]) for alias in aliases):
+                if any(map(lambda alias: alias in osm and is_same(osm[alias], official[o]), aliases)):
                     pass
                 else:
                     fix["+"][o] = official[o]

--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -1351,8 +1351,24 @@ verification of this data.'''))
 
     def mergeTags(self, osm, official, ref, keep_multiple):
         fix = {"+": {}, "~": {}, "-": []}
+        tag_aliases = {
+            "phone": ["phone", "contact:phone"],
+            "email": ["email", "contact:email"],
+            "website": ["website", "contact:website"],
+            "contact:phone": ["phone", "contact:phone"],
+            "contact:email": ["email", "contact:email"],
+            "contact:website": ["website", "contact:website"],
+        }
+
         for o in official:
-            if o in osm:
+            if o in tag_aliases:
+                aliases = tag_aliases[o]
+                is_same = (lambda a, b: a.replace(" ", "") == b.replace(" ", "")) if o in ["phone","contact:phone"] else (lambda a, b: a == b)
+                if any(alias in osm and is_same(osm[alias], official[o]) for alias in aliases):
+                    pass
+                else:
+                    fix["+"][o] = official[o]
+            elif o in osm:
                 if official[o] == Mapping.delete_tag:
                     fix["-"].append(o)
                 elif osm[o] == official[o]:


### PR DESCRIPTION
This proposal allows for better management of updates for the phone, email, and website tags, which have a variant in contact:*

In the current version of Osmose, if the merge analysis mentions contact:phone, only the contact:phone tag is taken into account, even if the information is already entered in the phone tag.

This results in unnecessary and redundant fix proposals.

With this change, the fix is not proposed if the information is already present and identical in a variant tag.

for instance, in merge_school_FR analyser:
object way/381224901
```
name=École primaire privée Notre-Dame de L'Espérance
(...)
phone=+33 1 46 72 45 93
```

for now, Osmose proposes:
```
+ ref:FR:SIRET=78572144000010
+ contact:phone=+33 146724593
```

with this change, Osmose proposes:
```
+ ref:FR:SIRET=78572144000010
```