### PR TITLE
Support Data-fair compatibility mode for merge analysers

### DIFF
--- a/analysers/Analyser_Merge.py
+++ b/analysers/Analyser_Merge.py
@@ -534,6 +534,28 @@ class SourceDataFair(Source):
 
         return datetime.datetime.fromisoformat(matching_file["updatedAt"][0:10])
 
+class SourceDataFairCompatOds(Source):
+    def __init__(self,
+                 url: str,
+                 select: str,
+                 format: str = "csv",
+                 where: Optional[str] = None,
+                 **kwargs):
+        self.url_base = url.replace("/datasets/", "/data-fair/api/v1/datasets/")
+        kwargs.update({
+            "encoding": "utf-8-sig",
+            "fileUrl": self.url_base + "/compat-ods/exports/" + format + "?select=" + select + ("&where=" + where if where else ""),
+            "millesime": None,
+        })
+        super().__init__(**kwargs)
+
+    def get_millesime(self) -> datetime.datetime:
+        response = downloader.request_get(self.url_base)
+        response.raise_for_status()
+        metadata = response.json()
+
+        return datetime.datetime.fromisoformat(metadata["dataUpdatedAt"][0:10])
+
 class SourceHttpLastModified(Source):
     """Get URL from Last-Modified HTTP headers"""
     def get_millesime(self):

--- a/analysers/analyser_merge_power_pole_FR_spec_enedis.py
+++ b/analysers/analyser_merge_power_pole_FR_spec_enedis.py
@@ -20,8 +20,9 @@
 ##                                                                       ##
 ###########################################################################
 
+import json
 from modules.OsmoseTranslation import T_
-from .Analyser_Merge import Analyser_Merge_Point, SourceDataGouv, CSV, Load_XY, Conflate, Select, Mapping
+from .Analyser_Merge import Analyser_Merge_Point, SourceDataFairCompatOds, CSV, Load_XY, Conflate, Select, Mapping
 
 
 class Analyser_Merge_power_pole_FR_spec_enedis (Analyser_Merge_Point):
