### PR TITLE
Fix Belgium phone formatting

### DIFF
--- a/osmose_config.py
+++ b/osmose_config.py
@@ -748,7 +748,7 @@ tr_part('central_anatolia', 2094194, 'TR-3')
 #########################################################################
 
 be_part = gen_country('europe', 'belgium', download_repo=OSMFR, proj=32631, municipality_ref='ref:INS',
-    phone_code='32', phone_len=[8, 9], phone_len_short=[3, 4], phone_format="r^([+]%s([- ./]*[0-9]){7,8}[0-9])|[0-9]{3,4}$", phone_international='00', phone_local_prefix='0')
+    phone_code='32', phone_len=[8, 9], phone_len_short=[3, 4], phone_format=r"^([+]%s([- ./]*[0-9]){7,8}[0-9])|[0-9]{3,4}$", phone_international='00', phone_local_prefix='0')
 
 be_part('brussels_capital_region', 54094, 'BE-BRU', language=['fr', 'nl'], multilingual_style='be')
 


### PR DESCRIPTION
This should fix #2719 (and 40-50k false positives in Belgium)

Looks like a copy paste mistake from https://github.com/osmose-qa/osmose-backend/pull/2706 and demonstrates the need for #2705 