### PR TITLE
Allow `socket:*` to have duplicate values

### DIFF
--- a/plugins/TagFix_DuplicateValue.py
+++ b/plugins/TagFix_DuplicateValue.py
@@ -98,6 +98,7 @@ Ensure the interpretation of the tag does not change when you delete one item.''
             re.compile('lacounty:.+'),
             re.compile('turn:lanes.*'),
             re.compile('.+:conditional'), # More thorough check in ConditionalRestrictions plugin
+            re.compile('socket:.+'),
         ))
         self.WhitelistSimilarRegex = set(( # Regexes for keys that can have similar, but not equal values
             re.compile('.+_name'),


### PR DESCRIPTION
Please see #2725 

I agree that this issue shouldn't be flagged for the `socket:*` tag.

From OSM wiki ([`amenity=charging_station` page](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station#:~:text=Note%3A%20Semi%2Dcolon%20separated%20values%20can%20be%20used%20if%20required.%20For%20example%2C%20use%20socket%3Atype2_combo%3D6%3B3%20with%20socket%3Atype2_combo%3Aoutput%3D350%20kW%3B90%20kW%20for%20a%20location%20with%20a%20total%20of%209x%20Type%202%20CCS%20cables%2C%20six%20of%20which%20can%20deliver%20up%20to%20350%20kW%2C%20while%20the%20other%203%20can%20deliver%20up%20to%2090%20kW.)):
>Note: Semi-colon separated values can be used if required. For example, use [socket:type2_combo](https://wiki.openstreetmap.org/wiki/Key:socket)=6;3 with [socket:type2_combo:output](https://wiki.openstreetmap.org/wiki/Key:socket)=350 kW;90 kW for a location with a total of 9x Type 2 CCS cables, six of which can deliver up to 350 kW, while the other 3 can deliver up to 90 kW.