@@ -40,18 +41,18 @@ class Analyser_Merge_power_pole_FR_spec_enedis (Analyser_Merge_Point):
         self.init(
             "https://www.data.gouv.fr/fr/datasets/position-geographique-des-poteaux-hta-et-bt/",
             "Position géographique des poteaux électriques HTA et BT Enedis",
-            CSV(SourceDataGouv(
-                attribution="Enedis",
-                dataset="60b9a555532a9939f42fcb3b",
-                resource="93186d05-f283-421c-8534-a92149a01a36"
-            ), fields=['Code Département', 'Geo Point', 'PREC'], separator=';'),
-            Load_XY("Geo Point", "Geo Point",
-                xFunction = lambda x: x and x.split(',')[1],
-                yFunction = lambda y: y and y.split(',')[0],
-                select = {
-                    "Code Département": dep_code,
-                    "PREC": ["A : 0 - 50cm", "B : 50cm - 1m 50"]
-                }),
+            CSV(
+                SourceDataFairCompatOds(
+                    attribution = "Enedis",
+                    url="https://opendata.enedis.fr/datasets/position-geographique-des-poteaux-hta-et-bt",
+                    select="code_departement,prec,geometry",
+                    where="code_departement=" + dep_code + " AND prec IN ('A : 0 - 50cm','B : 50cm - 1m 50')"
+                ),
+                fields=["code_departement", "prec", "geometry"],
+                separator=';'),
+            Load_XY("geometry", "geometry",
+                xFunction = lambda x: x and json.loads(x)["coordinates"][0],
+                yFunction = lambda y: y and json.loads(y)["coordinates"][1]),
             Conflate(
                 select = Select(
                     types = ['nodes'],

--- a/analysers/analyser_merge_power_substation_minor_FR.py
+++ b/analysers/analyser_merge_power_substation_minor_FR.py
@@ -20,8 +20,9 @@
 ##                                                                       ##
 ###########################################################################
 
+import json
 from modules.OsmoseTranslation import T_
-from .Analyser_Merge import Analyser_Merge_Point, SourceOpenDataSoft, CSV, Load_XY, Conflate, Select, Mapping
+from .Analyser_Merge import Analyser_Merge_Point, SourceDataFairCompatOds, CSV, Load_XY, Conflate, Select, Mapping
 
 
 class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
@@ -37,13 +38,17 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
         self.init(
             "https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/",
             "Postes HTA/BT",
-            CSV(SourceOpenDataSoft(
-                attribution="Exploitants contributeurs de l'Agence ORE",
-                url="https://opendata.agenceore.fr/explore/dataset/postes-de-distribution-publique-postes-htabt/"),
-                fields=["Geo Point", "GRD", "Nom poste"]),
-            Load_XY("Geo Point", "Geo Point",
-                xFunction = lambda x: x and x.split(',')[1],
-                yFunction = lambda y: y and y.split(',')[0]),
+            CSV(
+                SourceDataFairCompatOds(
+                    attribution = "Exploitants contributeurs de l'Agence ORE",
+                    url="https://opendata.agenceore.fr/datasets/postes-de-distribution-publique-postes-htabt",
+                    select="nom_grd,nom_poste,geometry"
+                ),
+                fields=["nom_grd", "nom_poste", "geometry"],
+                separator=';'),
+            Load_XY("geometry", "geometry",
+                xFunction = lambda x: x and json.loads(x)["coordinates"][0],
+                yFunction = lambda y: y and json.loads(y)["coordinates"][1]),
             Conflate(
                 select = Select(
                     types = ["nodes", "ways"],
@@ -59,10 +64,10 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
                         "substation": "minor_distribution", # Currently default value, we're unable to destinguish distribution and minor_distribution in opendata
                         "voltage": "20000"}, # Currently lawful default value as there is no opendata to define it. Mappers may be knowledgeable
                     mapping2 = {
-                        "name": lambda fields: fields["Nom poste"] if fields["Nom poste"] != "" else None,
-                        "operator": lambda res: self.extract_operator.get(res['GRD'])[0] if res['GRD'] in self.extract_operator else res['GRD'],
-                        "operator:wikidata": lambda res: self.extract_operator.get(res['GRD'])[1] if res['GRD'] in self.extract_operator else None,
-                        "source": lambda fields: self.source() + " - " + fields["GRD"]},
+                        "name": lambda fields: fields["nom_poste"] if fields["nom_poste"] != "" else None,
+                        "operator": lambda fields: self.extract_operator.get(fields['nom_grd'])[0] if fields['nom_grd'] in self.extract_operator else fields['nom_grd'],
+                        "operator:wikidata": lambda fields: self.extract_operator.get(fields['nom_grd'])[1] if fields['nom_grd'] in self.extract_operator else None,
+                        "source": lambda fields: self.source() + " - " + fields["nom_grd"]},
                 )))
 
     # Main source: https://wiki.openstreetmap.org/wiki/Power_networks/France/Exploitants#Entreprises_de_distribution
@@ -78,7 +83,7 @@ class Analyser_Merge_Power_Substation_minor_FR(Analyser_Merge_Point):
         'GreenAlp': ['GreenAlp', 'Q115580260'],
         #'Gignac Energie': [None, None],
         "Régie d'Electricité de Thônes": ['REThones', 'Q115579327'],
-        #'Régie Services Energie': [None, None],
+        'Régie Services Energie': ['RSE01', 'Q115579140'],
         'réséda': ['réséda', 'Q112115721'],
         'SOREA': ['Sorea', 'Q115470007'],
         'SRD': ['SRD', 'Q110319893'],


### PR DESCRIPTION
This PR proposes to support the ODS compatibility mode for Data-Fair platforms.
- Files are got from the corresponding endpoint on Data-Fair platforms on which compatibility mode is enabled
- Last update date is got from `dataUpdatedAt` field in main metadata information for the given dataset.

It also needs to remove BOM from CSV headers

It will restore `merge_power_pole_FR_spec_eneids` and `merge_power_substation_minor_FR` analysers.