### PR TITLE
Fix common false positives in nearby POI analyser

### DIFF
--- a/analysers/analyser_osmosis_duplicated_poi.py
+++ b/analysers/analyser_osmosis_duplicated_poi.py
@@ -203,7 +203,7 @@ a AS (
             WHEN 'post_office' THEN 200
             WHEN 'fire_station' THEN 200
             WHEN 'hospital' THEN 100
-            WHEN 'fuel' THEN 50
+            WHEN 'fuel' THEN 25
             WHEN 'clinic' THEN 100
             WHEN 'community_centre' THEN 100
             WHEN 'townhall' THEN 200
@@ -212,7 +212,7 @@ a AS (
             WHEN 'marketplace' THEN 200
             WHEN 'stadium' THEN 200
             WHEN 'mall' THEN 100
-            WHEN 'supermarket' THEN 50
+            WHEN 'supermarket' THEN 25
         END AS distance_m
     FROM
         poi_raw


### PR DESCRIPTION
Due to a lot of false positives in my region I'd propose to reduce the distances for some of them. 

- Fuel stations at opposite sides of the way (example: https://osmose.openstreetmap.fr/en/map/#country=netherlands_gelderland&item=1230&class=1&limit=500&zoom=17&lat=51.9871421&lon=6.5504802&level=1&issue_uuid=5ad4dc09-06c6-7078-f034-34ffaa5f735e&loc=19/51.9871247/6.5503808)
- Discounter and expensive supermarkets nearby (example: https://osmose.openstreetmap.fr/en/map/#country=netherlands_gelderland&item=1230&class=1&limit=500&zoom=17&lat=51.9838083&lon=5.9527193&level=1&loc=18/51.98379/5.952746&issue_uuid=4411623c-b86a-e781-d9d4-3038fab45bbc)

Note that there's still a lot of false positives remaining as supermarkets are often direct neighbours, usually a discounter and a more expensive one, or a specialized small one and a regular brand, but then I'd have to set it to 10m, but this should reduce the most severe ones.