### PR TITLE
Detect incorrect `crossing:island=yes`

### DIFF
--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -410,6 +410,12 @@ ANALYZE {0}.buildings;
                 elif table == 'not_touched_buildings':
                     self.requires_tables_build(["buildings"])
                     self.create_view_not_touched('buildings', ['W', 'R'])
+                elif table == 'touched_ways':
+                    self.requires_tables_build(["ways"])
+                    self.create_view_touched('ways', 'W')
+                elif table == 'not_touched_ways':
+                    self.requires_tables_build(["ways"])
+                    self.create_view_not_touched('ways', 'W')
                 else:
                     raise Exception('Unknown table name {0}'.format(table))
                 self.giscurs.execute('COMMIT')

--- a/analysers/Analyser_Osmosis.py
+++ b/analysers/Analyser_Osmosis.py
@@ -410,12 +410,6 @@ ANALYZE {0}.buildings;
                 elif table == 'not_touched_buildings':
                     self.requires_tables_build(["buildings"])
                     self.create_view_not_touched('buildings', ['W', 'R'])
-                elif table == 'touched_ways':
-                    self.requires_tables_build(["ways"])
-                    self.create_view_touched('ways', 'W')
-                elif table == 'not_touched_ways':
-                    self.requires_tables_build(["ways"])
-                    self.create_view_not_touched('ways', 'W')
                 else:
                     raise Exception('Unknown table name {0}'.format(table))
                 self.giscurs.execute('COMMIT')

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -58,7 +58,7 @@ class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[11] = self.def_class(item = 3040, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
+        self.classs_change[1] = self.def_class(item = 3040, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
             title = T_('Crossing island tag on a split crossing'),
             detail = T_(
 '''A crossing way is tagged with `crossing:island=yes` and connects to a
@@ -77,7 +77,7 @@ as one continuous crossing, keep `crossing:island=yes`.'''),
 '''If you are not sure whether the crossing way ends at the island or continues
 over it, do not change the tag.'''))
 
-        self.callback10 = lambda res: {"class": 11, "data": [self.way_full, self.way_full, self.positionAsText]}
+        self.callback10 = lambda res: {"class": 1, "data": [self.way_full, self.way_full, self.positionAsText]}
 
     def analyser_osmosis_full(self):
         self.run(sql10.format("", ""), self.callback10)
@@ -108,7 +108,7 @@ class Test(TestAnalyserOsmosis):
             a.analyser()
 
         self.root_err = self.load_errors()
-        self.check_err(cl="11", elems=[("way", "100"), ("way", "200")])
-        self.check_err(cl="11", elems=[("way", "110"), ("way", "210")])
-        self.check_err(cl="11", elems=[("way", "120"), ("way", "220")])
+        self.check_err(cl="1", elems=[("way", "100"), ("way", "200")])
+        self.check_err(cl="1", elems=[("way", "110"), ("way", "210")])
+        self.check_err(cl="1", elems=[("way", "120"), ("way", "220")])
         self.check_num_err(3)

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -52,7 +52,7 @@ class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[1] = self.def_class(item = 2090, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
+        self.classs_change[11] = self.def_class(item = 2090, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
             title = T_('Crossing island tag on a split crossing'),
             detail = T_(
 '''A crossing way is tagged with `crossing:island=yes` and connects to a
@@ -71,7 +71,7 @@ as one continuous crossing, keep `crossing:island=yes`.'''),
 '''If you are not sure whether the crossing way ends at the island or continues
 over it, do not change the tag.'''))
 
-        self.callback10 = lambda res: {"class": 1, "data": [self.way_full, self.way_full, self.positionAsText]}
+        self.callback10 = lambda res: {"class": 11, "data": [self.way_full, self.way_full, self.positionAsText]}
 
     def analyser_osmosis_full(self):
         self.run(sql10.format("", ""), self.callback10)
@@ -101,7 +101,7 @@ class Test(TestAnalyserOsmosis):
             a.analyser()
 
         self.root_err = self.load_errors()
