### PR TITLE
Clarify deprecated tags should be removed, don't suggest adding landuse=reservoir

### DIFF
--- a/analysers/analyser_osmosis_natural_swimming-pool.py
+++ b/analysers/analyser_osmosis_natural_swimming-pool.py
@@ -100,7 +100,7 @@ Wrong tag for private swimming pool.'''))
         self.run(sql10, lambda res: {"class":1, "data":[self.way_full, self.positionAsText], "fix":[
             {"-":["natural"], "+":{"leisure":"swimming_pool"}},
             {"-":["natural"], "+":{"leisure":"swimming_pool", "access":"private"}},
-            {"-":["natural"], "+":{"landuse":"reservoir"}},
+            {"+":{"water":"reservoir"}},
             {"-":["natural"], "+":{"landuse":"basin"}},
             {"-":["natural"], "+":{"landuse":"pond"}},
             {"+":{"water":"pond"}},

--- a/plugins/TagFix_Deprecated.py
+++ b/plugins/TagFix_Deprecated.py
@@ -70,12 +70,15 @@ class TagFix_Deprecated(Plugin):
 '''The tag or combination key/value is no longer used. List of deprecated
 features comes from [Deprecated
 features](https://wiki.openstreetmap.org/wiki/Deprecated_features)''')
+        fixText = T_('''Add the new tag(s) and remove the older, deprecated tags that are no longer used.''')
         self.errors[4010] = self.def_class(item = 4010, level = 2, tags = ['deprecated', 'tag', 'fix:chair'],
             title = T_('Deprecated tag'),
-            detail = detail)
+            detail = detail,
+            fix = fixText)
         self.errors[40102] = self.def_class(item = 4010, level = 2, tags = ['deprecated', 'value', 'fix:chair'],
             title = T_('Deprecated value'),
-            detail = detail)
+            detail = detail,
+            fix = fixText)
 
         self.Deprecated = self.deprecated_list()
         self.DeprecatedSet = set(self.Deprecated)


### PR DESCRIPTION
Fixes #2788 

- One analyser had landuse=reservoir as fix suggestion (and removed natural=water). Instead, only add water=reservoir)
- Add a more explicit description that old tags should also be removed. 

Example: https://osmose.openstreetmap.fr/nl/issue/96cc23bc-cc68-dd01-bfea-f2f0cb33157a