### PR TITLE
Don't generate unverified Wikipedia fix suggestion

### DIFF
--- a/analysers/analyser_osmosis_boundary_relation.py
+++ b/analysers/analyser_osmosis_boundary_relation.py
@@ -149,7 +149,7 @@ relations.'''))
         if self.municipality_ref:
             self.callback30 = lambda res: {"class":3, "data":[self.relation_full, self.positionAsText], "text":T_("Missing municipality ref tag {0}", ", ".join(self.municipality_ref)),
                 "fix":{self.municipality_ref: res[2]} if res[2] else None}
-        self.callback40 = lambda res: {"class":4, "data":[self.relation_full, self.positionAsText], "fix":{"wikipedia": res[2]} if res[2] else None}
+        self.callback40 = lambda res: {"class":4, "data":[self.relation_full, self.positionAsText]}
         self.callback50 = lambda res: {"class":5, "data":[self.relation_full, self.positionAsText],
             "text": T_("Population on admin_centre role ({0}) greater than population on the relation ({1})", res[2], res[3]) }
         self.callback60 = lambda res: {"class":6, "data":[self.relation_full, self.positionAsText], "text":{"en": res[2]}}
@@ -173,7 +173,7 @@ relations.'''))
         self.run(sql20.format("", "", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:
             self.run(sql20.format("", "", self.municipality_col(self.municipality_ref), self.municipality_not(self.municipality_ref)), self.callback30)
-        self.run(sql20.format("", "", self.municipality_col("wikipedia"), self.municipality_not("wikipedia")), self.callback40)
+        self.run(sql20.format("", "", "NULL::text", self.municipality_not("wikipedia")), self.callback40)
         self.run(sql50.format("", ""), self.callback50)
         self.run(sql60.format(""), self.callback60)
 
@@ -184,7 +184,7 @@ relations.'''))
         self.run(sql20.format("touched_", "", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:
             self.run(sql20.format("touched_", "", self.municipality_col(self.municipality_ref), self.municipality_not(self.municipality_ref)), self.callback30)
-        self.run(sql20.format("touched_", "", self.municipality_col("wikipedia"), self.municipality_not("wikipedia")), self.callback40)
+        self.run(sql20.format("touched_", "", "NULL::text", self.municipality_not("wikipedia")), self.callback40)
         self.run(sql50.format("touched_", ""), self.callback50)
 
         self.run(sql00.format("not_touched_", "touched_", self.admin_level))
@@ -193,7 +193,7 @@ relations.'''))
         self.run(sql20.format("not_touched_", "touched_", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:
             self.run(sql20.format("not_touched_", "touched_", self.municipality_col(self.municipality_ref), self.municipality_not(self.municipality_ref)), self.callback30)
-        self.run(sql20.format("not_touched_", "touched_", self.municipality_col("wikipedia"), self.municipality_not("wikipedia")), self.callback40)
+        self.run(sql20.format("not_touched_", "touched_", "NULL::text", self.municipality_not("wikipedia")), self.callback40)
         self.run(sql50.format("not_touched_", "touched_"), self.callback50)
 
         self.run(sql60.format("touched_"), self.callback60)

--- a/analysers/analyser_osmosis_boundary_relation.py
+++ b/analysers/analyser_osmosis_boundary_relation.py
@@ -116,12 +116,12 @@ class Analyser_Osmosis_Boundary_Relation(Analyser_Osmosis):
     def __init__(self, config, logger = None):
         Analyser_Osmosis.__init__(self, config, logger)
         self.admin_level = self.config.options and self.config.options.get("boundary_detail_level", 8) or 8
-        self.require_admmin_centre = not self.config.options or (self.config.options and self.config.options.get("boundary_require_admin_centre", True))
+        self.require_admin_centre = not self.config.options or (self.config.options and self.config.options.get("boundary_require_admin_centre", True))
         self.municipality_ref = self.config.options and self.config.options.get("municipality_ref")
         if self.municipality_ref and not isinstance(self.municipality_ref, list):
             self.municipality_ref = [self.municipality_ref]
 
-        if self.require_admmin_centre:
+        if self.require_admin_centre:
             self.classs_change[1] = self.def_class(item = 7120, level = 2, tags = ['boundary', 'fix:chair'],
                 title = T_('Missing `admin_centre` role'))
         self.classs_change[2] = self.def_class(item = 7120, level = 1, tags = ['boundary', 'name', 'fix:chair'],
@@ -143,7 +143,7 @@ class Analyser_Osmosis_Boundary_Relation(Analyser_Osmosis):
 roles](https://wiki.openstreetmap.org/wiki/Relation:boundary) on boundary
 relations.'''))
 
-        if self.require_admmin_centre:
+        if self.require_admin_centre:
             self.callback10 = lambda res: {"class":1, "data":[self.relation_full, self.positionAsText]}
         self.callback20 = lambda res: {"class":2, "data":[self.relation_full, self.positionAsText], "fix":{"name": res[2]} if res[2] else None}
         if self.municipality_ref:
@@ -168,7 +168,7 @@ relations.'''))
 
     def analyser_osmosis_full(self):
         self.run(sql00.format("", "", self.admin_level))
-        if self.require_admmin_centre:
+        if self.require_admin_centre:
             self.run(sql10.format("", ""), self.callback10)
         self.run(sql20.format("", "", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:
@@ -179,7 +179,7 @@ relations.'''))
 
     def analyser_osmosis_diff(self):
         self.run(sql00.format("touched_", "", self.admin_level))
-        if self.require_admmin_centre:
+        if self.require_admin_centre:
             self.run(sql10.format("touched_", ""), self.callback10)
         self.run(sql20.format("touched_", "", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:
@@ -188,7 +188,7 @@ relations.'''))
         self.run(sql50.format("touched_", ""), self.callback50)
 
         self.run(sql00.format("not_touched_", "touched_", self.admin_level))
-        if self.require_admmin_centre:
+        if self.require_admin_centre:
             self.run(sql10.format("not_touched_", "touched_"), self.callback10)
         self.run(sql20.format("not_touched_", "touched_", self.municipality_col("name"), self.municipality_not("name")), self.callback20)
         if self.municipality_ref:


### PR DESCRIPTION
See #2771

Don't generate Wikipedia page suggestions based on just the name.

I kept the input to sql20 as `"NULL::text"` to be consistent with the possible output of "municipality_col" for the other SQL runs that utilize sql20