-        self.check_err(cl="1", elems=[("way", "100"), ("way", "200")])
-        self.check_err(cl="1", elems=[("way", "110"), ("way", "210")])
-        self.check_err(cl="1", elems=[("way", "120"), ("way", "220")])
+        self.check_err(cl="11", elems=[("way", "100"), ("way", "200")])
+        self.check_err(cl="11", elems=[("way", "110"), ("way", "210")])
+        self.check_err(cl="11", elems=[("way", "120"), ("way", "220")])
         self.check_num_err(3)

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -49,8 +49,7 @@ WHERE
         crossing.tags->'path' = 'crossing'
     )
 ORDER BY
-    crossing.id,
-    traffic_island.id
+    crossing.id
 """
 
 
@@ -67,10 +66,10 @@ class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 '''A crossing way is tagged with `crossing:island=yes` and connects to a
 separately mapped `footway=traffic_island`.
 
-When a traffic island is mapped as its own way, the short crossing ways leading
+When a traffic island is mapped as its own way, the crossing ways leading
 to it usually should not also be tagged as having a crossing island.'''),
             fix = T_(
-'''Check the highlighted crossing way. If it is only a short segment leading to
+'''Check the highlighted crossing way. If it is a segment leading to
 the separately mapped traffic island, remove `crossing:island=yes`. You may add
 `crossing:island=no` for clarity.
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+###########################################################################
+##                                                                       ##
+## Copyright Osmose Contributors 2026                                    ##
+##                                                                       ##
+## This program is free software: you can redistribute it and/or modify  ##
+## it under the terms of the GNU General Public License as published by  ##
+## the Free Software Foundation, either version 3 of the License, or     ##
+## (at your option) any later version.                                   ##
+##                                                                       ##
+## This program is distributed in the hope that it will be useful,       ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of        ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         ##
+## GNU General Public License for more details.                          ##
+##                                                                       ##
+## You should have received a copy of the GNU General Public License     ##
+## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
+##                                                                       ##
+###########################################################################
+
+from modules.OsmoseTranslation import T_
+from .Analyser_Osmosis import Analyser_Osmosis
+
+
+sql10 = """
+SELECT DISTINCT
+    crossing.id,
+    traffic_island.id,
+    ST_AsText(way_locate(crossing.linestring))
+FROM
+    {0}ways AS crossing
+    JOIN {1}ways AS traffic_island ON
+        traffic_island.id != crossing.id AND
+        traffic_island.nodes && crossing.nodes AND
+        traffic_island.tags->'footway' = 'traffic_island'
+WHERE
+    crossing.tags->'crossing:island' = 'yes' AND
+    (
+        crossing.tags->'footway' = 'crossing' OR
+        crossing.tags->'cycleway' = 'crossing' OR
+        crossing.tags->'path' = 'crossing'
+    )
+"""
+
+
+class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
+
+    requires_tables_full = ['ways']
+    requires_tables_diff = ['ways', 'touched_ways', 'not_touched_ways']
+
+    def __init__(self, config, logger = None):
+        Analyser_Osmosis.__init__(self, config, logger)
+        self.classs_change[1] = self.def_class(item = 2090, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
+            title = T_('Crossing island tag on a split crossing'),
+            detail = T_(
+'''A crossing way is tagged with `crossing:island=yes` and connects to a
+separately mapped `footway=traffic_island`.
+
+When a traffic island is mapped as its own way, the short crossing ways leading
+to it usually should not also be tagged as having a crossing island.'''),
+            fix = T_(
+'''Check the highlighted crossing way. If it is only a short segment leading to
+the separately mapped traffic island, remove `crossing:island=yes`. You may add
+`crossing:island=no` for clarity.
+
+If the crossing way continues all the way across the street and over the island
+as one continuous crossing, keep `crossing:island=yes`.'''),
+            trap = T_(
+'''If you are not sure whether the crossing way ends at the island or continues
+over it, do not change the tag.'''))
+
+        self.callback10 = lambda res: {"class": 1, "data": [self.way_full, self.way_full, self.positionAsText]}
+
+    def analyser_osmosis_full(self):
+        self.run(sql10.format("", ""), self.callback10)
+
+    def analyser_osmosis_diff(self):
+        # Match issues when either the crossing way or the traffic island way is touched.
+        self.run(sql10.format("touched_", ""), self.callback10)
+        self.run(sql10.format("not_touched_", "touched_"), self.callback10)
+
+
+###########################################################################
+
+from .Analyser_Osmosis import TestAnalyserOsmosis
+
+
+class Test(TestAnalyserOsmosis):
+    @classmethod
+    def setup_class(cls):
+        from modules import config
+        TestAnalyserOsmosis.setup_class()
+        cls.analyser_conf = cls.load_osm("tests/osmosis_highway_traffic_island.osm",
+                                         config.dir_tmp + "/tests/osmosis_highway_traffic_island.test.xml",
+                                         {"proj": 2154})
+
+    def test_classes(self):
+        with Analyser_Osmosis_Highway_Traffic_Island(self.analyser_conf, self.logger) as a:
+            a.analyser()
+
+        self.root_err = self.load_errors()
+        self.check_err(cl="1", elems=[("way", "100"), ("way", "200")])
+        self.check_err(cl="1", elems=[("way", "110"), ("way", "210")])
+        self.check_err(cl="1", elems=[("way", "120"), ("way", "220")])
+        self.check_num_err(3)

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -55,9 +55,6 @@ ORDER BY
 
 class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 
-    requires_tables_full = ['ways']
-    requires_tables_diff = ['ways']
-
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
         self.classs_change[11] = self.def_class(item = 3040, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -30,7 +30,7 @@ SELECT DISTINCT ON (crossing.id)
     traffic_island.id,
     ST_AsText(way_locate(crossing.linestring))
 FROM
-    {0}ways AS crossing
+    {0}highways AS crossing
     JOIN {1}ways AS traffic_island ON
         traffic_island.linestring && crossing.linestring AND
         traffic_island.id != crossing.id AND
@@ -55,6 +55,9 @@ ORDER BY
 
 
 class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
+
+    requires_tables_common = ['highways']
+    requires_tables_diff = ['touched_highways', 'not_touched_highways']
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
@@ -84,7 +87,8 @@ over it, do not change the tag.'''))
 
     def analyser_osmosis_diff(self):
         # Match issues when either the crossing way or the traffic island way is touched.
-        # touched_ways and not_touched_ways views are created by the osmosis CreateTouched.sql script.
+        # touched_highways and not_touched_highways views are created by requires_tables_build.
+        # touched_ways view is created by the osmosis CreateTouched.sql script.
         self.run(sql10.format("touched_", ""), self.callback10)
         self.run(sql10.format("not_touched_", "touched_"), self.callback10)
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -31,7 +31,7 @@ SELECT DISTINCT ON (crossing.id)
     ST_AsText(way_locate(crossing.linestring))
 FROM
     {0}highways AS crossing
-    JOIN {1}ways AS traffic_island ON
+    JOIN {1}highways AS traffic_island ON
         traffic_island.linestring && crossing.linestring AND
         traffic_island.id != crossing.id AND
         traffic_island.nodes && crossing.nodes AND
@@ -88,7 +88,6 @@ over it, do not change the tag.'''))
     def analyser_osmosis_diff(self):
         # Match issues when either the crossing way or the traffic island way is touched.
         # touched_highways and not_touched_highways views are created by requires_tables_build.
-        # touched_ways view is created by the osmosis CreateTouched.sql script.
         self.run(sql10.format("touched_", ""), self.callback10)
         self.run(sql10.format("not_touched_", "touched_"), self.callback10)
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -56,7 +56,7 @@ ORDER BY
 class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 
     requires_tables_full = ['ways']
-    requires_tables_diff = ['ways', 'touched_ways', 'not_touched_ways']
+    requires_tables_diff = ['ways']
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
@@ -86,6 +86,8 @@ over it, do not change the tag.'''))
 
     def analyser_osmosis_diff(self):
         # Match issues when either the crossing way or the traffic island way is touched.
+        self.create_view_touched('ways', 'W')
+        self.create_view_not_touched('ways', 'W')
         self.run(sql10.format("touched_", ""), self.callback10)
         self.run(sql10.format("not_touched_", "touched_"), self.callback10)
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -25,23 +25,32 @@ from .Analyser_Osmosis import Analyser_Osmosis
 
 
 sql10 = """
