### PR TITLE
Fix Osmosis_Useless class 3

### DIFF
--- a/analysers/analyser_osmosis_useless.py
+++ b/analysers/analyser_osmosis_useless.py
@@ -102,7 +102,7 @@ WHERE
 """
 
 sql31 = """
-SELECT
+SELECT DISTINCT
     r.id,
     relation_members.relation_id,
     ST_AsText(relation_locate(r.id))

--- a/analysers/analyser_osmosis_useless.py
+++ b/analysers/analyser_osmosis_useless.py
@@ -96,9 +96,10 @@ FROM
         member_id = relations.id AND
         member_type = 'R'
 WHERE
-    (member_role IS NULL OR member_role = '') AND
-    relations.tags - ARRAY['created_by', 'source', 'note:qadastre', 'name'] = ''::hstore AND
-    relation_locate(relations.id) IS NOT NULL -- We can't locate pure relation or relations
+    member_role = '' AND
+    relations.tags - ARRAY['created_by', 'source', 'note:qadastre', 'name', 'type'] = ''::hstore AND
+    relation_locate(relations.id) IS NOT NULL AND -- We can't locate pure relation or relations
+    relations.tags?'type' -- relations without type have their own warning (item 2110, class 21102)
 """
 
 sql31 = """
@@ -114,7 +115,8 @@ FROM
         relation_members.member_role = ''
     JOIN not_touched_relations AS r ON
         r.id = relation_members.member_id AND
-        r.tags - ARRAY['created_by', 'source', 'note:qadastre', 'name'] = ''::hstore
+        r.tags - ARRAY['created_by', 'source', 'note:qadastre', 'name', 'type'] = ''::hstore AND
+        r.tags?'type' -- relations without type have their own warning
 """
 
 class Analyser_Osmosis_Useless(Analyser_Osmosis):


### PR DESCRIPTION
Class 3 of Osmosis_Useless:
- Gave an error in case a relation contained a duplicated relation member (diff mode only)
- Only gave errors for relations without `type` tag. Therefore, every result was also already found by class 21102, making it an unnecessary check

Changes:
- Only return a single result for relations with duplicate members (duplicate members are already detected by a different analyser for selected relation types) in diff-mode analyser sql31 (fixes #2693 )
- Requires a `type` tag on the relation. This subsequently required:
  - Relations containing _no_ relation members (e.g. `member_role IS NULL` for `member_type='R'`) have to be allowed. Valid examples include `associatedStreet` relations which have no members of type `relation` (in theory) and can contain just a `type` + `name` tag.
  - If this change also causes false positives (e.g. relations containing different relations with role `''` and just a name tag, then probably this class 3 should be removed. The number of detections I saw on the test extracts were very low.