### PR TITLE
Don't match NSI entries worldwide if all includes are unsupported

### DIFF
--- a/plugins/TagFix_Brand.py
+++ b/plugins/TagFix_Brand.py
@@ -135,6 +135,7 @@ class Test(TestPluginCommon):
         assert not a.node(None, {"brand": "Kiabi", "shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299"})
         assert not a.node(None, {"shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299"})
         assert not a.node(None, {"shop": "clothes", "name": "Kiabi","not:brand:wikidata": "Q3196299", "brand:wikidata": "Q1234567"})
+        assert not a.node(None, {"name": "Sparkasse", "amenity": "bank"}) # (Non-French) coordinates as include
         assert not a.node(None, {"name": "National Bank", "amenity": "bank", "atm": "yes"})
         assert a.node(None, {"name": "La Place", "amenity": "restaurant"}) # as 'fra' rather than 'FR' in NSI
 

--- a/plugins/modules/name_suggestion_index.py
+++ b/plugins/modules/name_suggestion_index.py
@@ -111,7 +111,7 @@ def nsi_rule_applies(locationSet, country):
             return False
         if c in incl:
             return True
-    return len(incl) == 0 or "001" in locationSet["include"]
+    return len(locationSet.get("include", [])) == 0 or "001" in locationSet["include"]
 
 
 # Gets all valid (shop, amenity, ...) names that exist within a certain country


### PR DESCRIPTION
See #2774

The `incl` list has unsupported entries filtered out. As a consequence, the list could be empty if *all* included entries were filtered out, which would lead to a worldwide match.

Instead check for the original entry of `include`. Only if that's empty, consider it as a worldwide match (minus possible excludes)

Also adds a test


**Note:** This has some consequences when NSI is used for whitelisting purposes. Previously an unknown entry (such as the Sparkasse in this issue) would match everything worldwide, thus - in whitelist context - whitelist everything (including the region it was supposed to whitelist). Now it whitelists nothing anymore, thus also not the region where it should act as a whitelist. It's a trade-off... 