-SELECT DISTINCT
+SELECT DISTINCT ON (crossing.id)
     crossing.id,
     traffic_island.id,
     ST_AsText(way_locate(crossing.linestring))
 FROM
     {0}ways AS crossing
     JOIN {1}ways AS traffic_island ON
+        traffic_island.linestring && crossing.linestring AND
         traffic_island.id != crossing.id AND
         traffic_island.nodes && crossing.nodes AND
+        traffic_island.tags != ''::hstore AND
+        traffic_island.tags?'footway' AND
         traffic_island.tags->'footway' = 'traffic_island'
 WHERE
+    crossing.tags != ''::hstore AND
+    crossing.tags?'crossing:island' AND
     crossing.tags->'crossing:island' = 'yes' AND
+    crossing.tags?|ARRAY['footway', 'cycleway', 'path'] AND
     (
         crossing.tags->'footway' = 'crossing' OR
         crossing.tags->'cycleway' = 'crossing' OR
         crossing.tags->'path' = 'crossing'
     )
+ORDER BY
+    crossing.id,
+    traffic_island.id
 """
 
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -49,7 +49,8 @@ WHERE
         crossing.tags->'path' = 'crossing'
     )
 ORDER BY
-    crossing.id
+    crossing.id,
+    traffic_island.id
 """
 
 
