### PR TITLE
add missing script definition for language mi

### DIFF
--- a/modules/languages.py
+++ b/modules/languages.py
@@ -73,6 +73,7 @@ language2scripts = {
     'lt': ['Latin'],
     'lv': ['Latin'],
     'mg': ['Latin'],
+    'mi': [u'[A-Za-zĀĒĪŌŪāēīōū]'],
     'mn': ['Cyrillic'],
     'ms': ['Latin'],
     'my': None, # Birman

--- a/modules/languages.py
+++ b/modules/languages.py
@@ -73,7 +73,7 @@ language2scripts = {
     'lt': ['Latin'],
     'lv': ['Latin'],
     'mg': ['Latin'],
-    'mi': [u'[A-Za-zĀĒĪŌŪāēīōū]'],
+    'mi': ['[A-Za-zĀĒĪŌŪāēīōū]'],
     'mn': ['Cyrillic'],
     'ms': ['Latin'],
     'my': None, # Birman


### PR DESCRIPTION
technically there are [only 15 letters](https://www.maorilanguage.net/maori-alphabet/), not 26. But it is common to use loan-words from English, so I've included all `A-Za-z`