@@ -83,8 +84,7 @@ over it, do not change the tag.'''))
 
     def analyser_osmosis_diff(self):
         # Match issues when either the crossing way or the traffic island way is touched.
-        self.create_view_touched('ways', 'W')
-        self.create_view_not_touched('ways', 'W')
+        # touched_ways and not_touched_ways views are created by the osmosis CreateTouched.sql script.
         self.run(sql10.format("touched_", ""), self.callback10)
         self.run(sql10.format("not_touched_", "touched_"), self.callback10)
 

--- a/analysers/analyser_osmosis_highway_traffic_island.py
+++ b/analysers/analyser_osmosis_highway_traffic_island.py
@@ -52,7 +52,7 @@ class Analyser_Osmosis_Highway_Traffic_Island(Analyser_Osmosis):
 
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
-        self.classs_change[11] = self.def_class(item = 2090, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
+        self.classs_change[11] = self.def_class(item = 3040, level = 3, tags = ['tag', 'highway', 'footway', 'fix:survey'],
             title = T_('Crossing island tag on a split crossing'),
             detail = T_(
 '''A crossing way is tagged with `crossing:island=yes` and connects to a

--- a/osmose_config.py
+++ b/osmose_config.py
@@ -178,6 +178,7 @@ class default_simple(template_config):
         self.analyser["osmosis_highway_noexit"] = "xxx"
         self.analyser["osmosis_parking_highway"] = "xxx"
         self.analyser["osmosis_highway_bad_intersection"] = "xxx"
+        self.analyser["osmosis_highway_traffic_island"] = "xxx"
         self.analyser["osmosis_water"] = "xxx"
         self.analyser["osmosis_relation_public_transport"] = "xxx"
         self.analyser["osmosis_highway_turn_lanes"] = "xxx"

--- a/tests/osmosis_highway_traffic_island.osm
+++ b/tests/osmosis_highway_traffic_island.osm
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='manual-test'>
+  <node id='1' lat='0.0000' lon='0.0000' />
+  <node id='2' lat='0.0001' lon='0.0000' />
+  <node id='3' lat='0.0003' lon='0.0000' />
+
+  <node id='11' lat='0.0010' lon='0.0000' />
+  <node id='12' lat='0.0011' lon='0.0000' />
+  <node id='13' lat='0.0013' lon='0.0000' />
+
+  <node id='21' lat='0.0020' lon='0.0000' />
+  <node id='22' lat='0.0021' lon='0.0000' />
+  <node id='23' lat='0.0023' lon='0.0000' />
+
+  <node id='31' lat='0.0030' lon='0.0000' />
+  <node id='32' lat='0.0031' lon='0.0000' />
+  <node id='33' lat='0.0033' lon='0.0000' />
+  <node id='34' lat='0.0034' lon='0.0000' />
+
+  <node id='41' lat='0.0040' lon='0.0000' />
+  <node id='42' lat='0.0041' lon='0.0000' />
+  <node id='43' lat='0.0043' lon='0.0000' />
+
+  <!-- Positive: footway=crossing with crossing:island=yes shares node 2 with footway=traffic_island. -->
+  <way id='100'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='footway' v='crossing' />
+    <tag k='crossing:island' v='yes' />
+  </way>
+  <way id='200'>
+    <nd ref='2' />
+    <nd ref='3' />
+    <tag k='footway' v='traffic_island' />
+  </way>
+
+  <!-- Positive: cycleway=crossing variant. -->
+  <way id='110'>
+    <nd ref='11' />
+    <nd ref='12' />
+    <tag k='cycleway' v='crossing' />
+    <tag k='crossing:island' v='yes' />
+  </way>
+  <way id='210'>
+    <nd ref='12' />
+    <nd ref='13' />
+    <tag k='footway' v='traffic_island' />
+  </way>
+
+  <!-- Positive: path=crossing variant. -->
+  <way id='120'>
+    <nd ref='21' />
+    <nd ref='22' />
+    <tag k='path' v='crossing' />
+    <tag k='crossing:island' v='yes' />
+  </way>
+  <way id='220'>
+    <nd ref='22' />
+    <nd ref='23' />
+    <tag k='footway' v='traffic_island' />
+  </way>
+
+  <!-- Negative: crossing island, but no shared traffic island node. -->
+  <way id='130'>
+    <nd ref='31' />
+    <nd ref='32' />
+    <tag k='footway' v='crossing' />
+    <tag k='crossing:island' v='yes' />
+  </way>
+  <way id='230'>
+    <nd ref='33' />
+    <nd ref='34' />
+    <tag k='footway' v='traffic_island' />
+  </way>
+
+  <!-- Negative: shared traffic island, but crossing:island is not yes. -->
+  <way id='140'>
+    <nd ref='41' />
+    <nd ref='42' />
+    <tag k='footway' v='crossing' />
+  </way>
+  <way id='240'>
+    <nd ref='42' />
+    <nd ref='43' />
+    <tag k='footway' v='traffic_island' />
+  </way>
+</osm>

--- a/tests/osmosis_highway_traffic_island.osm
+++ b/tests/osmosis_highway_traffic_island.osm
@@ -1,85 +1,85 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='manual-test'>
-  <node id='1' lat='0.0000' lon='0.0000' version='1' />
-  <node id='2' lat='0.0001' lon='0.0000' version='1' />
-  <node id='3' lat='0.0003' lon='0.0000' version='1' />
+  <node id='1' lat='0.0000' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='2' lat='0.0001' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='3' lat='0.0003' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
 
-  <node id='11' lat='0.0010' lon='0.0000' version='1' />
-  <node id='12' lat='0.0011' lon='0.0000' version='1' />
-  <node id='13' lat='0.0013' lon='0.0000' version='1' />
+  <node id='11' lat='0.0010' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='12' lat='0.0011' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='13' lat='0.0013' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
 
-  <node id='21' lat='0.0020' lon='0.0000' version='1' />
-  <node id='22' lat='0.0021' lon='0.0000' version='1' />
-  <node id='23' lat='0.0023' lon='0.0000' version='1' />
+  <node id='21' lat='0.0020' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='22' lat='0.0021' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='23' lat='0.0023' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
 
-  <node id='31' lat='0.0030' lon='0.0000' version='1' />
-  <node id='32' lat='0.0031' lon='0.0000' version='1' />
-  <node id='33' lat='0.0033' lon='0.0000' version='1' />
-  <node id='34' lat='0.0034' lon='0.0000' version='1' />
+  <node id='31' lat='0.0030' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='32' lat='0.0031' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='33' lat='0.0033' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='34' lat='0.0034' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
 
-  <node id='41' lat='0.0040' lon='0.0000' version='1' />
-  <node id='42' lat='0.0041' lon='0.0000' version='1' />
-  <node id='43' lat='0.0043' lon='0.0000' version='1' />
+  <node id='41' lat='0.0040' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='42' lat='0.0041' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
+  <node id='43' lat='0.0043' lon='0.0000' version='1' timestamp='2014-03-31T22:00:00Z' />
 
   <!-- Positive: footway=crossing with crossing:island=yes shares node 2 with footway=traffic_island. -->
-  <way id='100' version='1'>
+  <way id='100' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='1' />
     <nd ref='2' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='200' version='1'>
+  <way id='200' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='2' />
     <nd ref='3' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Positive: cycleway=crossing variant. -->
-  <way id='110' version='1'>
+  <way id='110' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='11' />
     <nd ref='12' />
     <tag k='cycleway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='210' version='1'>
+  <way id='210' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='12' />
     <nd ref='13' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Positive: path=crossing variant. -->
-  <way id='120' version='1'>
+  <way id='120' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='21' />
     <nd ref='22' />
     <tag k='path' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='220' version='1'>
+  <way id='220' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='22' />
     <nd ref='23' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Negative: crossing island, but no shared traffic island node. -->
-  <way id='130' version='1'>
+  <way id='130' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='31' />
     <nd ref='32' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='230' version='1'>
+  <way id='230' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='33' />
     <nd ref='34' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Negative: shared traffic island, but crossing:island is not yes. -->
-  <way id='140' version='1'>
+  <way id='140' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='41' />
     <nd ref='42' />
     <tag k='footway' v='crossing' />
   </way>
-  <way id='240' version='1'>
+  <way id='240' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='42' />
     <nd ref='43' />
     <tag k='footway' v='traffic_island' />

--- a/tests/osmosis_highway_traffic_island.osm
+++ b/tests/osmosis_highway_traffic_island.osm
@@ -1,85 +1,85 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='manual-test'>
-  <node id='1' lat='0.0000' lon='0.0000' />
-  <node id='2' lat='0.0001' lon='0.0000' />
-  <node id='3' lat='0.0003' lon='0.0000' />
+  <node id='1' lat='0.0000' lon='0.0000' version='1' />
+  <node id='2' lat='0.0001' lon='0.0000' version='1' />
+  <node id='3' lat='0.0003' lon='0.0000' version='1' />
 
-  <node id='11' lat='0.0010' lon='0.0000' />
-  <node id='12' lat='0.0011' lon='0.0000' />
-  <node id='13' lat='0.0013' lon='0.0000' />
+  <node id='11' lat='0.0010' lon='0.0000' version='1' />
+  <node id='12' lat='0.0011' lon='0.0000' version='1' />
+  <node id='13' lat='0.0013' lon='0.0000' version='1' />
 
-  <node id='21' lat='0.0020' lon='0.0000' />
-  <node id='22' lat='0.0021' lon='0.0000' />
-  <node id='23' lat='0.0023' lon='0.0000' />
+  <node id='21' lat='0.0020' lon='0.0000' version='1' />
+  <node id='22' lat='0.0021' lon='0.0000' version='1' />
+  <node id='23' lat='0.0023' lon='0.0000' version='1' />
 
-  <node id='31' lat='0.0030' lon='0.0000' />
-  <node id='32' lat='0.0031' lon='0.0000' />
-  <node id='33' lat='0.0033' lon='0.0000' />
-  <node id='34' lat='0.0034' lon='0.0000' />
+  <node id='31' lat='0.0030' lon='0.0000' version='1' />
+  <node id='32' lat='0.0031' lon='0.0000' version='1' />
+  <node id='33' lat='0.0033' lon='0.0000' version='1' />
+  <node id='34' lat='0.0034' lon='0.0000' version='1' />
 
-  <node id='41' lat='0.0040' lon='0.0000' />
-  <node id='42' lat='0.0041' lon='0.0000' />
-  <node id='43' lat='0.0043' lon='0.0000' />
+  <node id='41' lat='0.0040' lon='0.0000' version='1' />
+  <node id='42' lat='0.0041' lon='0.0000' version='1' />
+  <node id='43' lat='0.0043' lon='0.0000' version='1' />
 
   <!-- Positive: footway=crossing with crossing:island=yes shares node 2 with footway=traffic_island. -->
-  <way id='100'>
+  <way id='100' version='1'>
     <nd ref='1' />
     <nd ref='2' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='200'>
+  <way id='200' version='1'>
     <nd ref='2' />
     <nd ref='3' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Positive: cycleway=crossing variant. -->
-  <way id='110'>
+  <way id='110' version='1'>
     <nd ref='11' />
     <nd ref='12' />
     <tag k='cycleway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='210'>
+  <way id='210' version='1'>
     <nd ref='12' />
     <nd ref='13' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Positive: path=crossing variant. -->
-  <way id='120'>
+  <way id='120' version='1'>
     <nd ref='21' />
     <nd ref='22' />
     <tag k='path' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='220'>
+  <way id='220' version='1'>
     <nd ref='22' />
     <nd ref='23' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Negative: crossing island, but no shared traffic island node. -->
-  <way id='130'>
+  <way id='130' version='1'>
     <nd ref='31' />
     <nd ref='32' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
-  <way id='230'>
+  <way id='230' version='1'>
     <nd ref='33' />
     <nd ref='34' />
     <tag k='footway' v='traffic_island' />
   </way>
 
   <!-- Negative: shared traffic island, but crossing:island is not yes. -->
-  <way id='140'>
+  <way id='140' version='1'>
     <nd ref='41' />
     <nd ref='42' />
     <tag k='footway' v='crossing' />
   </way>
-  <way id='240'>
+  <way id='240' version='1'>
     <nd ref='42' />
     <nd ref='43' />
     <tag k='footway' v='traffic_island' />

--- a/tests/osmosis_highway_traffic_island.osm
+++ b/tests/osmosis_highway_traffic_island.osm
@@ -25,6 +25,7 @@
   <way id='100' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='1' />
     <nd ref='2' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
@@ -39,6 +40,7 @@
   <way id='110' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='11' />
     <nd ref='12' />
+    <tag k='highway' v='cycleway' />
     <tag k='cycleway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
@@ -53,6 +55,7 @@
   <way id='120' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='21' />
     <nd ref='22' />
+    <tag k='highway' v='path' />
     <tag k='path' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
@@ -67,6 +70,7 @@
   <way id='130' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='31' />
     <nd ref='32' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='crossing' />
     <tag k='crossing:island' v='yes' />
   </way>
@@ -81,6 +85,7 @@
   <way id='140' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='41' />
     <nd ref='42' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='crossing' />
   </way>
   <way id='240' version='1' timestamp='2014-03-31T22:00:00Z'>

--- a/tests/osmosis_highway_traffic_island.osm
+++ b/tests/osmosis_highway_traffic_island.osm
@@ -31,6 +31,7 @@
   <way id='200' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='2' />
     <nd ref='3' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='traffic_island' />
   </way>
 
@@ -44,6 +45,7 @@
   <way id='210' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='12' />
     <nd ref='13' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='traffic_island' />
   </way>
 
@@ -57,6 +59,7 @@
   <way id='220' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='22' />
     <nd ref='23' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='traffic_island' />
   </way>
 
@@ -70,6 +73,7 @@
   <way id='230' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='33' />
     <nd ref='34' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='traffic_island' />
   </way>
 
@@ -82,6 +86,7 @@
   <way id='240' version='1' timestamp='2014-03-31T22:00:00Z'>
     <nd ref='42' />
     <nd ref='43' />
+    <tag k='highway' v='footway' />
     <tag k='footway' v='traffic_island' />
   </way>
 </osm>


### PR DESCRIPTION
## Summary

Add an Osmosis analyzer that reports split crossing ways tagged `crossing:island=yes` when they connect to a separately mapped `footway=traffic_island`.

The check covers crossing ways tagged with any of:

- `footway=crossing`
- `cycleway=crossing`
- `path=crossing`

The issue reports both involved ways so mappers can review the crossing and the mapped traffic island together.

For some examples of what this targets, see https://maproulette.org/browse/challenges/55365.

## Rationale

When a traffic island is mapped as its own way, the short crossing ways leading to it usually should not also be tagged as having an island themselves. In those cases `crossing:island=yes` is redundant or misleading on the split crossing segment.

https://wiki.openstreetmap.org/wiki/Key:crossing:island

## Testing

- `python -m py_compile analysers/analyser_osmosis_highway_traffic_island.py osmose_config.py`
- `uv run --with polib --with psycopg2-binary --with python-dateutil --with lockfile --with shapely --with regex --with requests --with pyproj --with Unidecode --with osmium --with xmltodict --with termcolor python -c "import analysers.analyser_osmosis_highway_traffic_island as m; print(m.sql10.format('', ''))"`
- `uv run --with polib --with psycopg2-binary --with python-dateutil --with lockfile --with shapely --with regex --with requests --with pyproj --with Unidecode --with osmium --with xmltodict --with termcolor python -m osmose_config`
- `uv run --with 'git+https://github.com/ccxcz/pylama.git@14200a96c46acde592ee3effc24bc82a4217026d' --with polib --with psycopg2-binary --with python-dateutil --with lockfile --with shapely --with regex --with requests --with pyproj --with Unidecode --with osmium --with xmltodict --with termcolor pylama analysers/analyser_osmosis_highway_traffic_island.py osmose_config.py`
- `git diff --check`

## Disclosure

Generated by GPT 5.5 with human oversight.